### PR TITLE
DATACMNS-137, DATAJPA-116 - Separate the Auditable into two separate res...

### DIFF
--- a/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/AuditableMetadata.java
+++ b/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/AuditableMetadata.java
@@ -1,0 +1,127 @@
+package org.springframework.data.domain.audit;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Inspects the given {@link Class} for fields annotated by {@link CreatedBy}, {@link CreatedDate},
+ * {@link LastModifiedBy} , and {@link LastModifiedDate}. Only one field per annotation is stored.
+ * 
+ * @author Ranie Jade Ramiso
+ */
+public class AuditableMetadata {
+	private static final Map<Class, AuditableMetadata> cache = new HashMap<Class, AuditableMetadata>();
+
+	private Class<?> clazz;
+	private Field createdByField;
+	private Field createdDateField;
+	private Field lastModifiedByField;
+	private Field lastModifiedDateField;
+
+	protected AuditableMetadata(Class<?> clazz) {
+		this.clazz = clazz;
+		discoverAuditProperties();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * Discover fields annotated by {@link CreatedBy}, {@link CreatedDate}, {@link LastModifiedBy},
+	 * {@link LastModifiedDate}.
+	 */
+	private void discoverAuditProperties() {
+		ReflectionUtils.doWithFields(clazz, new CreatedByFieldCallback());
+		ReflectionUtils.doWithFields(clazz, new CreatedDateFieldCallback());
+		ReflectionUtils.doWithFields(clazz, new LastModifiedByFieldCallback());
+		ReflectionUtils.doWithFields(clazz, new LastModifiedDateFieldCallback());
+	}
+
+	/**
+	 * Return a {@link AuditableMetadata} for the given {@link Class}. The cache is first checked for an existing
+	 * {@link AuditableMetadata} otherwise a new one is created.
+	 */
+	public static AuditableMetadata getMetadata(Class<?> clazz) {
+		if (cache.containsKey(clazz)) {
+			return cache.get(clazz);
+		}
+		AuditableMetadata metadata = new AuditableMetadata(clazz);
+		cache.put(clazz, metadata);
+		return metadata;
+	}
+
+	/**
+	 * Returns if the {@link Class} represented in this instance is auditable or not.
+	 */
+	public boolean isAuditable() {
+		if ((createdByField == null) && (createdDateField == null) && (lastModifiedByField == null)
+				&& (lastModifiedDateField == null)) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Return the field annotated by {@link CreatedBy}, or null
+	 */
+	public Field getCreatedByField() {
+		return createdByField;
+	}
+
+	/**
+	 * Return the field annotated by {@link CreatedDate}, or null
+	 */
+	public Field getCreatedDateField() {
+		return createdDateField;
+	}
+
+	/**
+	 * Return the field annotated by {@link LastModifiedBy}, or null
+	 */
+	public Field getLastModifiedByField() {
+		return lastModifiedByField;
+	}
+
+	/**
+	 * Return the field annotated by {@link LastModifiedDate}, or null
+	 */
+	public Field getLastModifiedDateField() {
+		return lastModifiedDateField;
+	}
+
+	/**
+	 * Return the field annotated by {@link CreatedBy}, or null
+	 */
+	private final class CreatedByFieldCallback implements ReflectionUtils.FieldCallback {
+		public void doWith(Field field) {
+			if (field.getAnnotation(CreatedBy.class) != null) {
+				createdByField = field;
+			}
+		}
+	}
+
+	private final class CreatedDateFieldCallback implements ReflectionUtils.FieldCallback {
+		public void doWith(Field field) {
+			if (field.getAnnotation(CreatedDate.class) != null) {
+				createdDateField = field;
+			}
+		}
+	}
+
+	private final class LastModifiedByFieldCallback implements ReflectionUtils.FieldCallback {
+		public void doWith(Field field) {
+			if (field.getAnnotation(LastModifiedBy.class) != null) {
+				lastModifiedByField = field;
+			}
+		}
+	}
+
+	private final class LastModifiedDateFieldCallback implements ReflectionUtils.FieldCallback {
+		public void doWith(Field field) {
+			if (field.getAnnotation(LastModifiedDate.class) != null) {
+				lastModifiedDateField = field;
+			}
+		}
+	}
+}

--- a/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/CreatedBy.java
+++ b/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/CreatedBy.java
@@ -1,0 +1,14 @@
+package org.springframework.data.domain.audit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.FIELD })
+public @interface CreatedBy {
+}

