### PR TITLE
DATACMNS-636 - Add 'exists' method to QueryDslPredicateExecutor which accepts a querydsl Predicate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.10.0.BUILD-SNAPSHOT</version>
+	<version>1.10.0.DATACMNS-636-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/querydsl/QueryDslPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/querydsl/QueryDslPredicateExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,4 +83,12 @@ public interface QueryDslPredicateExecutor<T> {
 	 * @return the number of instances matching the {@link Predicate}.
 	 */
 	long count(Predicate predicate);
+
+	/**
+	 * Checks whether the data store contains elements that match the given {@link Predicate}.
+	 *
+	 * @param predicate the {@link Predicate} to use for the existance check, can be {@literal null}.
+	 * @return {@literal true} if the data store contains elements that match the given {@link Predicate}.
+	 */
+	boolean exists(Predicate predicate);
 }


### PR DESCRIPTION
Introduced exists(Predicate) method to QueryDslPredicateExecutor which enables  other SD Repository implementations to provide this functionality without users having to manually declare the method on their interfaces. 