### PR TITLE
DATACMNS-394 grid discovery spi

### DIFF
--- a/src/main/java/org/springframework/data/grid/AbstractCompositeListener.java
+++ b/src/main/java/org/springframework/data/grid/AbstractCompositeListener.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.List;
+
+/**
+ * Base implementation for all composite listeners.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of the listener
+ */
+public class AbstractCompositeListener<T> {
+
+	/** List of ordered composite listeners */
+	private OrderedComposite<T> listeners;
+
+	/**
+	 * Constructs instance with an empty listener list.
+	 */
+	public AbstractCompositeListener() {
+		listeners = new OrderedComposite<T>();
+	}
+
+	/**
+	 * Sets the list of listeners. This clears
+	 * all existing listeners.
+	 *
+	 * @param listeners the new listeners
+	 */
+	public void setListeners(List<? extends T> listeners) {
+		this.listeners.setItems(listeners);
+	}
+
+	/**
+	 * Register a new listener.
+	 *
+	 * @param listener the listener
+	 */
+	public void register(T listener) {
+		listeners.add(listener);
+	}
+
+	/**
+	 * Gets the listeners.
+	 *
+	 * @return the listeners
+	 */
+	public OrderedComposite<T> getListeners() {
+		return listeners;
+	}
+
+}

--- a/src/main/java/org/springframework/data/grid/ContainerGrid.java
+++ b/src/main/java/org/springframework/data/grid/ContainerGrid.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.Collection;
+
+/**
+ * Container grid allows to track members in a grid. Contract for
+ * interacting with user depends on the actual implementation which
+ * can be either build-in discovery system or static without any
+ * discovery logic.
+ * <p>
+ * If implementation has build-in discovery a use of setter methods outside
+ * of the implementation should be discouraged. Although it is up to
+ * the implementation what is actually supported.
+ * <p>
+ * Implementation can also be static in terms of that there are
+ * no logic for discovery and in case of that user is responsible
+ * to feed data into the implementation. In case of that the implementation
+ * would only have structure to store the necessary information.
+ * This is useful in cases where access to grid system needs to be abstracted
+ * still keeping the grid logic in its own implementation.
+ * <p>
+ * This interface and its extended interfaces are strongly typed
+ * order to allow extending returned types (i.e. {@link ContainerNode}
+ * to suit the needs of a custom implementations.
+ *
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ */
+public interface ContainerGrid<NID, CN extends ContainerNode<NID>> {
+
+	/**
+	 * Gets collection of container nodes know to the grid system or
+	 * empty collection if there are no known nodes.
+	 *
+	 * @return Collection of grid nodes
+	 */
+	Collection<CN> getNodes();
+
+	/**
+	 * Gets a container node by its identifier.
+	 *
+	 * @param id the container node identifier
+	 * @return Container node or <code>NULL</code> if node doesn't exist
+	 */
+	CN getNode(NID id);
+
+	/**
+	 * Adds a new container node.
+	 * <p>
+     * If a grid refuses to add a particular node for any reason
+     * other than that it already contains the node, it <i>must</i> throw
+     * an exception (rather than returning <tt>false</tt>).  This preserves
+     * the invariant that a grid always contains the specified node
+     * after this call returns.
+     *
+	 * @param node the container node
+	 * @return <tt>true</tt> if this grid changed as a result of the call
+	 */
+	boolean addNode(CN node);
+
+	/**
+	 * Removes a container node by its identifier.
+	 * <p>
+	 * Removes a single instance of the specified node from this
+     * grid, if it is present.
+	 *
+	 * @param id the container node identifier
+	 * @return <tt>true</tt> if a node was removed as a result of this call
+	 */
+	boolean removeNode(NID id);
+
+	/**
+	 * Adds a listener to be notified of grid container node events.
+	 *
+	 * @param listener the container grid listener
+	 */
+	void addContainerGridListener(ContainerGridListener<NID, CN> listener);
+
+}

--- a/src/main/java/org/springframework/data/grid/ContainerGridGroups.java
+++ b/src/main/java/org/springframework/data/grid/ContainerGridGroups.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.Collection;
+
+/**
+ * Container groups is an extension on top of {@link ContainerGrid} to
+ * introduce functionality of grouping of containers.
+ * <p>
+ * While this interface adds methods for groups the actual implementation
+ * should handle group resolving when new Container nodes are added to
+ * the grid using methods from a {@link ContainerGrid}.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <GID> the type of {@link ContainerGroup} identifier
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ * @param <CG> the type of {@link ContainerGroup}
+ * @see ContainerGrid
+ */
+public interface ContainerGridGroups<GID, NID, CN extends ContainerNode<NID>, CG extends ContainerGroup<GID, NID, CN>> extends ContainerGrid<NID, CN> {
+
+	/**
+	 * Adds a new group.
+	 * <p>
+     * If a grid refuses to add a particular grid for any reason
+     * other than that it already contains the group, it <i>must</i> throw
+     * an exception (rather than returning <tt>false</tt>).  This preserves
+     * the invariant that a grid always contains the specified group
+     * after this call returns.
+	 *
+	 * @param group the container group
+	 * @return <tt>true</tt> if this grid groups changed as a result of the call
+	 */
+	boolean addGroup(CG group);
+
+	/**
+	 * Removes a group by its id.
+	 * <p>
+     * Removes a single instance of the specified group from this
+     * grid, if it is present.
+	 *
+	 * @param id the container group identifier
+	 * @return <tt>true</tt> if a group was removed as a result of this call
+	 */
+	boolean removeGroup(GID id);
+
+	/**
+	 * Gets a Container group by its identifier.
+	 *
+	 * @param id the container group identifier
+	 * @return Container group
+	 */
+	CG getGroup(GID id);
+
+	/**
+	 * Gets a collection of Container groups or empty collection of there
+	 * are no groups defined.
+	 *
+	 * @return the collection of container groups
+	 */
+	Collection<CG> getGroups();
+
+	/**
+	 * Gets a Container Group where Container node belongs to.
+	 *
+	 * @param id the container node identifier
+	 * @return the container group or <code>NULL</code> if not match
+	 */
+	CG getGroupByNode(NID id);
+
+	/**
+	 * Adds a listener to be notified of Container Group events.
+	 *
+	 * @param listener the container group listener
+	 */
+	void addContainerGridGroupsListener(ContainerGridGroupsListener<GID, NID, CN, CG> listener);
+
+}

