### PR TITLE
s/User/Person/

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -107,14 +107,14 @@ Standard CRUD functionality repositories usually have queries on the underlying 
 +
 [source, java]
 ----
-interface PersonRepository extends Repository<User, Long> { … }
+interface PersonRepository extends Repository<Person, Long> { … }
 ----
 
 . Declare query methods on the interface.
 +
 [source, java]
 ----
-interface PersonRepository extends Repository<User, Long> {
+interface PersonRepository extends Repository<Person, Long> {
   List<Person> findByLastname(String lastname);
 }
 ----


### PR DESCRIPTION
It looks odd (wrong) that `PersonRepository` deals with `User` entity.
I think the type parameter should really be `Person`