### PR TITLE
[Test case DATACMNS-753] parsing of Sort fails to fallback properly

### DIFF
--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -150,6 +150,21 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 	}
 
 	/**
+	 *
+	 * @see DATACMNS-753
+	 * see also DATACMNS-408
+	 */
+	@Test
+	public void doesNotReturnNullWhenAnnotatedWithSortDefault() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", ""); //valid input
+
+		assertNotNull(resolveSort(request, getParameterOfMethod("simpleDefault")));
+		assertNotNull(resolveSort(request, getParameterOfMethod("containeredDefault")));
+	}
+
+	/**
 	 * @see DATACMNS-408
 	 */
 	@Test


### PR DESCRIPTION
The test cases of `DATACMNS-408` included a input of `null`, but a request with `?sort=` means that the parameter is `""`.
Discussion https://jira.spring.io/browse/DATACMNS-753.