### PR TITLE
DATACMNS-399 - Support "query" prefix to designate repository query meth...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATACMNS-399-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/docbkx/repositories.xml
+++ b/src/docbkx/repositories.xml
@@ -316,7 +316,7 @@ interface UserRepository extends MyBaseRepository&lt;User, Long&gt; {
         <para>The query builder mechanism built into Spring Data repository
         infrastructure is useful for building constraining queries over
         entities of the repository. The mechanism strips the prefixes
-        <code>find…By</code>, <code>read…By</code>, and <code>get…By</code>
+        <code>find…By</code>, <code>read…By</code>, <code>query…By</code>, and <code>get…By</code>
         from the method and starts parsing the rest of it. The introducing
         clause can contain further expressions such as a <code>Distinct</code>
         to set a distinct flag on the query to be created. However, the first

--- a/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
@@ -38,7 +38,7 @@ import org.springframework.util.StringUtils;
  */
 public class PartTree implements Iterable<OrPart> {
 
-	private static final Pattern PREFIX_TEMPLATE = Pattern.compile("^(find|read|get|count)(\\p{Lu}.*?)??By");
+	private static final Pattern PREFIX_TEMPLATE = Pattern.compile("^(find|read|get|count|query)(\\p{Lu}.*?)??By");
 
 	/*
 	 * We look for a pattern of: keyword followed by

--- a/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
@@ -44,7 +44,7 @@ import org.springframework.data.repository.query.parser.PartTree.OrPart;
  */
 public class PartTreeUnitTests {
 
-	private String[] PREFIXES = { "find", "read", "get" };
+	private String[] PREFIXES = { "find", "read", "get", "query" };
 
 	@Test(expected = IllegalArgumentException.class)
 	public void rejectsNullSource() throws Exception {
@@ -415,6 +415,19 @@ public class PartTreeUnitTests {
 
 		PartTree tree = new PartTree("countByLastname", User.class);
 		assertThat(tree.isCountProjection(), is(true));
+	}
+
+	/**
+	 * @see DATACMNS-399
+	 */
+	@Test
+	public void queryPrefixShouldBeSupportedInRepositoryQueryMethods() {
+
+		PartTree tree = new PartTree("queryByFirstnameAndLastname", User.class);
+		Iterable<Part> parts = tree.getParts();
+
+		assertThat(parts, hasItem(part("firstname")));
+		assertThat(parts, hasItem(part("lastname")));
 	}
 
 	/**


### PR DESCRIPTION
...ods.

Extended PREFIX regex in PartTree to support the "query" prefix.

Original Author: @jiming
