### PR TITLE
DATACMNS-363 - Improved support for unicode characters for Repository query methods.

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
@@ -34,11 +34,22 @@ import org.springframework.util.StringUtils;
  * each query execution.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class PartTree implements Iterable<OrPart> {
 
 	private static final Pattern PREFIX_TEMPLATE = Pattern.compile("^(find|read|get|count)(\\p{Lu}.*?)??By");
-	private static final String KEYWORD_TEMPLATE = "(%s)(?=\\p{Lu})";
+
+	/*
+	 * We look for a pattern of: keyword followed by 
+	 * 	an upper-case letter that has a lower-case variant \p{Lu}
+	 * OR
+	 *  any other letter NOT in the BASIC_LATIN Uni-code Block \\P{InBASIC_LATIN} (like Chinese, Korean, Japanese, etc.).
+	 *    
+	 * @see http://www.regular-expressions.info/unicode.html
+	 * @see http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#ubc 
+	 */
+	private static final String KEYWORD_TEMPLATE = "(%s)(?=(\\p{Lu}|\\P{InBASIC_LATIN}))";
 
 	/**
 	 * The subject, for example "findDistinctUserByNameOrderByAge" would have the subject "DistinctUser".


### PR DESCRIPTION
In order to find a keyword like "And" followed by a property name we now probe also for non Basic Latin characters in addition to just an uppercase letter. This is needed to support property-names with characters that don't have an upper or lowercase representation. This allows us to support finder methods like: findBy이름And생일OrderBy생일Asc(…).
