### PR TITLE
DATACMNS-739 - Performance improvement for MultiTransactionStatus

### DIFF
--- a/src/main/java/org/springframework/data/transaction/MultiTransactionStatus.java
+++ b/src/main/java/org/springframework/data/transaction/MultiTransactionStatus.java
@@ -37,7 +37,8 @@ import org.springframework.util.Assert;
 class MultiTransactionStatus implements TransactionStatus {
 
 	private final PlatformTransactionManager mainTransactionManager;
-	private final Map<PlatformTransactionManager, TransactionStatus> transactionStatuses = new ConcurrentHashMap<PlatformTransactionManager, TransactionStatus>();
+	private final Map<PlatformTransactionManager, TransactionStatus> transactionStatuses = 
+				new ConcurrentHashMap<PlatformTransactionManager, TransactionStatus>();
 
 	private boolean newSynchonization;
 

--- a/src/main/java/org/springframework/data/transaction/MultiTransactionStatus.java
+++ b/src/main/java/org/springframework/data/transaction/MultiTransactionStatus.java
@@ -18,6 +18,7 @@ package org.springframework.data.transaction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -36,8 +37,7 @@ import org.springframework.util.Assert;
 class MultiTransactionStatus implements TransactionStatus {
 
 	private final PlatformTransactionManager mainTransactionManager;
-	private final Map<PlatformTransactionManager, TransactionStatus> transactionStatuses = Collections
-			.synchronizedMap(new HashMap<PlatformTransactionManager, TransactionStatus>());
+	private final Map<PlatformTransactionManager, TransactionStatus> transactionStatuses = new ConcurrentHashMap<PlatformTransactionManager, TransactionStatus>();
 
 	private boolean newSynchonization;
 


### PR DESCRIPTION
Its always better in Multi-threading and low latency application that not to have single lock on Map.
ConcurrentHashMap holds default 16 locks which significantly improves the performance than having single lock SyncronizedMap.
