### PR TITLE
Issue/datacmns 766

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.12.0.BUILD-SNAPSHOT</version>
+	<version>1.12.0.DATACMNS-766-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java
@@ -182,7 +182,7 @@ class DefaultRepositoryInformation implements RepositoryInformation {
 	 */
 	private boolean isQueryMethodCandidate(Method method) {
 		return !method.isBridge() && !ReflectionUtils.isDefaultMethod(method) //
-				&& (isQueryAnnotationPresentOn(method) || !isCustomMethod(method) && !isBaseClassMethod(method));
+				&& (isQueryAnnotationPresentOn(method) || !isBaseClassMethod(method));
 	}
 
 	/**


### PR DESCRIPTION
DO NOT MERGE - REVIEW REQUEST

@olivergierke @thomasdarimont I have run into a situation where someone wants to wrap a custom repository with Spring Data REST. The "real" backend is a SOAP interface, but I coded an experiment where I just use a `Map<ID, T>`. I found that by coding a custom Implementation (as shown [here](https://github.com/gregturn/issue-002/blob/master/src/main/java/demo/BookRepositoryImpl.java) for demo purposes), Spring Data REST works with it perfectly. Unfortunately, custom finders (like [this](https://github.com/gregturn/issue-002/blob/master/src/main/java/demo/BookRepositoryImpl.java#L137-L145)) are not listed underneath Spring Data REST's /search path as a custom finder because of [this](https://github.com/spring-projects/spring-data-commons/blob/master/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java#L185) explicit check for `isCustomMethod()`.

This PR shows me removing that one restriction. Upon building and deployment to my own local maven repository, my demo app that I linked to up above listed my custom finder and invoked it properly, so it looks like a good fix. What I cannot discern is other impacts. Basically, why was this restriction coded in the first place? Something else to test and verify? And seeing that this change didn't break any test cases, I am wondering what test case to write to verify it.

Thanks.