--- a/src/main/java/org/springframework/data/grid/ContainerGridGroupsListener.java
+++ b/src/main/java/org/springframework/data/grid/ContainerGridGroupsListener.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+/**
+ * Listener for grid container group events.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <GID> the type of {@link ContainerGroup} identifier
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ * @param <CG> the type of {@link ContainerGroup}
+ */
+public interface ContainerGridGroupsListener<GID, NID, CN extends ContainerNode<NID>, CG extends ContainerGroup<GID, NID, CN>> {
+
+	/**
+	 * Invoked when group is added.
+	 *
+	 * @param group the {@link ContainerGroup}
+	 */
+	void groupAdded(CG group);
+
+	/**
+	 * Invoked when group is removed.
+	 *
+	 * @param group the {@link ContainerGroup}
+	 */
+	void groupRemoved(CG group);
+
+	/**
+	 * Invoked when node is added into a group.
+	 *
+	 * @param group the {@link ContainerGroup} node belongs to
+	 * @param node the {@link ContainerNode}
+	 */
+	void nodeAdded(CG group, CN node);
+
+	/**
+	 * Invoked when node is removed from a group.
+	 *
+	 * @param group the {@link ContainerGroup} node belongs to
+	 * @param node the {@link ContainerNode}
+	 */
+	void nodeRemoved(CG group, CN node);
+
+}

--- a/src/main/java/org/springframework/data/grid/ContainerGridListener.java
+++ b/src/main/java/org/springframework/data/grid/ContainerGridListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+/**
+ * Listener for grid container node events.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ */
+public interface ContainerGridListener<NID, CN extends ContainerNode<NID>> {
+
+	/**
+	 * Invoked when container node is added into a grid.
+	 *
+	 * @param node the {@link ContainerNode}
+	 */
+	void nodeAdded(CN node);
+
+	/**
+	 * Invoked when container node is removed from a grid.
+	 *
+	 * @param node the {@link ContainerNode}
+	 */
+	void nodeRemoved(CN node);
+
+}

--- a/src/main/java/org/springframework/data/grid/ContainerGroup.java
+++ b/src/main/java/org/springframework/data/grid/ContainerGroup.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.Collection;
+
+/**
+ * Interface representing a container group.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <GID> the type of {@link ContainerGroup} identifier
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ */
+public interface ContainerGroup<GID, NID, CN extends ContainerNode<NID>> {
+
+	/**
+	 * Gets a container group identifier.
+	 *
+	 * @return container group identifier
+	 */
+	GID getId();
+
+	/**
+	 * Checks if node is a member of this group.
+	 *
+	 * @param id the node identifier
+	 * @return true, if node is a member of group
+	 */
+	boolean hasNode(NID id);
+
+	/**
+	 * Adds the container node.
+	 * <p>
+     * If a group refuses to add a particular node for any reason
+     * other than that it already contains the node, it <i>must</i> throw
+     * an exception (rather than returning <tt>false</tt>).  This preserves
+     * the invariant that a group always contains the specified node
+     * after this call returns.
+     * <p>
+     * Implementation itself should define if a node added in a group is
+     * also added to a grid itself.
+	 *
+	 * @param node the node
+	 * @return <tt>true</tt> if this group changed as a result of the call
+	 */
+	boolean addNode(CN node);
+
+	/**
+	 * Removes the node from this group if it is present. Returns the {@code ContainerNode} to which
+	 * given node identifier was previously associated, or null if node wasn't a member of this group.
+     * <p>
+     * Implementation itself should define if a node removed from a group is
+     * also removed from a grid itself.
+	 *
+	 * @param id the node identifier
+	 * @return the removed container node, or <code>NULL</code> if node wasn't a member of this group.
+	 */
+	CN removeNode(NID id);
+
+	/**
+	 * Gets the container node.
+	 *
+	 * @param id the container node id
+	 * @return the node, or <code>NULL</code> if node wasn't a member of this group.
+	 */
+	CN getNode(NID id);
+
+	/**
+	 * Gets the members of this group as {@code Collection}.
+	 *
+	 * @return the nodes
+	 */
+	Collection<CN> getNodes();
+
+}

--- a/src/main/java/org/springframework/data/grid/ContainerNode.java
+++ b/src/main/java/org/springframework/data/grid/ContainerNode.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+/**
+ * Interface representing a container node.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <NID> the type of {@link ContainerNode} identifier
+ */
+public interface ContainerNode<NID> {
+
+	/**
+	 * Gets a container code identifier.
+	 *
+	 * @return container node identifier
+	 */
+	NID getId();
+
+}

