### PR TITLE
Looser PagedResourcesAssembler declaration

### DIFF
--- a/src/main/java/org/springframework/data/web/config/HateoasAwareSpringDataWebConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/HateoasAwareSpringDataWebConfiguration.java
@@ -56,7 +56,7 @@ public class HateoasAwareSpringDataWebConfiguration extends SpringDataWebConfigu
 	}
 
 	@Bean
-	public PagedResourcesAssembler<Object> pagedResourcesAssembler() {
+	public PagedResourcesAssembler<?> pagedResourcesAssembler() {
 		return new PagedResourcesAssembler<Object>(pageableResolver(), null);
 	}
 


### PR DESCRIPTION
Based on the discussion in [SPR-11004](https://jira.springsource.org/browse/SPR-11004?focusedCommentId=94898&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-94898), the declaration of the `PagedResourcesAssembler` in `HateoasAwareSpringDataWebConfiguration` will not result in it being autowired using Spring 4.0 in certain circumstances.  This change loosens the declaration so that it can be autowired into declarations that have specific generics declarations.
