### PR TITLE
DATACMNS-363 - Support unicode characters in in query method names.

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
@@ -34,11 +34,13 @@ import org.springframework.util.StringUtils;
  * each query execution.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class PartTree implements Iterable<OrPart> {
 
-	private static final Pattern PREFIX_TEMPLATE = Pattern.compile("^(find|read|get|count)(\\p{Lu}.*?)??By");
-	private static final String KEYWORD_TEMPLATE = "(%s)(?=\\p{Lu})";
+	private static final Pattern PREFIX_TEMPLATE = Pattern
+			.compile("^(find|read|get|count)((\\p{Lu}|\\P{M}\\p{M}*+).*?)??By");
+	private static final String KEYWORD_TEMPLATE = "(%s)(?=(\\p{Lu}|\\P{M}\\p{M}*+))";
 
 	/**
 	 * The subject, for example "findDistinctUserByNameOrderByAge" would have the subject "DistinctUser".

--- a/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.repository.query.parser.PartTree.OrPart;
  * 
  * @author Oliver Gierke
  * @author Phillip Webb
+ * @author Thomas Darimont
  */
 public class PartTreeUnitTests {
 
@@ -357,6 +358,17 @@ public class PartTreeUnitTests {
 		assertThat(new PartTree("findByCategoryId", Product.class), is(notNullValue()));
 	}
 
+	/**
+	 * @see DATACMNS-363
+	 */
+	@Test
+	public void supportNonLowercaseUnicodeAttributeNamesInQueryMethodNames() throws Exception {
+
+		PartTree tree = new PartTree("findBy생일And이름", DomainObjectWithSpecialChars.class);
+		assertPart(tree, new Part[] { new Part("생일", DomainObjectWithSpecialChars.class),
+				new Part("이름", DomainObjectWithSpecialChars.class) });
+	}
+
 	private static void assertType(Iterable<String> sources, Type type, String property) {
 		assertType(sources, type, property, 1, true);
 	}
@@ -434,6 +446,9 @@ public class PartTreeUnitTests {
 	class DomainObjectWithSpecialChars {
 		String øre;
 		String år;
+
+		String 생일; // Birthday
+		String 이름; // Name
 	}
 
 	interface Product {


### PR DESCRIPTION
Modified the regex for prefix_template and keyword_template in PartTree in order to support arbitrary unicode characters.
Before that change we didn't support unicode correctly since we assumed that a character would have a lower and upper case representation which is often not the case, e.g. in chinese.

This fix is prototypic and needs some revision.
