### PR TITLE
DATACMNS-345 - Use the actual type of the persistent property.

### DIFF
--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -178,12 +178,8 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			return null;
 		}
 
-		try {
-			read.lock();
-			return persistentEntities.get(persistentProperty.getTypeInformation());
-		} finally {
-			read.unlock();
-		}
+		TypeInformation<?> typeInfo = persistentProperty.getTypeInformation();
+		return getPersistentEntity(typeInfo.getActualType());
 	}
 
 	/*


### PR DESCRIPTION
Changed getPersistentEntity(..) to return the actual type of the persistent property in order to deal with generic collection types.
