### PR TITLE
DATACMNS-734 - Allow comma separated list of values to be bound to an array.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.0.BUILD-SNAPSHOT</version>
+	<version>1.11.0.DATACMNS-734-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
@@ -191,7 +191,8 @@ public class QuerydslPredicateBuilder {
 	 */
 	private Collection<Object> convertToPropertyPathSpecificType(List<String> source, PropertyPath path) {
 
-		Class<?> targetType = path.getLeafProperty().getType();
+		Class<?> targetType = path.getLeafProperty().getOwningType().getProperty(path.getLeafProperty().getSegment())
+				.getType();
 
 		if (source.isEmpty() || isSingleElementCollectionWithoutText(source)) {
 			return Collections.emptyList();
@@ -201,8 +202,8 @@ public class QuerydslPredicateBuilder {
 
 		for (String value : source) {
 
-			target.add(conversionService.canConvert(value.getClass(), targetType)
-					? conversionService.convert(value, targetType) : value);
+			target.add(conversionService.canConvert(String.class, targetType) ? conversionService.convert(
+					targetType.isArray() ? value.split(",") : value, targetType) : value);
 		}
 
 		return target;

--- a/src/test/java/org/springframework/data/querydsl/Address.java
+++ b/src/test/java/org/springframework/data/querydsl/Address.java
@@ -24,6 +24,7 @@ import com.mysema.query.annotations.QueryEntity;
 public class Address {
 
 	public String street, city;
+	public Double[] lonLat;
 
 	public Address(String street, String city) {
 		this.street = street;


### PR DESCRIPTION
We now convert comma separated values for an array property for a QueryDSL `Predicate` by splitting values and converting each of them. This allows to convert `address.location=40.740337,-73.995146` to

```java
class Address {
  Double[] location;
}
```