### PR TITLE
Change property reflection mechanisms from java.beans.Introspector to spring specific BeanUtils

### DIFF
--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -15,9 +15,6 @@
  */
 package org.springframework.data.mapping.context;
 
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -34,6 +31,8 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
@@ -281,10 +280,10 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			// Eagerly cache the entity as we might have to find it during recursive lookups.
 			persistentEntities.put(typeInformation, entity);
 
-			BeanInfo info = Introspector.getBeanInfo(type);
+			PropertyDescriptor[] pds = BeanUtils.getPropertyDescriptors(type);
 
 			final Map<String, PropertyDescriptor> descriptors = new HashMap<String, PropertyDescriptor>();
-			for (PropertyDescriptor descriptor : info.getPropertyDescriptors()) {
+			for (PropertyDescriptor descriptor : pds) {
 				descriptors.put(descriptor.getName(), descriptor);
 			}
 
@@ -308,7 +307,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 			return entity;
 
-		} catch (IntrospectionException e) {
+		} catch (BeansException e) {
 			throw new MappingException(e.getMessage(), e);
 		} finally {
 			write.unlock();


### PR DESCRIPTION
The purpose is to:
 1. cache the introspection results
 2. enable BeanInfoFactory support to custom bean reflection strategies (fluent setters, default methods with getters/setters etc.)

DATACMNS-693