### PR TITLE
DATACMNS-497 Changed visibility to protected for customization

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -176,7 +176,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware {
 	 * @param repositoryInterface
 	 * @return
 	 */
-	RepositoryMetadata getRepositoryMetadata(Class<?> repositoryInterface) {
+	protected RepositoryMetadata getRepositoryMetadata(Class<?> repositoryInterface) {
 		return Repository.class.isAssignableFrom(repositoryInterface) ? new DefaultRepositoryMetadata(repositoryInterface)
 				: new AnnotationRepositoryMetadata(repositoryInterface);
 	}


### PR DESCRIPTION
Just filed [DATACMNS-497](https://jira.spring.io/browse/DATACMNS-497) for this minor change. 

I've got a scenario where I can't create repositories without overriding `RepositoryFactorySupport.getRepositoryMetadata()` and can't do so because it has default visibility.

Also, I've signed the Contributor Agreement so I should be good there. Thanks!