### PR TITLE
Added a exception handling for when was specified the invalid value in the pagination parameter.

### DIFF
--- a/src/test/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverUnitTests.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.SortDefault.SortDefaults;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.ServletRequestBindingException;
 
 /**
  * Unit tests for {@link PageableHandlerMethodArgumentResolver}. Pulls in defaulting tests from
@@ -113,6 +114,70 @@ public class PageableHandlerMethodArgumentResolverUnitTests extends PageableDefa
 		exception.expectMessage("invalidDefaultPageSize");
 
 		assertSupportedAndResult(parameter, PageableHandlerMethodArgumentResolver.DEFAULT_PAGE_REQUEST);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void pageParamIsNegative() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("page", "-1");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void pageParamIsNotNumeric() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("page", "a");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void sizeParamIsNotNumeric() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("size", "a");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void sortParamIsEmpty() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void sortParamIsInvalidProperty() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", ",DESC");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void sortParamIsInvalidPropertyWhenMultiProperty() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "property1,,DESC");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
+	}
+
+	@Test(expected = ServletRequestBindingException.class)
+	public void sortParamIsEmptyWhenMultiParams() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "property,DESC");
+		request.addParameter("sort", "");
+
+		assertSupportedAndResult(supportedMethodParameter, null, request);
 	}
 
 	@Override


### PR DESCRIPTION
[example of invalid value]
- page=-1 (negative numeric)
- size=a (not numeric)
- sort= (not specified)
- sort=,DESC (not specified property of sort target)
- etc ...

Current implementation of the PageableHandlerMethodArgumentResolver is occurred IllegalArgumentException, and http response status is returned 500(Innternal Server Error) on the default setting of SpringMVC.
I think a best that http response status is returned 400(Bad Request).

Easy a way for resolve this problem is that catch a IllegalArgumentException in PageableHandlerMethodArgumentResolver, and throw a ServletRequestBindingException.
ServletRequestBindingException is handled by the DefaultHandlerExceptionResolver, and http response status is returned 400(Bad Request).

What Do you think?
If you have a same thinking, Please pushed to a master branch.
