### PR TITLE
Fixed maven typo in dependencies

### DIFF
--- a/src/main/asciidoc/dependencies.adoc
+++ b/src/main/asciidoc/dependencies.adoc
@@ -16,7 +16,7 @@ Due to different inception dates of individual Spring Data modules, most of them
       <scope>import</scope>
       <type>pom</type>
     </dependency>
-  <dependencies>
+  </dependencies>
 </dependencyManagement>
 ----
 ====


### PR DESCRIPTION
Corrected the closing tag for dependency for Spring Data Commons section on dependencies. See: http://docs.spring.io/spring-data/jpa/docs/1.9.0.RC1/reference/html/#dependencies