### PR TITLE
Enable multipleStoresDetected overriden

### DIFF
--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -157,7 +157,7 @@ public class RepositoryConfigurationDelegate {
 	 * 
 	 * @return
 	 */
-	private boolean multipleStoresDetected() {
+	protected boolean multipleStoresDetected() {
 
 		ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false,
 				environment);


### PR DESCRIPTION
The RepositoryConfigurationDelegate class do not enable to chose the ClassPathScanningCandidateComponentProvider used by the multipleStoresDetected.
In order to extend Spring Data Commons to support VFS2, I need to inherites from ClassPathScanningCandidateComponentProvider and choose a custom implementation of the ResourcePatternResolver interface.
Olivier, I need this change for the OSS project https://github.com/arey/spring4-vfs2-support
Without this change, I'll be block to the Spring Data JPA 1.6.4

I've already signed the SpringSource contributor agreement. My confirmation number is 76920140328121837.
