### PR TITLE
DATACMNS-634 - Scan for repositories of superclasses.

### DIFF
--- a/src/main/java/org/springframework/data/repository/support/Repositories.java
+++ b/src/main/java/org/springframework/data/repository/support/Repositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.util.ClassUtils;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Thomas Eizinger
  */
 public class Repositories implements Iterable<Class<?>> {
 
@@ -133,10 +134,18 @@ public class Repositories implements Iterable<Class<?>> {
 
 		Assert.notNull(domainClass, DOMAIN_TYPE_MUST_NOT_BE_NULL);
 
-		RepositoryFactoryInformation<Object, Serializable> repositoryInfo = repositoryFactoryInfos.get(ClassUtils
-				.getUserClass(domainClass));
+		Class<?> classToInspect = domainClass;
+		RepositoryFactoryInformation<Object, Serializable> repositoryInfo = repositoryFactoryInfos
+				.get(ClassUtils.getUserClass(classToInspect));
+
+		while (repositoryInfo == null && !classToInspect.equals(Object.class)) {
+			classToInspect = classToInspect.getSuperclass();
+			repositoryInfo = repositoryFactoryInfos.get(ClassUtils.getUserClass(classToInspect));
+		}
+
 		return repositoryInfo == null ? EMPTY_REPOSITORY_FACTORY_INFO : repositoryInfo;
 	}
+
 
 	/**
 	 * Returns the {@link EntityInformation} for the given domain class.

--- a/src/test/java/org/springframework/data/repository/support/RepositoriesUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/support/RepositoriesUnitTests.java
@@ -108,9 +108,21 @@ public class RepositoriesUnitTests {
 		assertThat(repositories.getPersistentEntity(Address.class), is(notNullValue()));
 	}
 
+	/**
+	 * @see DATAREST-321
+	 */
+	@Test
+	public void findsRepositoryForSubTypes() {
+
+		Repositories repositories = new Repositories(context);
+		assertThat(repositories.getPersistentEntity(AdvancedAddress.class), is(notNullValue()));
+	}
+
 	class Person {}
 
 	class Address {}
+
+	class AdvancedAddress extends Address { }
 
 	interface PersonRepository extends CrudRepository<Person, Long> {}
 


### PR DESCRIPTION
I believe the referenced issue is wrongly tagged as an issue in SDR as the affected code belongs to the spring-data-commons repository. Previously, a repository defined for a supertype of a class could not be discovered. This pull request adds the functionality to retrieve the repository information of the repository assigned to the supertype.