### PR TITLE
DATACMNS-716 - Allow collection executions with wrapper types as return values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATACMNS-716-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<springhateoas>0.17.0.RELEASE</springhateoas>
 		<dist.key>DATACMNS</dist.key>
+		<spring>4.2.0.BUILD-SNAPSHOT</spring>
 	</properties>
 
 	<dependencies>

--- a/src/test/java/org/springframework/data/repository/query/QueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/QueryMethodUnitTests.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.*;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.junit.Test;
@@ -34,6 +37,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  * Unit tests for {@link QueryMethod}.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class QueryMethodUnitTests {
 
@@ -163,6 +167,54 @@ public class QueryMethodUnitTests {
 		assertThat(new QueryMethod(method, repositoryMetadata).isStreamQuery(), is(true));
 	}
 
+	/**
+	 * @see DATACMNS-716
+	 */
+	@Test
+	public void doesNotRejectCompletableFutureQueryForSingleEntity() throws Exception {
+
+		RepositoryMetadata repositoryMetadata = new DefaultRepositoryMetadata(SampleRepository.class);
+		Method method = SampleRepository.class.getMethod("returnsCompletableFutureForSingleEntity");
+
+		assertThat(new QueryMethod(method, repositoryMetadata).isCollectionQuery(), is(false));
+	}
+
+	/**
+	 * @see DATACMNS-716
+	 */
+	@Test
+	public void doesNotRejectCompletableFutureQueryForEntityCollection() throws Exception {
+
+		RepositoryMetadata repositoryMetadata = new DefaultRepositoryMetadata(SampleRepository.class);
+		Method method = SampleRepository.class.getMethod("returnsCompletableFutureForEntityCollection");
+
+		assertThat(new QueryMethod(method, repositoryMetadata).isCollectionQuery(), is(true));
+	}
+
+	/**
+	 * @see DATACMNS-716
+	 */
+	@Test
+	public void doesNotRejectFutureQueryForSingleEntity() throws Exception {
+
+		RepositoryMetadata repositoryMetadata = new DefaultRepositoryMetadata(SampleRepository.class);
+		Method method = SampleRepository.class.getMethod("returnsFutureForSingleEntity");
+
+		assertThat(new QueryMethod(method, repositoryMetadata).isCollectionQuery(), is(false));
+	}
+
+	/**
+	 * @see DATACMNS-716
+	 */
+	@Test
+	public void doesNotRejectFutureQueryForEntityCollection() throws Exception {
+
+		RepositoryMetadata repositoryMetadata = new DefaultRepositoryMetadata(SampleRepository.class);
+		Method method = SampleRepository.class.getMethod("returnsFutureForEntityCollection");
+
+		assertThat(new QueryMethod(method, repositoryMetadata).isCollectionQuery(), is(true));
+	}
+
 	interface SampleRepository extends Repository<User, Serializable> {
 
 		String pagingMethodWithInvalidReturnType(Pageable pageable);
@@ -186,6 +238,26 @@ public class QueryMethodUnitTests {
 		Stream<String> streaming();
 
 		Stream<String> streaming(Pageable pageable);
+
+		/**
+		 * @see DATACMNS-716
+		 */
+		CompletableFuture<User> returnsCompletableFutureForSingleEntity();
+
+		/**
+		 * @see DATACMNS-716
+		 */
+		CompletableFuture<List<User>> returnsCompletableFutureForEntityCollection();
+
+		/**
+		 * @see DATACMNS-716
+		 */
+		Future<User> returnsFutureForSingleEntity();
+
+		/**
+		 * @see DATACMNS-716
+		 */
+		Future<List<User>> returnsFutureForEntityCollection();
 	}
 
 	class User {


### PR DESCRIPTION
We now support CollectionExecutions in query derivation in combination with Wrapper types like (Future, Optional, CompletableFuture, ListenableFuture) that wrap a collection, e.g. Future<List<User>>.
Previously we used the “raw” return type which tricked our  detection for Collection / Page / Slice executions.