### PR TITLE
DATACMNS-597 - BasicPersistentEntity.getPropertyAccessor for target bean...

### DIFF
--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Jon Brisbin
  * @author Patryk Wasik
  * @author Thomas Darimont
+ * @author John Blum
  */
 public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implements MutablePersistentEntity<T, P> {
 
@@ -372,7 +373,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 	public PersistentPropertyAccessor getPropertyAccessor(Object bean) {
 
 		Assert.notNull(bean, "Target bean must not be null!");
-		Assert.isTrue(getType().equals(bean.getClass()), "Target bean is not of type of the persistent entity!");
+		Assert.isTrue(getType().isAssignableFrom(bean.getClass()), "Target bean is not of type of the persistent entity!");
 
 		return new BeanWrapper<Object>(bean);
 	}

--- a/src/test/java/org/springframework/data/mapping/model/BasicPersistentEntityUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/BasicPersistentEntityUnitTests.java
@@ -210,6 +210,19 @@ public class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 		entity.getPropertyAccessor("foo");
 	}
 
+  @Test
+  public void acceptsInheritedBeanForPropertyAccessor() {
+
+    SampleMappingContext context = new SampleMappingContext();
+    PersistentEntity<Object, SamplePersistentProperty> entity = context.getPersistentEntity(Entity.class);
+
+    SubEntity value = new SubEntity();
+    PersistentPropertyAccessor accessor = entity.getPropertyAccessor(value);
+
+    assertThat(accessor, is(instanceOf(BeanWrapper.class)));
+    assertThat(accessor.getBean(), is((Object) value));
+  }
+
 	private BasicPersistentEntity<Person, T> createEntity(Comparator<T> comparator) {
 		return new BasicPersistentEntity<Person, T>(ClassTypeInformation.from(Person.class), comparator);
 	}
@@ -232,4 +245,8 @@ public class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 			return property;
 		}
 	}
+
+  static class SubEntity extends Entity {
+  }
+
 }


### PR DESCRIPTION
... does not properly handle inheritance when PersistentEntity instances are interface or abstract class based.
