### PR TITLE
Ensuring isNew supports primitive ID types

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/AbstractEntityInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractEntityInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,14 @@ import org.springframework.util.Assert;
  * {@link #getId(Object)} returns {@literal null}.
  * 
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 public abstract class AbstractEntityInformation<T, ID extends Serializable> implements EntityInformation<T, ID> {
 
 	private final Class<T> domainClass;
+
+	private boolean idTypePrimitiveSet;
+	private boolean idTypePrimitive;
 
 	/**
 	 * Creates a new {@link AbstractEntityInformation} from the given domain class.
@@ -51,7 +55,7 @@ public abstract class AbstractEntityInformation<T, ID extends Serializable> impl
 	public boolean isNew(T entity) {
 
 		ID id = getId(entity);
-		return id == null || (id instanceof Number && ((Number) id).longValue() < 1);
+		return id == null || (this.isIdTypePrimitive() && id instanceof Number && ((Number) id).longValue() < 1L);
 	}
 
 	/*
@@ -64,5 +68,14 @@ public abstract class AbstractEntityInformation<T, ID extends Serializable> impl
 	public Class<T> getJavaType() {
 
 		return this.domainClass;
+	}
+
+	protected boolean isIdTypePrimitive() {
+		if (!this.idTypePrimitiveSet) {
+			this.idTypePrimitive = getIdType() != null && getIdType().isPrimitive();
+			this.idTypePrimitiveSet = true;
+		}
+
+		return this.idTypePrimitive;
 	}
 }

--- a/src/test/java/org/springframework/data/repository/core/support/DummyEntityAndIdInformation.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DummyEntityAndIdInformation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import org.springframework.data.domain.Persistable;
+
+import java.io.Serializable;
+
+/**
+ * Dummy implementation of {@link AbstractEntityInformation} that also provides ID information.
+ *
+ * @author Nick Williams
+ */
+public class DummyEntityAndIdInformation<T extends Persistable<ID>, ID extends Serializable>
+		extends AbstractEntityInformation<T, ID> {
+
+	private final Class<ID> idClass;
+
+	/**
+	 * Creates a new {@link DummyEntityInformation} for the given domain class.
+	 *
+	 * @param domainClass
+	 */
+	public DummyEntityAndIdInformation(Class<T> domainClass, Class<ID> idClass) {
+		super(domainClass);
+		this.idClass = idClass;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.core.EntityInformation#getId(java.lang.Object)
+	 */
+	public ID getId(T entity) {
+		return entity == null ? null : entity.getId();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.core.EntityInformation#getIdType()
+	 */
+	public Class<ID> getIdType() {
+		return this.idClass;
+	}
+}


### PR DESCRIPTION
`AbstractEntityInformation`'s `isNew` method returns `true` only if the ID attribute is `null`. Primitive attributes can never be `null`. This change also returns `true` if the ID is a `java.lang.Number` less than 1, which is the convention for unassigned primitive IDs.

Issue: DATACMNS-357
