### PR TITLE
DATACMNS-304 documentation fix

### DIFF
--- a/src/docbkx/repositories.xml
+++ b/src/docbkx/repositories.xml
@@ -1066,7 +1066,7 @@ public class UserController {
             <row>
               <entry><code>page.page</code></entry>
 
-              <entry>Page you want to retrieve.</entry>
+              <entry>Page you want to retrieve (1-based).</entry>
             </row>
 
             <row>


### PR DESCRIPTION
I slightly changed the repositories.xml file to include better information about pagination:
- requested page parameter evaluated by PageableArgumentResolver in Table 1.1 is now correctly page.page (using page doesn't work)
- explicitly stated that page.page parameter evaluated by PageableArgumentResolver is 1-based