--- a/src/main/java/org/springframework/data/grid/DefaultContainerGridGroupsListener.java
+++ b/src/main/java/org/springframework/data/grid/DefaultContainerGridGroupsListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.Iterator;
+
+/**
+ * Composite listener for handling container group events.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <GID> the type of {@link ContainerGroup} identifier
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ * @param <CG> the type of {@link ContainerGroup}
+ */
+public class DefaultContainerGridGroupsListener<GID, NID, CN extends ContainerNode<NID>, CG extends ContainerGroup<GID, NID, CN>> extends
+		AbstractCompositeListener<ContainerGridGroupsListener<GID, NID, CN, CG>> implements ContainerGridGroupsListener<GID, NID, CN, CG> {
+
+	@Override
+	public void groupAdded(CG group) {
+		for (Iterator<ContainerGridGroupsListener<GID, NID, CN, CG>> iterator = getListeners().reverse(); iterator.hasNext();) {
+			iterator.next().groupAdded(group);
+		}
+	}
+
+	@Override
+	public void groupRemoved(CG group) {
+		for (Iterator<ContainerGridGroupsListener<GID, NID, CN, CG>> iterator = getListeners().reverse(); iterator.hasNext();) {
+			iterator.next().groupRemoved(group);
+		}
+	}
+
+	@Override
+	public void nodeAdded(CG group, CN node) {
+		for (Iterator<ContainerGridGroupsListener<GID, NID, CN, CG>> iterator = getListeners().reverse(); iterator.hasNext();) {
+			iterator.next().nodeAdded(group, node);
+		}
+	}
+
+	@Override
+	public void nodeRemoved(CG group, CN node) {
+		for (Iterator<ContainerGridGroupsListener<GID, NID ,CN ,CG>> iterator = getListeners().reverse(); iterator.hasNext();) {
+			iterator.next().nodeRemoved(group, node);
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/grid/DefaultContainerGridListener.java
+++ b/src/main/java/org/springframework/data/grid/DefaultContainerGridListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.Iterator;
+
+/**
+ * Composite listener for handling grid container node events.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ */
+public class DefaultContainerGridListener<NID, CN extends ContainerNode<NID>> extends
+		AbstractCompositeListener<ContainerGridListener<NID, CN>> implements ContainerGridListener<NID, CN> {
+
+	@Override
+	public void nodeAdded(CN node) {
+		for (Iterator<ContainerGridListener<NID, CN>> iterator = getListeners().reverse(); iterator.hasNext();) {
+			iterator.next().nodeAdded(node);
+		}
+	}
+
+	@Override
+	public void nodeRemoved(CN node) {
+		for (Iterator<ContainerGridListener<NID, CN>> iterator = getListeners().reverse(); iterator.hasNext();) {
+			iterator.next().nodeRemoved(node);
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/grid/GroupsRebalanceData.java
+++ b/src/main/java/org/springframework/data/grid/GroupsRebalanceData.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+/**
+ * Empty marker interface allowing custom implementations
+ * to extend return types. Generally this interface and
+ * especially its extended interface would return instruction
+ * data to rebalance grouping handled by implementation
+ * of {@code ManagedContainerGridGroups}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface GroupsRebalanceData {
+}

--- a/src/main/java/org/springframework/data/grid/ManagedContainerGridGroups.java
+++ b/src/main/java/org/springframework/data/grid/ManagedContainerGridGroups.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+/**
+ * Managed container groups is an extension on top of {@link ContainerGridGroups}
+ * to introduce functionality of managing the group sizes.
+ * <p>
+ * Main purpose of this interface is to allow user to resize the Container
+ * Group and request instructions of how group should be resized.
+ * Implementation may do these automatically but in case it relies
+ * other party to do it externally the {@link GroupsRebalanceData}
+ * returned from a method {@link #getGroupsRebalanceData()} should
+ * have enough instructions order to do it.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <GID> the type of {@link ContainerGroup} identifier
+ * @param <NID> the type of {@link ContainerNode} identifier
+ * @param <CN> the type of {@link ContainerNode}
+ * @param <CG> the type of {@link ContainerGroup}
+ * @param <GRD> the type of {@link GroupsRebalanceData}
+ * @see ContainerGridGroups
+ * @see ContainerGrid
+ */
+public interface ManagedContainerGridGroups<GID, NID, CN extends ContainerNode<NID>, CG extends ContainerGroup<GID, NID, CN>, GRD extends GroupsRebalanceData>
+		extends ContainerGridGroups<GID, NID, CN, CG> {
+
+	/**
+	 * Sets the projected container group size.
+	 *
+	 * @param id Container group identifier
+	 * @param size New size of the Container group
+	 * @return true, if group size was modified
+	 */
+	boolean setGroupSize(GID id, int size);
+
+	/**
+	 * Gets the groups rebalance data.
+	 * <p>
+	 * Data returned from this method would reflect instructions to rebalance
+	 * grouping sizes to satisfy a difference between what the situation is
+	 * now and what it is expected to be.
+	 *
+	 * @return the groups rebalance data
+	 */
+	GRD getGroupsRebalanceData();
+
+}

--- a/src/main/java/org/springframework/data/grid/OrderedComposite.java
+++ b/src/main/java/org/springframework/data/grid/OrderedComposite.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Composite item which can be used in other components which
+ * may want to allow automatic and annotation based ordering.
+ * Good use case is a list of listeners where user may want
+ * to place some of them to be processed before the others.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <S> the type of the item
+ */
+public class OrderedComposite<S> {
+
+	private List<S> unordered = new ArrayList<S>();
+
+	private List<S> ordered = new ArrayList<S>();
+
+	private Comparator<? super S> comparator = new AnnotationAwareOrderComparator();
+
+	private List<S> list = new ArrayList<S>();
+
+	/**
+	 * Public setter for the listeners.
+	 *
+	 * @param items
+	 */
+	public void setItems(List<? extends S> items) {
+		unordered.clear();
+		ordered.clear();
+		for (S s : items) {
+			add(s);
+		}
+	}
+
+	/**
+	 * Register additional item.
+	 *
+	 * @param item
+	 */
+	public void add(S item) {
+		if (item instanceof Ordered) {
+			if (!ordered.contains(item)) {
+				ordered.add(item);
+			}
+		} else if (AnnotationUtils.isAnnotationDeclaredLocally(Order.class, item.getClass())) {
+			if (!ordered.contains(item)) {
+				ordered.add(item);
+			}
+		} else if (!unordered.contains(item)) {
+			unordered.add(item);
+		}
+		Collections.sort(ordered, comparator);
+		list.clear();
+		list.addAll(ordered);
+		list.addAll(unordered);
+	}
+
+	/**
+	 * Public getter for the list of items. The {@link Ordered} items come
+	 * first, followed by any unordered ones.
+	 *
+	 * @return an iterator over the list of items
+	 */
+	public Iterator<S> iterator() {
+		return new ArrayList<S>(list).iterator();
+	}
+
+	/**
+	 * Public getter for the list of items in reverse. The {@link Ordered} items
+	 * come last, after any unordered ones.
+	 *
+	 * @return an iterator over the list of items
+	 */
+	public Iterator<S> reverse() {
+		ArrayList<S> result = new ArrayList<S>(list);
+		Collections.reverse(result);
+		return result.iterator();
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/AbstractContainerGridGroupsTests.java
+++ b/src/test/java/org/springframework/data/grid/AbstractContainerGridGroupsTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base test class sharing mock components for {@code ContainerGridGroups}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractContainerGridGroupsTests extends AbstractContainerGridTests {
+
+	protected static class MockContainerGridGroupsListener
+			implements ContainerGridGroupsListener<String, String, ContainerNode<String>, ContainerGroup<String, String, ContainerNode<String>>> {
+
+		List<ContainerGroup<String, String, ContainerNode<String>>> groupAdded = new ArrayList<ContainerGroup<String,String,ContainerNode<String>>>();
+		List<ContainerGroup<String, String, ContainerNode<String>>> groupRemoved = new ArrayList<ContainerGroup<String,String,ContainerNode<String>>>();
+		Map<String, List<ContainerNode<String>>> groupMemberAdded = new HashMap<String, List<ContainerNode<String>>>();
+		Map<String, List<ContainerNode<String>>> groupMemberRemoved = new HashMap<String, List<ContainerNode<String>>>();
+
+		@Override
+		public void groupAdded(ContainerGroup<String, String, ContainerNode<String>> group) {
+			groupAdded.add(group);
+		}
+
+		@Override
+		public void groupRemoved(ContainerGroup<String, String, ContainerNode<String>> group) {
+			groupRemoved.add(group);
+		}
+
+		@Override
+		public void nodeAdded(ContainerGroup<String, String, ContainerNode<String>> group, ContainerNode<String> node) {
+			List<ContainerNode<String>> list = groupMemberAdded.get(group.getId());
+			if (list == null) {
+				list = new ArrayList<ContainerNode<String>>();
+				groupMemberAdded.put(group.getId(), list);
+			}
+			list.add(node);
+		}
+
+		@Override
+		public void nodeRemoved(ContainerGroup<String, String, ContainerNode<String>> group, ContainerNode<String> node) {
+			List<ContainerNode<String>> list = groupMemberRemoved.get(group.getId());
+			if (list == null) {
+				list = new ArrayList<ContainerNode<String>>();
+				groupMemberRemoved.put(group.getId(), list);
+			}
+			list.add(node);
+		}
+
+	}
+
+	protected static class MockContainerGroup implements ContainerGroup<String, String, ContainerNode<String>> {
+		String name;
+		Map<String, ContainerNode<String>> nodes = new HashMap<String, ContainerNode<String>>();
+
+		DefaultContainerGridGroupsListener<String, String, ContainerNode<String>, ContainerGroup<String, String, ContainerNode<String>>> glistener;
+
+		MockContainerGroup(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getId() {
+			return name;
+		}
+
+		@Override
+		public boolean hasNode(String id) {
+			return nodes.containsKey(id);
+		}
+
+		@Override
+		public ContainerNode<String> getNode(String id) {
+			return nodes.get(id);
+		}
+
+		@Override
+		public Collection<ContainerNode<String>> getNodes() {
+			return nodes.values();
+		}
+
+		@Override
+		public boolean addNode(ContainerNode<String> member) {
+			ContainerNode<String> put = nodes.put(member.getId(), member);
+			if (glistener != null) {
+				glistener.nodeAdded(this, member);
+			}
+			return put == null;
+		}
+
+		@Override
+		public ContainerNode<String> removeNode(String id) {
+			ContainerNode<String> removed = nodes.remove(id);
+			if (glistener != null && removed != null) {
+				glistener.nodeRemoved(this, removed);
+			}
+			return removed;
+		}
+	}
+
+	protected static class MockContainerGridGroups extends MockContainerGrid
+			implements ContainerGridGroups<String, String, ContainerNode<String>, ContainerGroup<String, String, ContainerNode<String>>> {
+
+		Map<String, ContainerGroup<String, String, ContainerNode<String>>> groups = new HashMap<String, ContainerGroup<String, String, ContainerNode<String>>>();
+		DefaultContainerGridGroupsListener<String, String, ContainerNode<String>, ContainerGroup<String, String, ContainerNode<String>>> glistener =
+				new DefaultContainerGridGroupsListener<String, String, ContainerNode<String>, ContainerGroup<String, String, ContainerNode<String>>>();
+
+		@Override
+		public boolean addGroup(ContainerGroup<String, String, ContainerNode<String>> group) {
+			ContainerGroup<String, String, ContainerNode<String>> put = groups.put(group.getId(), group);
+			glistener.groupAdded(group);
+			if (group instanceof MockContainerGroup) {
+				((MockContainerGroup)group).glistener = glistener;
+			}
+			return put == null;
+		}
+
+		@Override
+		public boolean removeGroup(String id) {
+			ContainerGroup<String, String, ContainerNode<String>> removed = groups.remove(id);
+			if (removed != null) {
+				glistener.groupRemoved(removed);
+			}
+			if (removed instanceof MockContainerGroup) {
+				((MockContainerGroup)removed).glistener = null;
+			}
+			return removed != null;
+		}
+
+		@Override
+		public ContainerGroup<String, String, ContainerNode<String>> getGroup(String id) {
+			return groups.get(id);
+		}
+
+		@Override
+		public Collection<ContainerGroup<String, String, ContainerNode<String>>> getGroups() {
+			return groups.values();
+		}
+
+		@Override
+		public ContainerGroup<String, String, ContainerNode<String>> getGroupByNode(String id) {
+			Iterator<ContainerGroup<String, String, ContainerNode<String>>> iterator = groups.values().iterator();
+			while (iterator.hasNext()) {
+				ContainerGroup<String, String, ContainerNode<String>> group = iterator.next();
+				if (group.hasNode(id)) {
+					return group;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public void addContainerGridGroupsListener(
+				ContainerGridGroupsListener<String, String, ContainerNode<String>, ContainerGroup<String, String, ContainerNode<String>>> listener) {
+			glistener.register(listener);
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/AbstractContainerGridTests.java
+++ b/src/test/java/org/springframework/data/grid/AbstractContainerGridTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base test class sharing mock components for {@code ContainerGrid}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractContainerGridTests {
+
+	protected static class MockContainerGridListener implements ContainerGridListener<String, ContainerNode<String>> {
+
+		List<ContainerNode<String>> added = new ArrayList<ContainerNode<String>>();
+		List<ContainerNode<String>> removed = new ArrayList<ContainerNode<String>>();
+
+		@Override
+		public void nodeAdded(ContainerNode<String> node) {
+			added.add(node);
+		}
+
+		@Override
+		public void nodeRemoved(ContainerNode<String> node) {
+			removed.add(node);
+		}
+
+	}
+
+	protected static class MockContainerNode implements ContainerNode<String> {
+		String name;
+		MockContainerNode(String name) {
+			this.name = name;
+		}
+		@Override
+		public String getId() {
+			return name;
+		}
+	}
+
+	protected static class MockContainerGrid implements ContainerGrid<String, ContainerNode<String>> {
+
+		Map<String, ContainerNode<String>> nodes = new HashMap<String, ContainerNode<String>>();
+		DefaultContainerGridListener<String, ContainerNode<String>> listener =
+				new DefaultContainerGridListener<String, ContainerNode<String>>();
+
+		@Override
+		public Collection<ContainerNode<String>> getNodes() {
+			return nodes.values();
+		}
+
+		@Override
+		public ContainerNode<String> getNode(String id) {
+			return nodes.get(id);
+		}
+
+		@Override
+		public boolean addNode(ContainerNode<String> node) {
+			ContainerNode<String> put = nodes.put(node.getId(), node);
+			listener.nodeAdded(node);
+			return put == null;
+		}
+
+		@Override
+		public boolean removeNode(String id) {
+			ContainerNode<String> removed = nodes.remove(id);
+			if (removed != null) {
+				listener.nodeRemoved(removed);
+			}
+			return removed != null;
+		}
+
+		@Override
+		public void addContainerGridListener(ContainerGridListener<String, ContainerNode<String>> listener) {
+			this.listener.register(listener);
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/AbstractExtendedInterfacesTests.java
+++ b/src/test/java/org/springframework/data/grid/AbstractExtendedInterfacesTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base test class sharing extended interfaces and mocked objects.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractExtendedInterfacesTests {
+
+	protected interface ExtendedContainerNode<NID> extends ContainerNode<NID> {
+		Object getNodeObject();
+	}
+
+	protected interface ExtendedContainerGroup<GID, NID> extends ContainerGroup<GID, NID, ExtendedContainerNode<NID>> {
+		Object getGroupObject();
+	}
+
+	protected interface ExtendedContainerGrid<NID> extends ContainerGrid<NID, ExtendedContainerNode<NID>> {
+		Object getGridObject();
+	}
+
+	protected interface ExtendedContainerGridGroup<GID, NID>
+			extends ContainerGridGroups<GID, NID, ExtendedContainerNode<NID>, ExtendedContainerGroup<GID, NID>> {
+		Object getGridGroupObject();
+	}
+
+	protected static class MockContainerGridListener implements ContainerGridListener<String, ExtendedContainerNode<String>> {
+
+		List<ExtendedContainerNode<String>> added = new ArrayList<ExtendedContainerNode<String>>();
+		List<ExtendedContainerNode<String>> removed = new ArrayList<ExtendedContainerNode<String>>();
+
+		@Override
+		public void nodeAdded(ExtendedContainerNode<String> node) {
+			added.add(node);
+		}
+
+		@Override
+		public void nodeRemoved(ExtendedContainerNode<String> node) {
+			removed.add(node);
+		}
+
+	}
+
+	protected static class MockContainerGridGroupsListener
+			implements ContainerGridGroupsListener<String, String, ExtendedContainerNode<String>, ExtendedContainerGroup<String, String>> {
+
+		List<ExtendedContainerGroup<String, String>> groupAdded = new ArrayList<ExtendedContainerGroup<String,String>>();
+		List<ExtendedContainerGroup<String, String>> groupRemoved = new ArrayList<ExtendedContainerGroup<String,String>>();
+		Map<String, List<ExtendedContainerNode<String>>> groupMemberAdded = new HashMap<String, List<ExtendedContainerNode<String>>>();
+		Map<String, List<ExtendedContainerNode<String>>> groupMemberRemoved = new HashMap<String, List<ExtendedContainerNode<String>>>();
+
+		@Override
+		public void groupAdded(ExtendedContainerGroup<String, String> group) {
+			groupAdded.add(group);
+		}
+
+		@Override
+		public void groupRemoved(ExtendedContainerGroup<String, String> group) {
+			groupRemoved.add(group);
+		}
+
+		@Override
+		public void nodeAdded(ExtendedContainerGroup<String, String> group, ExtendedContainerNode<String> node) {
+			List<ExtendedContainerNode<String>> list = groupMemberAdded.get(group.getId());
+			if (list == null) {
+				list = new ArrayList<ExtendedContainerNode<String>>();
+				groupMemberAdded.put(group.getId(), list);
+			}
+			list.add(node);
+		}
+
+		@Override
+		public void nodeRemoved(ExtendedContainerGroup<String, String> group, ExtendedContainerNode<String> node) {
+			List<ExtendedContainerNode<String>> list = groupMemberRemoved.get(group.getId());
+			if (list == null) {
+				list = new ArrayList<ExtendedContainerNode<String>>();
+				groupMemberRemoved.put(group.getId(), list);
+			}
+			list.add(node);
+		}
+
+	}
+
+	protected static class MockContainerGridGroups extends MockContainerGrid implements ExtendedContainerGridGroup<String, String> {
+
+		Map<String, ExtendedContainerGroup<String, String>> groups = new HashMap<String, ExtendedContainerGroup<String, String>>();
+		DefaultContainerGridGroupsListener<String, String, ExtendedContainerNode<String>, ExtendedContainerGroup<String, String>> glistener =
+				new DefaultContainerGridGroupsListener<String, String, ExtendedContainerNode<String>, ExtendedContainerGroup<String, String>>();
+
+		@Override
+		public boolean addGroup(ExtendedContainerGroup<String, String> group) {
+			ExtendedContainerGroup<String, String> put = groups.put(group.getId(), group);
+			glistener.groupAdded(group);
+			if (group instanceof MockContainerGroup) {
+				((MockContainerGroup)group).glistener = glistener;
+			}
+			return put == null;
+		}
+
+		@Override
+		public boolean removeGroup(String id) {
+			ExtendedContainerGroup<String, String> removed = groups.remove(id);
+			if (removed != null) {
+				glistener.groupRemoved(removed);
+			}
+			if (removed instanceof MockContainerGroup) {
+				((MockContainerGroup)removed).glistener = null;
+			}
+			return removed != null;
+		}
+
+		@Override
+		public ExtendedContainerGroup<String, String> getGroup(String id) {
+			return groups.get(id);
+		}
+
+		@Override
+		public Collection<ExtendedContainerGroup<String, String>> getGroups() {
+			return groups.values();
+		}
+
+		@Override
+		public ExtendedContainerGroup<String, String> getGroupByNode(String id) {
+			Iterator<ExtendedContainerGroup<String, String>> iterator = groups.values().iterator();
+			while (iterator.hasNext()) {
+				ExtendedContainerGroup<String, String> group = iterator.next();
+				if (group.hasNode(id)) {
+					return group;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public void addContainerGridGroupsListener(
+				ContainerGridGroupsListener<String, String, ExtendedContainerNode<String>, ExtendedContainerGroup<String, String>> listener) {
+			glistener.register(listener);
+		}
+
+		@Override
+		public Object getGridGroupObject() {
+			return "gridGroupObject";
+		}
+
+	}
+
+	protected static class MockContainerGrid implements ExtendedContainerGrid<String> {
+
+		Map<String, ExtendedContainerNode<String>> nodes = new HashMap<String, ExtendedContainerNode<String>>();
+		DefaultContainerGridListener<String, ExtendedContainerNode<String>> listener =
+				new DefaultContainerGridListener<String, ExtendedContainerNode<String>>();
+
+		@Override
+		public Collection<ExtendedContainerNode<String>> getNodes() {
+			return nodes.values();
+		}
+
+		@Override
+		public ExtendedContainerNode<String> getNode(String id) {
+			return nodes.get(id);
+		}
+
+		@Override
+		public boolean addNode(ExtendedContainerNode<String> node) {
+			ExtendedContainerNode<String> put = nodes.put(node.getId(), node);
+			listener.nodeAdded(node);
+			return put == null;
+		}
+
+		@Override
+		public boolean removeNode(String id) {
+			ExtendedContainerNode<String> removed = nodes.remove(id);
+			if (removed != null) {
+				listener.nodeRemoved(removed);
+			}
+			return removed != null;
+		}
+
+		@Override
+		public void addContainerGridListener(ContainerGridListener<String, ExtendedContainerNode<String>> listener) {
+			this.listener.register(listener);
+		}
+
+		@Override
+		public Object getGridObject() {
+			return "gridObject";
+		}
+
+	}
+
+	protected static class MockContainerNode implements ExtendedContainerNode<String> {
+		String name;
+
+		MockContainerNode(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getId() {
+			return name;
+		}
+
+		@Override
+		public Object getNodeObject() {
+			return "nodeObject";
+		}
+	}
+
+	protected static class MockContainerGroup implements ExtendedContainerGroup<String,String> {
+		String name;
+		Map<String, ExtendedContainerNode<String>> nodes = new HashMap<String, ExtendedContainerNode<String>>();
+		DefaultContainerGridGroupsListener<String, String, ExtendedContainerNode<String>, ExtendedContainerGroup<String, String>> glistener;
+
+		MockContainerGroup(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getId() {
+			return name;
+		}
+
+		@Override
+		public boolean hasNode(String id) {
+			return nodes.containsKey(id);
+		}
+
+		@Override
+		public boolean addNode(ExtendedContainerNode<String> member) {
+			ExtendedContainerNode<String> put = nodes.put(member.getId(), member);
+			if (glistener != null) {
+				glistener.nodeAdded(this, member);
+			}
+			return put == null;
+		}
+
+		@Override
+		public ExtendedContainerNode<String> removeNode(String id) {
+			ExtendedContainerNode<String> removed = nodes.remove(id);
+			if (glistener != null && removed != null) {
+				glistener.nodeRemoved(this, removed);
+			}
+			return removed;
+		}
+
+		@Override
+		public ExtendedContainerNode<String> getNode(String id) {
+			return nodes.get(id);
+		}
+
+		@Override
+		public Collection<ExtendedContainerNode<String>> getNodes() {
+			return nodes.values();
+		}
+
+		@Override
+		public Object getGroupObject() {
+			return "groupObject";
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/AbstractRebalanceTests.java
+++ b/src/test/java/org/springframework/data/grid/AbstractRebalanceTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+/**
+ * Base test class sharing extended interfaces and mocked objects.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractRebalanceTests extends AbstractExtendedInterfacesTests {
+
+	protected interface ExtendedManagedContainerGridGroup<GID, NID> extends
+			ManagedContainerGridGroups<GID, NID, ExtendedContainerNode<NID>, ExtendedContainerGroup<GID, NID>, ExtendedGroupsRebalanceData> {
+	}
+
+	protected interface ExtendedGroupsRebalanceData extends GroupsRebalanceData {
+		Object getRebalanceObject();
+	}
+
+	protected static class MockManagedContainerGridGroups extends MockContainerGridGroups implements
+			ExtendedManagedContainerGridGroup<String, String> {
+
+		@Override
+		public boolean setGroupSize(String id, int size) {
+			return false;
+		}
+
+		@Override
+		public ExtendedGroupsRebalanceData getGroupsRebalanceData() {
+			return new ExtendedGroupsRebalanceData() {
+				@Override
+				public Object getRebalanceObject() {
+					return "rebalanceObject";
+				}
+
+			};
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/ContainerGridGroupsTests.java
+++ b/src/test/java/org/springframework/data/grid/ContainerGridGroupsTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@code ContainerGridGroups} interfaces.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ContainerGridGroupsTests extends AbstractContainerGridGroupsTests {
+
+	@Test
+	public void testSimpleOperations() {
+		MockContainerNode node1 = new MockContainerNode("mocknode1");
+		MockContainerNode node2 = new MockContainerNode("mocknode2");
+		MockContainerGroup group1 = new MockContainerGroup("mockgroup1");
+		MockContainerGroup group2 = new MockContainerGroup("mockgroup2");
+		MockContainerGridGroups groups = new MockContainerGridGroups();
+
+		// adding nodes to grid
+		groups.addNode(node1);
+		groups.addNode(node2);
+		assertThat(groups.getNodes().size(), is(2));
+
+		// adding nodes to groups
+		groups.addGroup(group1);
+		groups.addGroup(group2);
+		group1.addNode(node1);
+		group2.addNode(node2);
+		assertThat(groups.getNode("mocknode1"), notNullValue());
+		assertThat(groups.getNode("mocknode2"), notNullValue());
+		assertThat(groups.getNode("mocknode1").getId(), is("mocknode1"));
+		assertThat(groups.getNode("mocknode2").getId(), is("mocknode2"));
+		assertThat(groups.getGroups().size(), is(2));
+		assertThat(groups.getGroup("mockgroup1").getNodes().size(), is(1));
+		assertThat(groups.getGroup("mockgroup1").hasNode("mocknode1"), is(true));
+		assertThat(groups.getGroup("mockgroup1").hasNode("mocknode2"), is(false));
+		assertThat(groups.getGroup("mockgroup1").getNode("mocknode1"), notNullValue());
+		assertThat(groups.getGroup("mockgroup1").getNode("mocknode1").getId(), is("mocknode1"));
+
+		// start removing nodes from a grid and groups
+		assertThat(group1.removeNode("mocknode1"), notNullValue());
+		assertThat(group1.removeNode("mocknode2"), nullValue());
+		assertThat(groups.getGroup("mockgroup1").getNodes().size(), is(0));
+		groups.removeNode("mocknode1");
+		assertThat(groups.getNodes().size(), is(1));
+
+		assertThat(group2.removeNode("mocknode2"), notNullValue());
+		assertThat(group2.removeNode("mocknode1"), nullValue());
+		assertThat(groups.getGroup("mockgroup2").getNodes().size(), is(0));
+		groups.removeNode("mocknode2");
+		assertThat(groups.getNodes().size(), is(0));
+
+		assertThat(groups.getNode("mocknode1"), nullValue());
+		assertThat(groups.getNode("mocknode2"), nullValue());
+	}
+
+	@Test
+	public void testListener() {
+		MockContainerGridListener listener = new MockContainerGridListener();
+		MockContainerGridGroupsListener glistener = new MockContainerGridGroupsListener();
+		MockContainerNode node1 = new MockContainerNode("mocknode1");
+		MockContainerNode node2 = new MockContainerNode("mocknode2");
+		MockContainerGroup group1 = new MockContainerGroup("mockgroup1");
+		MockContainerGroup group2 = new MockContainerGroup("mockgroup2");
+		MockContainerGridGroups groups = new MockContainerGridGroups();
+
+		groups.addContainerGridListener(listener);
+		groups.addContainerGridGroupsListener(glistener);
+
+		groups.addNode(node1);
+		groups.addNode(node2);
+		assertThat(listener.added.size(), is(2));
+		assertThat(listener.removed.size(), is(0));
+
+		groups.addGroup(group1);
+		groups.addGroup(group2);
+		group1.addNode(node1);
+		group2.addNode(node2);
+		assertThat(glistener.groupAdded.size(), is(2));
+		assertThat(glistener.groupMemberAdded.size(), is(2));
+		assertThat(glistener.groupMemberAdded.get("mockgroup1").size(), is(1));
+		assertThat(glistener.groupMemberAdded.get("mockgroup2").size(), is(1));
+
+		group1.removeNode("mocknode1");
+		group2.removeNode("mocknode2");
+		groups.removeNode("mocknode1");
+		groups.removeNode("mocknode2");
+		groups.removeGroup("mockgroup1");
+		groups.removeGroup("mockgroup2");
+		assertThat(listener.added.size(), is(2));
+		assertThat(listener.removed.size(), is(2));
+		assertThat(glistener.groupRemoved.size(), is(2));
+		assertThat(glistener.groupMemberRemoved.size(), is(2));
+		assertThat(glistener.groupMemberRemoved.get("mockgroup1").size(), is(1));
+		assertThat(glistener.groupMemberRemoved.get("mockgroup2").size(), is(1));
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/ContainerGridTests.java
+++ b/src/test/java/org/springframework/data/grid/ContainerGridTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@code ContainerGrid} interfaces.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ContainerGridTests extends AbstractContainerGridTests {
+
+	@Test
+	public void testSimpleOperations() {
+		ContainerGrid<String, ContainerNode<String>> grid = new MockContainerGrid();
+		grid.addNode(new MockContainerNode("mock1"));
+		grid.addNode(new MockContainerNode("mock2"));
+		assertThat(grid.getNodes().size(), is(2));
+		assertThat(grid.getNode("mock1"), notNullValue());
+		assertThat(grid.getNode("mock2"), notNullValue());
+		assertThat(grid.getNode("mock1").getId(), is("mock1"));
+		assertThat(grid.getNode("mock2").getId(), is("mock2"));
+		grid.removeNode("mock2");
+		assertThat(grid.getNodes().size(), is(1));
+		grid.removeNode("mock1");
+		assertThat(grid.getNodes().size(), is(0));
+		assertThat(grid.getNode("mock1"), nullValue());
+		assertThat(grid.getNode("mock2"), nullValue());
+	}
+
+	@Test
+	public void testListener() {
+		MockContainerGridListener listener = new MockContainerGridListener();
+		ContainerGrid<String, ContainerNode<String>> grid = new MockContainerGrid();
+		grid.addContainerGridListener(listener);
+		grid.addNode(new MockContainerNode("mock1"));
+		grid.addNode(new MockContainerNode("mock2"));
+		assertThat(listener.added.size(), is(2));
+		assertThat(listener.removed.size(), is(0));
+		grid.removeNode("mock1");
+		grid.removeNode("mock2");
+		assertThat(listener.added.size(), is(2));
+		assertThat(listener.removed.size(), is(2));
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/ExtendedInterfacesTests.java
+++ b/src/test/java/org/springframework/data/grid/ExtendedInterfacesTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for extended interfaces.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ExtendedInterfacesTests extends AbstractExtendedInterfacesTests {
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void testSimpleOperations() {
+		MockContainerNode node1 = new MockContainerNode("mocknode1");
+		MockContainerNode node2 = new MockContainerNode("mocknode2");
+		MockContainerGroup group1 = new MockContainerGroup("mockgroup1");
+		MockContainerGroup group2 = new MockContainerGroup("mockgroup2");
+		MockContainerGridGroups groups = new MockContainerGridGroups();
+
+		assertThat(node1, instanceOf(ExtendedContainerNode.class));
+		assertThat(node2, instanceOf(ExtendedContainerNode.class));
+		assertThat(group1, instanceOf(ExtendedContainerGroup.class));
+		assertThat(group2, instanceOf(ExtendedContainerGroup.class));
+		assertThat(groups, instanceOf(ExtendedContainerGrid.class));
+		assertThat(groups, instanceOf(ExtendedContainerGridGroup.class));
+
+		assertThat(((ExtendedContainerNode)node1).getNodeObject(), instanceOf(String.class));
+		assertThat((String)((ExtendedContainerNode)node1).getNodeObject(), is("nodeObject"));
+		assertThat(((ExtendedContainerNode)node2).getNodeObject(), instanceOf(String.class));
+		assertThat((String)((ExtendedContainerNode)node2).getNodeObject(), is("nodeObject"));
+
+		assertThat(((ExtendedContainerGroup)group1).getGroupObject(), instanceOf(String.class));
+		assertThat((String)((ExtendedContainerGroup)group1).getGroupObject(), is("groupObject"));
+		assertThat(((ExtendedContainerGroup)group2).getGroupObject(), instanceOf(String.class));
+		assertThat((String)((ExtendedContainerGroup)group2).getGroupObject(), is("groupObject"));
+
+		assertThat(((ExtendedContainerGrid)groups).getGridObject(), instanceOf(String.class));
+		assertThat((String)((ExtendedContainerGrid)groups).getGridObject(), is("gridObject"));
+		assertThat(((ExtendedContainerGridGroup)groups).getGridGroupObject(), instanceOf(String.class));
+		assertThat((String)((ExtendedContainerGridGroup)groups).getGridGroupObject(), is("gridGroupObject"));
+
+		// adding nodes to grid
+		groups.addNode(node1);
+		groups.addNode(node2);
+		assertThat(groups.getNodes().size(), is(2));
+
+		// adding nodes to groups
+		groups.addGroup(group1);
+		groups.addGroup(group2);
+		group1.addNode(node1);
+		group2.addNode(node2);
+		assertThat(groups.getNode("mocknode1"), notNullValue());
+		assertThat(groups.getNode("mocknode2"), notNullValue());
+		assertThat(groups.getNode("mocknode1").getId(), is("mocknode1"));
+		assertThat(groups.getNode("mocknode2").getId(), is("mocknode2"));
+		assertThat(groups.getGroups().size(), is(2));
+		assertThat(groups.getGroup("mockgroup1").getNodes().size(), is(1));
+		assertThat(groups.getGroup("mockgroup1").hasNode("mocknode1"), is(true));
+		assertThat(groups.getGroup("mockgroup1").hasNode("mocknode2"), is(false));
+		assertThat(groups.getGroup("mockgroup1").getNode("mocknode1"), notNullValue());
+		assertThat(groups.getGroup("mockgroup1").getNode("mocknode1").getId(), is("mocknode1"));
+
+		// start removing nodes from a grid and groups
+		assertThat(group1.removeNode("mocknode1"), notNullValue());
+		assertThat(group1.removeNode("mocknode2"), nullValue());
+		assertThat(groups.getGroup("mockgroup1").getNodes().size(), is(0));
+		groups.removeNode("mocknode1");
+		assertThat(groups.getNodes().size(), is(1));
+
+		assertThat(group2.removeNode("mocknode2"), notNullValue());
+		assertThat(group2.removeNode("mocknode1"), nullValue());
+		assertThat(groups.getGroup("mockgroup2").getNodes().size(), is(0));
+		groups.removeNode("mocknode2");
+		assertThat(groups.getNodes().size(), is(0));
+
+		assertThat(groups.getNode("mocknode1"), nullValue());
+		assertThat(groups.getNode("mocknode2"), nullValue());
+	}
+
+	@Test
+	public void testListener() {
+		MockContainerGridListener listener = new MockContainerGridListener();
+		MockContainerGridGroupsListener glistener = new MockContainerGridGroupsListener();
+		MockContainerNode node1 = new MockContainerNode("mocknode1");
+		MockContainerNode node2 = new MockContainerNode("mocknode2");
+		MockContainerGroup group1 = new MockContainerGroup("mockgroup1");
+		MockContainerGroup group2 = new MockContainerGroup("mockgroup2");
+		MockContainerGridGroups groups = new MockContainerGridGroups();
+
+		groups.addContainerGridListener(listener);
+		groups.addContainerGridGroupsListener(glistener);
+
+		groups.addNode(node1);
+		groups.addNode(node2);
+		assertThat(listener.added.size(), is(2));
+		assertThat(listener.removed.size(), is(0));
+
+		groups.addGroup(group1);
+		groups.addGroup(group2);
+		group1.addNode(node1);
+		group2.addNode(node2);
+		assertThat(glistener.groupAdded.size(), is(2));
+		assertThat(glistener.groupMemberAdded.size(), is(2));
+		assertThat(glistener.groupMemberAdded.get("mockgroup1").size(), is(1));
+		assertThat(glistener.groupMemberAdded.get("mockgroup2").size(), is(1));
+
+		group1.removeNode("mocknode1");
+		group2.removeNode("mocknode2");
+		groups.removeNode("mocknode1");
+		groups.removeNode("mocknode2");
+		groups.removeGroup("mockgroup1");
+		groups.removeGroup("mockgroup2");
+		assertThat(listener.added.size(), is(2));
+		assertThat(listener.removed.size(), is(2));
+		assertThat(glistener.groupRemoved.size(), is(2));
+		assertThat(glistener.groupMemberRemoved.size(), is(2));
+		assertThat(glistener.groupMemberRemoved.get("mockgroup1").size(), is(1));
+		assertThat(glistener.groupMemberRemoved.get("mockgroup2").size(), is(1));
+	}
+
+}

--- a/src/test/java/org/springframework/data/grid/RebalanceTests.java
+++ b/src/test/java/org/springframework/data/grid/RebalanceTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.grid;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for rebalance methods.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class RebalanceTests extends AbstractRebalanceTests {
+
+	@Test
+	public void testSimpleOperations() {
+		MockManagedContainerGridGroups groups = new MockManagedContainerGridGroups();
+		MockContainerGroup group1 = new MockContainerGroup("mockgroup1");
+		MockContainerGroup group2 = new MockContainerGroup("mockgroup2");
+		groups.addGroup(group1);
+		groups.addGroup(group2);
+
+		assertThat(groups.getGroupsRebalanceData(), instanceOf(ExtendedGroupsRebalanceData.class));
+		assertThat(groups.getGroupsRebalanceData().getRebalanceObject(), instanceOf(String.class));
+		assertThat((String)groups.getGroupsRebalanceData().getRebalanceObject(), is("rebalanceObject"));
+
+		// no functional test results, just test that methods are there
+		assertThat(groups.setGroupSize("mockgroup1", 0), is(false));
+	}
+
+}


### PR DESCRIPTION
NOTE: PR to get visibility for this code and it needs a shared home outside of SHDP/XD.

Adding functionality on an interface level to do discovery of a grid,
handle node grouping and manage grouping.
- Interfaces are strongly typed order to have flexibility to extend
  framework interfaces and custom implementors to work around issues more easily.
- Multiple levels of interfaces: ContainerGrid, ContainerGridGroups and
  ManagedContainerGridGroups. These should be flexible enough to be used
  internally(grid will discover itself) or externally(data is fed in the
  system externally). Should also work in cases where grid nodes will
  discover itself without any central server(i.e. hazelcast), or having a central
  point of origin for discovery(Hadoop Yarn/Appmaster).
- ContainerNode and ContainerGroup is using typed identifier to work through
  not having a need to fix identifier as String or Object.
- From a framework point of view, all interfaces can be extended to
  create a totally extended discovery spi while other users are still able to
  understand what happens on a low level interfaces(what i.e.
  ContainerGrid, ContainerNode is giving out.

![grid-spi](https://f.cloud.github.com/assets/50398/1515989/7953a40c-4b0c-11e3-9694-015c65dec8fb.png)
