### PR TITLE
Adding support for case insensitive sorts

### DIFF
--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -217,13 +217,16 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 	 * {@link Sort}
 	 * 
 	 * @author Oliver Gierke
+	 * @author Kevin Raymond
 	 */
 	public static class Order implements Serializable {
 
 		private static final long serialVersionUID = 1522511010900108987L;
+		private static final boolean DEFAULT_IGNORE_CASE = false;
 
 		private final Direction direction;
 		private final String property;
+		private boolean ignoreCase;
 
 		/**
 		 * Creates a new {@link Order} instance. if order is {@literal null} then order defaults to
@@ -234,12 +237,7 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 		 */
 		public Order(Direction direction, String property) {
 
-			if (!StringUtils.hasText(property)) {
-				throw new IllegalArgumentException("Property must not null or empty!");
-			}
-
-			this.direction = direction == null ? DEFAULT_DIRECTION : direction;
-			this.property = property;
+			this(direction, property, DEFAULT_IGNORE_CASE);
 		}
 
 		/**
@@ -250,6 +248,25 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 		 */
 		public Order(String property) {
 			this(DEFAULT_DIRECTION, property);
+		}
+		
+		/**
+		 * Creates a new {@link Order} instance. if order is {@literal null} then order defaults to
+		 * {@link Sort#DEFAULT_DIRECTION}
+		 * 
+		 * @param direction can be {@literal null}, will default to {@link Sort#DEFAULT_DIRECTION}
+		 * @param property must not be {@literal null} or empty.
+		 * @param ignoreCase true if sorting should be case insensitive. false if sorting should be case sensitive.
+		 */
+		private Order(Direction direction, String property, boolean ignoreCase) {
+
+			if (!StringUtils.hasText(property)) {
+				throw new IllegalArgumentException("Property must not null or empty!");
+			}
+
+			this.direction = direction == null ? DEFAULT_DIRECTION : direction;
+			this.property = property;
+			this.ignoreCase = ignoreCase;
 		}
 
 		/**
@@ -291,6 +308,15 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 		public boolean isAscending() {
 			return this.direction.equals(Direction.ASC);
 		}
+		
+		/**
+		 * Returns whether or not the sort will be case sensitive or not.
+		 * 
+		 * @return
+		 */
+		public boolean isIgnoreCase() {
+			return ignoreCase;
+		}
 
 		/**
 		 * Returns a new {@link Order} with the given {@link Order}.
@@ -310,6 +336,16 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 		 */
 		public Sort withProperties(String... properties) {
 			return new Sort(this.direction, properties);
+		}
+		
+		/**
+		 * Returns a new {@link Order} with case insensitive sorting enabled.
+		 * 
+		 * @return
+		 */
+		public Order ignoreCase() {
+			ignoreCase = true;
+			return this;
 		}
 
 		/*

--- a/src/test/java/org/springframework/data/domain/SortUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/SortUnitTests.java
@@ -21,11 +21,13 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
 
 /**
  * Unit test for {@link Sort}.
  * 
  * @author Oliver Gierke
+ * @author Kevin Raymond
  */
 public class SortUnitTests {
 
@@ -97,5 +99,31 @@ public class SortUnitTests {
 
 		Sort sort = new Sort("foo").and(null);
 		assertThat(sort, hasItem(new Sort.Order("foo")));
+	}
+	
+	/**
+	 * Asserts that the ignore case flag is set when the ignoreCase method is called.
+	 * 
+	 * @see DATACMNS-281
+	 * @author Kevin Raymond
+	 */
+	@Test
+	public void ignoreCaseAllowed() {
+		
+		Sort.Order order = new Sort.Order(Direction.ASC, "foo").ignoreCase();
+		assertThat(order.isIgnoreCase(), equalTo(true));
+	}
+	
+	/**
+	 * Asserts that the ignore case flag is false when a new {@link Order} is created.
+	 * 
+	 * @see DATACMNS-281
+	 * @author Kevin Raymond
+	 */
+	@Test	
+	public void ignoreCaseDefault() {
+		
+		Sort.Order order = new Sort.Order(Direction.ASC, "foo");
+		assertThat(order.isIgnoreCase(), equalTo(false));
 	}
 }


### PR DESCRIPTION
All sorting done within Spring Data is case insensitive.  On string columns, it is sometimes desirable to have this sort be case insensitive.  

In this particular change, I modified the Order class to allow an ignore case flag to be set so that case insensitive sorts could be supported.  This change works in conjunction with the change made for https://jira.springsource.org/browse/DATAJPA-296.

Issue: DATACMNS-281

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
