### PR TITLE
Make class public

### DIFF
--- a/src/main/java/org/springframework/data/domain/jaxb/PageableAdapter.java
+++ b/src/main/java/org/springframework/data/domain/jaxb/PageableAdapter.java
@@ -31,7 +31,7 @@ import org.springframework.data.domain.jaxb.SpringDataJaxb.SortDto;
  * 
  * @author Oliver Gierke
  */
-class PageableAdapter extends XmlAdapter<PageRequestDto, Pageable> {
+public class PageableAdapter extends XmlAdapter<PageRequestDto, Pageable> {
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
It has package visibility which prevents this adapter from using outside the package it declared in.