### PR TITLE
page number JavaDoc: positive -> non-negative

### DIFF
--- a/spring-data-commons-core/src/main/java/org/springframework/data/domain/Page.java
+++ b/spring-data-commons-core/src/main/java/org/springframework/data/domain/Page.java
@@ -28,7 +28,7 @@ import java.util.List;
 public interface Page<T> extends Iterable<T> {
 
 	/**
-	 * Returns the number of the current page. Is always positive and less that {@code Page#getTotalPages()}.
+	 * Returns the number of the current page. Is non-negative and less that {@code Page#getTotalPages()}.
 	 * 
 	 * @return the number of the current page
 	 */


### PR DESCRIPTION
I was confused for a day or two from reading this JavaDoc and thinking that page numbers for PagingAndSortingRepositories were 1-based rather than 0-based. My JUnit test suggests strongly that they are 0-based, so I changed the JavaDoc to read "non-negative" rather than positive.
