### PR TITLE
Add queryByXxx in sping-data-jap

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
@@ -37,7 +37,7 @@ import org.springframework.util.StringUtils;
  */
 public class PartTree implements Iterable<OrPart> {
 
-	private static final Pattern PREFIX_TEMPLATE = Pattern.compile("^(find|read|get|count)(\\p{Lu}.*?)??By");
+	private static final Pattern PREFIX_TEMPLATE = Pattern.compile("^(find|read|get|count|query)(\\p{Lu}.*?)??By");
 	private static final String KEYWORD_TEMPLATE = "(%s)(?=\\p{Lu})";
 
 	/**


### PR DESCRIPTION
findByXxx() in sping-data-jpa to generate the query is super cool. Unfortunately I use "query" as start for my Dao.

As far as I tried, to fix it I need modify code in spring-data-commons. Please add it in your code if it doesn't affect other features.

Or you might make the start name configable, and let the user decide it by themselves.

Thanks!
