### PR TITLE
Improving argument resolvers to make Spring HATEOAS optional

### DIFF
--- a/src/main/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolver.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.mvc.UriComponentsContributor;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Extension of {@link PageableHandlerMethodArgumentResolver} that also supports enhancing URIs using Spring HATEOAS
+ * support.
+ *
+ * @since 1.6
+ * @author Oliver Gierke
+ * @author Nick Williams
+ */
+@SuppressWarnings("deprecation")
+public class HateoasPageableHandlerMethodArgumentResolver extends PageableHandlerMethodArgumentResolver
+		implements UriComponentsContributor {
+
+	/**
+	 * A {@link HateoasPageableHandlerMethodArgumentResolver} preconfigured to the setup of
+	 * {@link PageableArgumentResolver}. Use that if you need to stick to the former request parameters an 1-indexed
+	 * behavior. This will be removed in the next major version (1.7). So consider migrating to the new way of exposing
+	 * request parameters.
+	 */
+	@Deprecated public static final HateoasPageableHandlerMethodArgumentResolver LEGACY;
+
+	static {
+		LEGACY = new HateoasPageableHandlerMethodArgumentResolver();
+		LEGACY.setPageParameterName("page.page");
+		LEGACY.setSizeParameterName("page.size");
+		LEGACY.setFallbackPageable(new PageRequest(1, 10));
+		LEGACY.setOneIndexedParameters(true);
+		LEGACY.getSortResolver().setLegacyMode(true);
+		LEGACY.getSortResolver().setSortParameter("page.sort");
+	}
+
+	/**
+	 * Constructs an instance of this resolver with a default {@link HateoasSortHandlerMethodArgumentResolver}.
+	 */
+	public HateoasPageableHandlerMethodArgumentResolver() {
+		super(new HateoasSortHandlerMethodArgumentResolver());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.mvc.UriComponentsContributor#enhance(org.springframework.web.util.UriComponentsBuilder, org.springframework.core.MethodParameter, java.lang.Object)
+	 */
+	@Override
+	public void enhance(UriComponentsBuilder builder, MethodParameter parameter, Object value) {
+
+		if (!(value instanceof Pageable)) {
+			return;
+		}
+
+		Pageable pageable = (Pageable) value;
+
+		String pagePropertyName = getParameterNameToUse(getPageParameterName(), parameter);
+		String sizePropertyName = getParameterNameToUse(getSizeParameterName(), parameter);
+
+		int pageNumber = pageable.getPageNumber();
+
+		builder.replaceQueryParam(pagePropertyName, isOneIndexedParameters() ? pageNumber + 1 : pageNumber);
+		builder.replaceQueryParam(sizePropertyName, pageable.getPageSize() <= getMaxPageSize() ? pageable.getPageSize()
+				: getMaxPageSize());
+
+		((HateoasSortHandlerMethodArgumentResolver) getSortResolver()).enhance(builder, parameter, pageable.getSort());
+	}
+
+	/**
+	 * Configure the {@link HateoasSortHandlerMethodArgumentResolver} to be used with the
+	 * {@link HateoasPageableHandlerMethodArgumentResolver}.
+	 *
+	 * @param sortResolver the {@link HateoasSortHandlerMethodArgumentResolver} to be used or {@literal null} to reset
+	 *                     it to the default one.
+	 * @throws IllegalArgumentException if the argument does not extend {@link HateoasSortHandlerMethodArgumentResolver}.
+	 */
+	@Override
+	public void setSortResolver(SortHandlerMethodArgumentResolver sortResolver) {
+		if (sortResolver == null) {
+			sortResolver = new HateoasSortHandlerMethodArgumentResolver();
+		} else if(!(sortResolver instanceof HateoasSortHandlerMethodArgumentResolver)) {
+			throw new IllegalArgumentException("Sort resolver not instance of HateoasSortHandlerMethodArgumentResolver");
+		}
+
+		super.setSortResolver(sortResolver);
+	}
+}

--- a/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import java.util.List;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort;
+import org.springframework.hateoas.mvc.UriComponentsContributor;
+import org.springframework.util.Assert;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Extension of {@link SortHandlerMethodArgumentResolver} that also supports enhancing URIs using Spring HATEOAS
+ * support.
+ *
+ * @since 1.6
+ * @author Oliver Gierke
+ * @author Thomas Darimont
+ * @author Nick Williams
+ */
+public class HateoasSortHandlerMethodArgumentResolver extends SortHandlerMethodArgumentResolver
+		implements UriComponentsContributor {
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.mvc.UriComponentsContributor#enhance(org.springframework.web.util.UriComponentsBuilder, org.springframework.core.MethodParameter, java.lang.Object)
+	 */
+	@Override
+	public void enhance(UriComponentsBuilder builder, MethodParameter parameter, Object value) {
+
+		if (!(value instanceof Sort)) {
+			return;
+		}
+
+		Sort sort = (Sort) value;
+
+		if (legacyMode) {
+
+			List<String> expressions = legacyFoldExpressions(sort);
+			Assert.isTrue(expressions.size() == 2,
+					String.format("Expected 2 sort expressions (fields, direction) but got %d!", expressions.size()));
+			builder.queryParam(getSortParameter(parameter), expressions.get(0));
+			builder.queryParam(getLegacyDirectionParameter(parameter), expressions.get(1));
+
+		} else {
+
+			for (String expression : foldIntoExpressions(sort)) {
+				builder.queryParam(getSortParameter(parameter), expression);
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
@@ -22,25 +22,24 @@ import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.hateoas.mvc.UriComponentsContributor;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Extracts paging information from web requests and thus allows injecting {@link Pageable} instances into controller
- * methods. Request properties to be parsed can be configured. Default configuration uses request properties beginning
- * with {@link #PAGE_PROPERTY}{@link #DEFAULT_SEPARATOR}.
+ * methods. Request properties to be parsed can be configured. Default configuration uses request parameters beginning
+ * with {@link #DEFAULT_PAGE_PARAMETER}{@link #DEFAULT_QUALIFIER_DELIMITER}.
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 @SuppressWarnings("deprecation")
-public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver, UriComponentsContributor {
+public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
 
 	/**
 	 * A {@link PageableHandlerMethodArgumentResolver} preconfigured to the setup of {@link PageableArgumentResolver}. Use
@@ -60,20 +59,36 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	}
 
 	private static final Pageable DEFAULT_PAGE_REQUEST = new PageRequest(0, 20);
-	private static final String DEFAULT_PAGE_PROPERTY = "page";
+	private static final String DEFAULT_PAGE_PARAMETER = "page";
 	private static final String DEFAULT_SIZE_PROPERTY = "size";
 	private static final String DEFAULT_PREFIX = "";
 	private static final String DEFAULT_QUALIFIER_DELIMITER = "_";
 	private static final int DEFAULT_MAX_PAGE_SIZE = 2000;
 
 	private Pageable fallbackPageable = DEFAULT_PAGE_REQUEST;
-	private SortHandlerMethodArgumentResolver sortResolver = new SortHandlerMethodArgumentResolver();
-	private String pageParameterName = DEFAULT_PAGE_PROPERTY;
+	private SortHandlerMethodArgumentResolver sortResolver;
+	private String pageParameterName = DEFAULT_PAGE_PARAMETER;
 	private String sizeParameterName = DEFAULT_SIZE_PROPERTY;
 	private String prefix = DEFAULT_PREFIX;
 	private String qualifierDelimiter = DEFAULT_QUALIFIER_DELIMITER;
 	private int maxPageSize = DEFAULT_MAX_PAGE_SIZE;
 	private boolean oneIndexedParameters = false;
+
+	/**
+	 * Constructs an instance of this resolved with a default {@link SortHandlerMethodArgumentResolver}.
+	 */
+	public PageableHandlerMethodArgumentResolver() {
+		this(new SortHandlerMethodArgumentResolver());
+	}
+
+	/**
+	 * Constructs an instance of this resolver with the specified {@link SortHandlerMethodArgumentResolver}.
+	 *
+	 * @param sortResolver The sort resolver to use
+	 */
+	protected PageableHandlerMethodArgumentResolver(SortHandlerMethodArgumentResolver sortResolver) {
+		this.sortResolver = sortResolver;
+	}
 
 	/**
 	 * Configures the {@link Pageable} to be used as fallback in case no {@link PageableDefault} or
@@ -100,6 +115,16 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	}
 
 	/**
+	 * Retrieves the maximum page size to be accepted. This allows to put an upper boundary of the page size to prevent
+	 * potential attacks trying to issue an {@link OutOfMemoryError}. Defaults to {@link #DEFAULT_MAX_PAGE_SIZE}.
+	 *
+	 * @return the maximum page size allowed.
+	 */
+	public int getMaxPageSize() {
+		return this.maxPageSize;
+	}
+
+	/**
 	 * Configures the parameter name to be used to find the page number in the request. Defaults to {@code page}.
 	 * 
 	 * @param pageParameterName the parameter name to be used, must not be {@literal null} or empty.
@@ -111,6 +136,15 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	}
 
 	/**
+	 * Retrieves the parameter name to be used to find the page number in the request. Defaults to {@code page}.
+	 *
+	 * @return the parameter name to be used, never {@literal null} or empty.
+	 */
+	public String getPageParameterName() {
+		return this.pageParameterName;
+	}
+
+	/**
 	 * Configures the parameter name to be used to find the page size in the request. Defaults to {@code size}.
 	 * 
 	 * @param sizeParameterName the parameter name to be used, must not be {@literal null} or empty.
@@ -119,6 +153,15 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 
 		Assert.hasText(sizeParameterName, "Size parameter name must not be null or empty!");
 		this.sizeParameterName = sizeParameterName;
+	}
+
+	/**
+	 * Retrieves the parameter name to be used to find the page size in the request. Defaults to {@code size}.
+	 *
+	 * @return the parameter name to be used, never {@literal null} or empty.
+	 */
+	public String getSizeParameterName() {
+		return this.sizeParameterName;
 	}
 
 	/**
@@ -145,11 +188,21 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	 * Configure the {@link SortHandlerMethodArgumentResolver} to be used with the
 	 * {@link PageableHandlerMethodArgumentResolver}.
 	 * 
-	 * @param sortResolver the {@link SortHandlerMethodArgumentResolver} to be used ot {@literal null} to reset it to the
-	 *          default one.
+	 * @param sortResolver the {@link SortHandlerMethodArgumentResolver} to be used or {@literal null} to reset it to the
+	 *                     default one.
 	 */
 	public void setSortResolver(SortHandlerMethodArgumentResolver sortResolver) {
 		this.sortResolver = sortResolver == null ? new SortHandlerMethodArgumentResolver() : sortResolver;
+	}
+
+	/**
+	 * Retrieves the {@link SortHandlerMethodArgumentResolver} to be used with the
+	 * {@link PageableHandlerMethodArgumentResolver}.
+	 *
+	 * @return the {@link SortHandlerMethodArgumentResolver} currently in use.
+	 */
+	public SortHandlerMethodArgumentResolver getSortResolver() {
+		return this.sortResolver;
 	}
 
 	/**
@@ -163,42 +216,31 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 		this.oneIndexedParameters = oneIndexedParameters;
 	}
 
+	/**
+	 * Indicates whether to expose and assume 1-based page number indexes in the request parameters. Defaults to
+	 * {@literal false}, meaning a page number of 0 in the request equals the first page. If this is set to
+	 * {@literal true}, a page number of 1 in the request will be considered the first page.
+	 *
+	 * @return whether to assume 1-based page number indexes in the request parameters.
+	 */
+	public boolean isOneIndexedParameters() {
+		return this.oneIndexedParameters;
+	}
+
 	/* 
 	 * (non-Javadoc)
 	 * @see org.springframework.web.method.support.HandlerMethodArgumentResolver#supportsParameter(org.springframework.core.MethodParameter)
 	 */
+	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
 		return Pageable.class.equals(parameter.getParameterType());
 	}
 
-	/* 
-	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.mvc.UriComponentsContributor#enhance(org.springframework.web.util.UriComponentsBuilder, org.springframework.core.MethodParameter, java.lang.Object)
-	 */
-	public void enhance(UriComponentsBuilder builder, MethodParameter parameter, Object value) {
-
-		if (!(value instanceof Pageable)) {
-			return;
-		}
-
-		Pageable pageable = (Pageable) value;
-
-		String pagePropertyName = getParameterNameToUse(pageParameterName, parameter);
-		String sizePropertyName = getParameterNameToUse(sizeParameterName, parameter);
-
-		int pageNumber = pageable.getPageNumber();
-
-		builder.replaceQueryParam(pagePropertyName, oneIndexedParameters ? pageNumber + 1 : pageNumber);
-		builder.replaceQueryParam(sizePropertyName, pageable.getPageSize() <= maxPageSize ? pageable.getPageSize()
-				: maxPageSize);
-
-		sortResolver.enhance(builder, parameter, pageable.getSort());
-	}
-
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.web.method.support.HandlerMethodArgumentResolver#resolveArgument(org.springframework.core.MethodParameter, org.springframework.web.method.support.ModelAndViewContainer, org.springframework.web.context.request.NativeWebRequest, org.springframework.web.bind.support.WebDataBinderFactory)
 	 */
+	@Override
 	public Pageable resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
 			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
@@ -225,9 +267,9 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	 * 
 	 * @param source the basic parameter name.
 	 * @param parameter the {@link MethodParameter} potentially qualified.
-	 * @return
+	 * @return the name of the request parameter.
 	 */
-	private String getParameterNameToUse(String source, MethodParameter parameter) {
+	protected String getParameterNameToUse(String source, MethodParameter parameter) {
 
 		StringBuilder builder = new StringBuilder(prefix);
 

--- a/src/main/java/org/springframework/data/web/PagedResourcesAssembler.java
+++ b/src/main/java/org/springframework/data/web/PagedResourcesAssembler.java
@@ -38,10 +38,11 @@ import org.springframework.web.util.UriComponentsBuilder;
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 public class PagedResourcesAssembler<T> implements ResourceAssembler<Page<T>, PagedResources<Resource<T>>> {
 
-	private final PageableHandlerMethodArgumentResolver pageableResolver;
+	private final HateoasPageableHandlerMethodArgumentResolver pageableResolver;
 	private final UriComponents baseUri;
 
 	/**
@@ -52,9 +53,9 @@ public class PagedResourcesAssembler<T> implements ResourceAssembler<Page<T>, Pa
 	 * @param resolver
 	 * @param baseUri
 	 */
-	public PagedResourcesAssembler(PageableHandlerMethodArgumentResolver resolver, UriComponents baseUri) {
+	public PagedResourcesAssembler(HateoasPageableHandlerMethodArgumentResolver resolver, UriComponents baseUri) {
 
-		this.pageableResolver = resolver == null ? new PageableHandlerMethodArgumentResolver() : resolver;
+		this.pageableResolver = resolver == null ? new HateoasPageableHandlerMethodArgumentResolver() : resolver;
 		this.baseUri = baseUri;
 	}
 

--- a/src/main/java/org/springframework/data/web/PagedResourcesAssemblerArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PagedResourcesAssemblerArgumentResolver.java
@@ -32,10 +32,11 @@ import org.springframework.web.util.UriComponentsBuilder;
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 public class PagedResourcesAssemblerArgumentResolver implements HandlerMethodArgumentResolver {
 
-	private final PageableHandlerMethodArgumentResolver resolver;
+	private final HateoasPageableHandlerMethodArgumentResolver resolver;
 	private final MethodLinkBuilderFactory<?> linkBuilderFactory;
 
 	/**
@@ -45,7 +46,7 @@ public class PagedResourcesAssemblerArgumentResolver implements HandlerMethodArg
 	 * @param resolver can be {@literal null}.
 	 * @param linkBuilderFactory can be {@literal null}, will be defaulted to a {@link ControllerLinkBuilderFactory}.
 	 */
-	public PagedResourcesAssemblerArgumentResolver(PageableHandlerMethodArgumentResolver resolver,
+	public PagedResourcesAssemblerArgumentResolver(HateoasPageableHandlerMethodArgumentResolver resolver,
 			MethodLinkBuilderFactory<?> linkBuilderFactory) {
 
 		this.resolver = resolver;

--- a/src/main/java/org/springframework/data/web/config/HateoasAwareSpringDataWebConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/HateoasAwareSpringDataWebConfiguration.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.HateoasSortHandlerMethodArgumentResolver;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -28,18 +30,33 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 @Configuration
 public class HateoasAwareSpringDataWebConfiguration extends SpringDataWebConfiguration {
 
+	@Override
+	public HateoasPageableHandlerMethodArgumentResolver createPageableResolver() {
+		return new HateoasPageableHandlerMethodArgumentResolver();
+	}
+
+	@Override
+	public HateoasSortHandlerMethodArgumentResolver createSortResolver() {
+		return new HateoasSortHandlerMethodArgumentResolver();
+	}
+
 	@Bean
 	public PagedResourcesAssembler<Object> pagedResourcesAssembler() {
-		return new PagedResourcesAssembler<Object>(pageableResolver(), null);
+		return new PagedResourcesAssembler<Object>(
+				(HateoasPageableHandlerMethodArgumentResolver) pageableResolver(), null
+		);
 	}
 
 	@Bean
 	public PagedResourcesAssemblerArgumentResolver pagedResourcesAssemblerArgumentResolver() {
-		return new PagedResourcesAssemblerArgumentResolver(pageableResolver(), null);
+		return new PagedResourcesAssemblerArgumentResolver(
+				(HateoasPageableHandlerMethodArgumentResolver) pageableResolver(), null
+		);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/web/config/SpringDataWebConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/SpringDataWebConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 @Configuration
 public class SpringDataWebConfiguration extends WebMvcConfigurerAdapter {
@@ -43,11 +44,21 @@ public class SpringDataWebConfiguration extends WebMvcConfigurerAdapter {
 
 	@Bean
 	public PageableHandlerMethodArgumentResolver pageableResolver() {
+		return createPageableResolver();
+	}
+
+	// Necessary to prevent IllegalStateException: Singleton 'pageableResolver' isn't currently in creation for HATEOAS
+	PageableHandlerMethodArgumentResolver createPageableResolver() {
 		return new PageableHandlerMethodArgumentResolver();
 	}
 
 	@Bean
 	public SortHandlerMethodArgumentResolver sortResolver() {
+		return createSortResolver();
+	}
+
+	// Necessary to prevent IllegalStateException: Singleton 'sortResolver' isn't currently in creation for HATEOAS
+	public SortHandlerMethodArgumentResolver createSortResolver() {
 		return new SortHandlerMethodArgumentResolver();
 	}
 

--- a/src/test/java/org/springframework/data/web/LegacyPageableHandlerArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/LegacyPageableHandlerArgumentResolverUnitTests.java
@@ -39,6 +39,7 @@ import org.springframework.web.context.request.ServletWebRequest;
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 @SuppressWarnings("deprecation")
 public class LegacyPageableHandlerArgumentResolverUnitTests extends PageableDefaultUnitTests {
@@ -210,8 +211,8 @@ public class LegacyPageableHandlerArgumentResolverUnitTests extends PageableDefa
 	}
 
 	@Override
-	protected PageableHandlerMethodArgumentResolver getResolver() {
-		return PageableHandlerMethodArgumentResolver.LEGACY;
+	protected HateoasPageableHandlerMethodArgumentResolver getResolver() {
+		return HateoasPageableHandlerMethodArgumentResolver.LEGACY;
 	}
 
 	static interface SampleController {

--- a/src/test/java/org/springframework/data/web/PageableDefaultUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PageableDefaultUnitTests.java
@@ -42,6 +42,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 public abstract class PageableDefaultUnitTests {
 
@@ -154,7 +155,7 @@ public abstract class PageableDefaultUnitTests {
 		assertThat(builder.build().toUriString(), endsWith(expected));
 	}
 
-	protected abstract PageableHandlerMethodArgumentResolver getResolver();
+	protected abstract HateoasPageableHandlerMethodArgumentResolver getResolver();
 
 	protected abstract Class<?> getControllerClass();
 

--- a/src/test/java/org/springframework/data/web/PagedResourcesAssemblerUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PagedResourcesAssemblerUnitTests.java
@@ -35,10 +35,11 @@ import org.springframework.web.util.UriComponentsBuilder;
  * Unit tests for {@link PagedResourcesAssembler}.
  * 
  * @author Oliver Gierke
+ * @author Nick Williams
  */
 public class PagedResourcesAssemblerUnitTests {
 
-	PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
+	HateoasPageableHandlerMethodArgumentResolver resolver = new HateoasPageableHandlerMethodArgumentResolver();
 
 	@Before
 	public void setUp() {

--- a/src/test/java/org/springframework/data/web/SortHandlerArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerArgumentResolverUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @since 1.6
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Nick Williams
  */
 public class SortHandlerArgumentResolverUnitTests extends SortDefaultUnitTests {
 
@@ -129,7 +130,7 @@ public class SortHandlerArgumentResolverUnitTests extends SortDefaultUnitTests {
 		UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/");
 		MethodParameter parameter = getParameterOfMethod("supportedMethod");
 
-		new SortHandlerMethodArgumentResolver().enhance(builder, parameter, sort);
+		new HateoasSortHandlerMethodArgumentResolver().enhance(builder, parameter, sort);
 
 		assertThat(builder.build().toUriString(), endsWith(expected));
 	}


### PR DESCRIPTION
The `PageableHandlerMethodArgumentResolver` and `SortHandlerMethodArgumentResolver` introduced a mandatory dependency on Spring HATEOAS, despite the assertion in the JavaDoc that HATEOAS resources would only be registered if Spring HATEOAS is on the class path. Some users may not need or want to include Spring HATEOAS in their project. This commit makes that dependency optional, and includes several new unit tests.

Issue: DATACMNS-353