--- a/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/CreatedDate.java
+++ b/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/CreatedDate.java
@@ -1,0 +1,14 @@
+package org.springframework.data.domain.audit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.FIELD })
+public @interface CreatedDate {
+}

--- a/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/LastModifiedBy.java
+++ b/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/LastModifiedBy.java
@@ -1,0 +1,14 @@
+package org.springframework.data.domain.audit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.FIELD })
+public @interface LastModifiedBy {
+}

--- a/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/LastModifiedDate.java
+++ b/spring-data-commons-core/src/main/java/org/springframework/data/domain/audit/LastModifiedDate.java
@@ -1,0 +1,14 @@
+package org.springframework.data.domain.audit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.FIELD })
+public @interface LastModifiedDate {
+}

--- a/spring-data-commons-core/src/test/java/org/springframework/data/domain/domain/AuditableMetadataUnitTest.java
+++ b/spring-data-commons-core/src/test/java/org/springframework/data/domain/domain/AuditableMetadataUnitTest.java
@@ -1,0 +1,72 @@
+package org.springframework.data.domain.domain;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+import org.springframework.data.domain.audit.*;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Unit test for {@link org.springframework.data.domain.audit.AuditableMetadata}
+ *
+ * @author Ranie Jade Ramiso
+ */
+public class AuditableMetadataUnitTest {
+	private class User {
+		@CreatedBy
+		private Object createdBy;
+
+		@CreatedDate
+		private Object createdDate;
+
+		@LastModifiedBy
+		private Object lastModifiedBy;
+
+		@LastModifiedDate
+		private Object lastModifiedDate;
+	}
+
+	private class NonAuditableUser {
+		private Object nonAuditProperty;
+	}
+
+	private static final Field createdByField = ReflectionUtils.findField(User.class, "createdBy");
+	private static final Field createdDateField = ReflectionUtils.findField(User.class, "createdDate");
+	private static final Field lastModifiedByField = ReflectionUtils.findField(User.class, "lastModifiedBy");
+	private static final Field lastModifiedDateField = ReflectionUtils.findField(User.class, "lastModifiedDate");
+
+	@Test
+	public void checkAnnotationDiscovery() {
+		AuditableMetadata metadata = AuditableMetadata.getMetadata(User.class);
+		assertNotNull(metadata);
+
+		assertEquals(createdByField, metadata.getCreatedByField());
+		assertEquals(createdDateField, metadata.getCreatedDateField());
+		assertEquals(lastModifiedByField, metadata.getLastModifiedByField());
+		assertEquals(lastModifiedDateField, metadata.getLastModifiedDateField());
+	}
+
+	@Test
+	public void checkCaching() {
+		AuditableMetadata firstCall = AuditableMetadata.getMetadata(User.class);
+		assertNotNull(firstCall);
+
+		AuditableMetadata secondCall = AuditableMetadata.getMetadata(User.class);
+		assertEquals(firstCall, secondCall);
+	}
+
+	@Test
+	public void checkIsAuditable() {
+		AuditableMetadata metadata = AuditableMetadata.getMetadata(User.class);
+		assertNotNull(metadata);
+
+		assertTrue(metadata.isAuditable());
+
+		metadata = AuditableMetadata.getMetadata(NonAuditableUser.class);
+		assertNotNull(metadata);
+
+		assertFalse(metadata.isAuditable());
+	}
+}


### PR DESCRIPTION
...ponsibilities: AuditableDate, AuditableBy.

Added annotation types CreatedBy, CreatedDate, LastModifiedBy, and LastModifiedDate as proposed in https://jira.springsource.org/browse/DATAJPA-116. Added AuditableMetadata for providing a way of discovering auditable classes. Provided unit tests for the discovery process.

I'll be submitting a pull request for the spring-data-jpa part once this get merged to main repo. Have to close the previous pull request (some rebasing issues). Thanks
