### PR TITLE
fix NullPointerException when listing non-pageable repositories

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -93,6 +93,11 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	public boolean isPagingRepository() {
 
 		Method findAllMethod = getCrudMethods().getFindAllMethod();
+
+		if (findAllMethod == null) {
+			return false;
+		}
+
 		return Arrays.asList(findAllMethod.getParameterTypes()).contains(Pageable.class);
 	}
 }

--- a/src/test/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadataUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadataUnitTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.querydsl.User;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.RepositoryMetadata;
 
@@ -65,6 +66,20 @@ public class AbstractRepositoryMetadataUnitTests {
 	}
 
 	@Test
+	public void nonPageableRepository() throws Exception {
+
+		RepositoryMetadata metadata = new DummyRepositoryMetadata(UserRepository.class);
+		assertFalse(metadata.isPagingRepository());
+	}
+
+	@Test
+	public void pageableRepository() throws Exception {
+
+		RepositoryMetadata metadata = new DummyRepositoryMetadata(PagedRepository.class);
+		assertTrue(metadata.isPagingRepository());
+	}
+
+	@Test
 	public void determinesReturnTypeFromGenericType() throws Exception {
 		RepositoryMetadata metadata = new DummyRepositoryMetadata(ExtendingRepository.class);
 		Method method = ExtendingRepository.class.getMethod("someMethod");
@@ -100,6 +115,10 @@ public class AbstractRepositoryMetadataUnitTests {
 		GenericType<User> someMethod();
 
 		List<Map<String, Object>> anotherMethod();
+	}
+
+	interface PagedRepository extends PagingAndSortingRepository<User, Long> {
+
 	}
 
 	class GenericType<T> {


### PR DESCRIPTION
Listing repositories if one repository has no pageable finders leads to a NullPointerException. Includes Unit Test and Fix.
