### PR TITLE
DATACMNS-658 - Add 'ignorecase' ordering option to SortHandlerMethodArgumentResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.2.RELEASE</version>
+	<version>1.11.3.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.2.BUILD-SNAPSHOT</version>
+		<version>1.7.2.RELEASE</version>
 	</parent>
 
 	<properties>
@@ -257,8 +257,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.1.RELEASE</version>
+	<version>1.11.2.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.0.RELEASE</version>
+	<version>1.11.1.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.1.RELEASE</version>
+		<version>1.7.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -257,8 +257,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.1.BUILD-SNAPSHOT</version>
+	<version>1.11.1.RELEASE</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.0.RELEASE</version>
+		<version>1.7.1.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -257,8 +257,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.2.RELEASE</version>
+		<version>1.7.3.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -257,8 +257,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.1.BUILD-SNAPSHOT</version>
+		<version>1.7.1.RELEASE</version>
 	</parent>
 
 	<properties>
@@ -257,8 +257,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.11.2.BUILD-SNAPSHOT</version>
+	<version>1.11.2.RELEASE</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/asciidoc/dependencies.adoc
+++ b/src/main/asciidoc/dependencies.adoc
@@ -22,7 +22,7 @@ Due to different inception dates of individual Spring Data modules, most of them
 ====
 
 [[dependencies.train-names]]
-The current release train version is `{releasetrainVersion}. The train names are ascending alphabetically and currently available ones are listed https://github.com/spring-projects/spring-data-commons/wiki/Release-planning[here]. The version name follows the following pattern: `${name}-${release}` where release can be one of the following:
+The current release train version is `{releasetrainVersion}`. The train names are ascending alphabetically and currently available ones are listed https://github.com/spring-projects/spring-data-commons/wiki/Release-planning[here]. The version name follows the following pattern: `${name}-${release}` where release can be one of the following:
 
 * `BUILD-SNAPSHOT` - current snapshots
 * `M1`, `M2` etc. - milestones

--- a/src/main/asciidoc/dependencies.adoc
+++ b/src/main/asciidoc/dependencies.adoc
@@ -21,7 +21,8 @@ Due to different inception dates of individual Spring Data modules, most of them
 ----
 ====
 
-The current release train version is {releasetrainVersion}. The train names are ascending alphabetically and currently available ones are listed https://github.com/spring-projects/spring-data-commons/wiki/Release-planning[here]. The version name follows the following pattern: `${name}-${release}` where release can be one of the following:
+[[dependencies.train-names]]
+The current release train version is `{releasetrainVersion}. The train names are ascending alphabetically and currently available ones are listed https://github.com/spring-projects/spring-data-commons/wiki/Release-planning[here]. The version name follows the following pattern: `${name}-${release}` where release can be one of the following:
 
 * `BUILD-SNAPSHOT` - current snapshots
 * `M1`, `M2` etc. - milestones
@@ -29,9 +30,7 @@ The current release train version is {releasetrainVersion}. The train names are 
 * `RELEASE` - GA release
 * `SR1`, `SR2` etc. - service releases
 
-A working example of using the BOMs can be found in our https://github.com/spring-projects/spring-data-examples/tree/master/bom[Spring Data examples repository].
-
-If that's in place declare the Spring Data modules you'd like to use without a version in the `<dependencies />` block.
+A working example of using the BOMs can be found in our https://github.com/spring-projects/spring-data-examples/tree/master/bom[Spring Data examples repository]. If that's in place declare the Spring Data modules you'd like to use without a version in the `<dependencies />` block.
 
 .Declaring a dependency to a Spring Data module
 ====
@@ -49,9 +48,10 @@ If that's in place declare the Spring Data modules you'd like to use without a v
 [[dependencies.spring-boot]]
 == Dependency management with Spring Boot
 
-Spring Boot already selects a very recent version of Spring Data modules for you. In case you want to upgrade to a newer version nonetheless, simply configure the property `spring-data-releasetrain.version` to the train name and iteration you'd like to use.
+Spring Boot already selects a very recent version of Spring Data modules for you. In case you want to upgrade to a newer version nonetheless, simply configure the property `spring-data-releasetrain.version` to the <<dependencies.train-names,train name and iteration>> you'd like to use.
 
 [[dependencies.spring-framework]]
 == Spring Framework
 
 The current version of Spring Data modules require Spring Framework in version {springVersion} or better. The modules might also work with an older bugfix version of that minor version. However, using the most recent version within that generation is highly recommended.
+

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -1,6 +1,5 @@
 :spring-framework-docs: http://docs.spring.io/spring/docs/current/spring-framework-reference/html
 
-
 [[repositories]]
 = Working with Spring Data Repositories
 

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -107,6 +107,7 @@ Standard CRUD functionality repositories usually have queries on the underlying 
 
 . Declare an interface extending Repository or one of its subinterfaces and type it to the domain class and ID type that it will handle.
 +
+
 [source, java]
 ----
 interface PersonRepository extends Repository<Person, Long> { … }
@@ -114,6 +115,7 @@ interface PersonRepository extends Repository<Person, Long> { … }
 
 . Declare query methods on the interface.
 +
+
 [source, java]
 ----
 interface PersonRepository extends Repository<Person, Long> {
@@ -123,6 +125,7 @@ interface PersonRepository extends Repository<Person, Long> {
 
 . Set up Spring to create proxy instances for those interfaces. Either via <<repositories.create-instances.java-config,JavaConfig>>:
 +
+
 [source, java]
 ----
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -130,9 +133,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableJpaRepositories
 class Config {}
 ----
+
 +
 or via <<repositories.create-instances,XML configuration>>:
 +
+
 [source, xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
@@ -148,13 +153,15 @@ or via <<repositories.create-instances,XML configuration>>:
 
 </beans>
 ----
+
 +
 The JPA namespace is used in this example. If you are using the repository abstraction for any other store, you need to change this to the appropriate namespace declaration of your store module which should be exchanging `jpa` in favor of, for example, `mongodb`.
-
++
 Also, note that the JavaConfig variant doesn't configure a package explictly as the package of the annotated class is used by default. To customize the package to scan use one of the `basePackage…` attribute of the data-store specific repository `@Enable…`-annotation.
 
 . Get the repository instance injected and use it.
 +
+
 [source, java]
 ----
 public class SomeClient {
@@ -578,8 +585,9 @@ public class MyRepositoryImpl<T, ID extends Serializable>
 
   private final EntityManager entityManager;
 
-  public MyRepositoryImpl(Class<T> domainClass, EntityManager entityManager) {
-    super(domainClass, entityManager);
+  public MyRepositoryImpl(JpaEntityInformation entityInformation,
+                          EntityManager entityManager) {
+    super(entityInformation, entityManager);
 
     // Keep the EntityManager around to used from the newly introduced methods.
     this.entityManager = entityManager;
@@ -591,6 +599,8 @@ public class MyRepositoryImpl<T, ID extends Serializable>
 }
 ----
 ====
+
+WARNING: The class needs to have a constructor of the super class which the store-specific repository factory implementation is using. In case the repository base class has multiple constructors, override the one taking an `EntityInformation` plus a store specific infrastructure object (e.g. an `EntityManager` or a template class).
 
 The default behavior of the Spring `<repositories />` namespace is to provide an implementation for all interfaces that fall under the `base-package`. This means that if left in its current state, an implementation instance of `MyRepository` will be created by Spring. This is of course not desired as it is just supposed to act as an intermediary between `Repository` and the actual repository interfaces you want to define for each entity. To exclude an interface that extends `Repository` from being instantiated as a repository instance, you can either annotate it with `@NoRepositoryBean` (as seen above) or move it outside of the configured `base-package`.
 

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -749,7 +749,7 @@ The default `Pageable` handed into the method is equivalent to a `new PageReques
 
 [[core.web.pageables]]
 ==== Hypermedia support for Pageables
-Spring HATEOAS ships with a representation model class `PagedResources` that allows enrichting the content of a `Page` instance with the necessary `Page` metadata as well as links to let the clients easily navigate the pages. The conversion of a Page to a `PagedResources` is done by an implementation of the Spring HATEOAS `ResourceAssembler` interface, the `PagedResourcesAssembler`.
+Spring HATEOAS ships with a representation model class `PagedResources` that allows enriching the content of a `Page` instance with the necessary `Page` metadata as well as links to let the clients easily navigate the pages. The conversion of a Page to a `PagedResources` is done by an implementation of the Spring HATEOAS `ResourceAssembler` interface, the `PagedResourcesAssembler`.
 
 .Using a PagedResourcesAssembler as controller method argument
 ====
@@ -874,7 +874,7 @@ interface UserRepository extends CrudRepository<User, String>,
 <1> `QueryDslPredicateExecutor` provides access to specific finder methods for `Predicate`.
 <2> `QuerydslBinderCustomizer` defined on the repository interface will be automatically picked up and shortcuts `@QuerydslPredicate(bindings=...)`.
 <3> Define the binding for the `username` property to be a simple contains binding.
-<4> Define the default binding for `String` properies to be a case insensitive contains match.
+<4> Define the default binding for `String` properties to be a case insensitive contains match.
 <5> Exclude the _password_ property from `Predicate` resolution.
 ====
 

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -912,7 +912,7 @@ You can easily populate your repositories by using the populator elements of the
     http://www.springframework.org/schema/data/repository
     http://www.springframework.org/schema/data/repository/spring-repository.xsd">
 
-  <repository:jackson-populator locations="classpath:data.json" />
+  <repository:jackson2-populator locations="classpath:data.json" />
 
 </beans>
 ----

--- a/src/main/java/org/springframework/data/convert/DefaultTypeMapper.java
+++ b/src/main/java/org/springframework/data/convert/DefaultTypeMapper.java
@@ -147,10 +147,16 @@ public class DefaultTypeMapper<S> implements TypeMapper<S> {
 
 		Class<T> rawType = basicType == null ? null : basicType.getType();
 
-		boolean isMoreConcreteCustomType = rawType == null ? true : rawType.isAssignableFrom(documentsTargetType)
-				&& !rawType.equals(documentsTargetType);
-		return isMoreConcreteCustomType ? (TypeInformation<? extends T>) ClassTypeInformation.from(documentsTargetType)
-				: basicType;
+		boolean isMoreConcreteCustomType = rawType == null ? true
+				: rawType.isAssignableFrom(documentsTargetType) && !rawType.equals(documentsTargetType);
+
+		if (!isMoreConcreteCustomType) {
+			return basicType;
+		}
+
+		ClassTypeInformation<?> targetType = ClassTypeInformation.from(documentsTargetType);
+
+		return (TypeInformation<? extends T>) (basicType != null ? basicType.specialize(targetType) : targetType);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/domain/Page.java
+++ b/src/main/java/org/springframework/data/domain/Page.java
@@ -29,7 +29,7 @@ public interface Page<T> extends Slice<T> {
 	/**
 	 * Returns the number of total pages.
 	 * 
-	 * @return the number of toral pages
+	 * @return the number of total pages
 	 */
 	int getTotalPages();
 

--- a/src/main/java/org/springframework/data/mapping/PropertyPath.java
+++ b/src/main/java/org/springframework/data/mapping/PropertyPath.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mapping;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
@@ -53,7 +54,7 @@ public class PropertyPath implements Iterable<PropertyPath> {
 	 * @param owningType must not be {@literal null}.
 	 */
 	PropertyPath(String name, Class<?> owningType) {
-		this(name, ClassTypeInformation.from(owningType), null);
+		this(name, ClassTypeInformation.from(owningType), Collections.<PropertyPath> emptyList());
 	}
 
 	/**
@@ -65,8 +66,9 @@ public class PropertyPath implements Iterable<PropertyPath> {
 	 */
 	PropertyPath(String name, TypeInformation<?> owningType, List<PropertyPath> base) {
 
-		Assert.hasText(name);
-		Assert.notNull(owningType);
+		Assert.hasText(name, "Name must not be null or empty!");
+		Assert.notNull(owningType, "Owning type must not be null!");
+		Assert.notNull(base, "Perviously found properties must not be null!");
 
 		String propertyName = name.matches(ALL_UPPERCASE) ? name : StringUtils.uncapitalize(name);
 		TypeInformation<?> propertyType = owningType.getProperty(propertyName);

--- a/src/main/java/org/springframework/data/mapping/PropertyReferenceException.java
+++ b/src/main/java/org/springframework/data/mapping/PropertyReferenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
  */
 package org.springframework.data.mapping;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.PropertyMatches;
 import org.springframework.data.util.TypeInformation;
@@ -38,20 +40,21 @@ public class PropertyReferenceException extends RuntimeException {
 	private final String propertyName;
 	private final TypeInformation<?> type;
 	private final List<PropertyPath> alreadyResolvedPath;
-	private final List<String> propertyMatches;
+	private final Set<String> propertyMatches;
 
 	/**
 	 * Creates a new {@link PropertyReferenceException}.
 	 * 
-	 * @param propertyName the name of the property not found on the given type.
-	 * @param type the type the property could not be found on.
-	 * @param alreadyResolvedPah the previously calculated {@link PropertyPath}s.
+	 * @param propertyName the name of the property not found on the given type, must not be {@literal null} or empty.
+	 * @param type the type the property could not be found on, must not be {@literal null}.
+	 * @param alreadyResolvedPah the previously calculated {@link PropertyPath}s, must not be {@literal null}.
 	 */
 	public PropertyReferenceException(String propertyName, TypeInformation<?> type,
 			List<PropertyPath> alreadyResolvedPah) {
 
-		Assert.hasText(propertyName);
-		Assert.notNull(type);
+		Assert.hasText(propertyName, "Property name must not be null!");
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(alreadyResolvedPah, "Already resolved paths must not be null!");
 
 		this.propertyName = propertyName;
 		this.type = type;
@@ -71,10 +74,19 @@ public class PropertyReferenceException extends RuntimeException {
 	/**
 	 * Returns the type the property could not be found on.
 	 * 
-	 * @return the type
+	 * @return will never be {@literal null}.
 	 */
 	public TypeInformation<?> getType() {
 		return type;
+	}
+
+	/**
+	 * Returns the properties that the invalid property might have been meant to be referred to.
+	 * 
+	 * @return will never be {@literal null}.
+	 */
+	Collection<String> getPropertyMatches() {
+		return propertyMatches;
 	}
 
 	/* 
@@ -114,7 +126,7 @@ public class PropertyReferenceException extends RuntimeException {
 	 * Returns whether the given {@link PropertyReferenceException} has a deeper resolution depth (i.e. a longer path of
 	 * already resolved properties) than the current exception.
 	 * 
-	 * @param exception
+	 * @param exception must not be {@literal null}.
 	 * @return
 	 */
 	public boolean hasDeeperResolutionDepthThan(PropertyReferenceException exception) {
@@ -128,9 +140,9 @@ public class PropertyReferenceException extends RuntimeException {
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
-	private static List<String> detectPotentialMatches(String propertyName, Class<?> type) {
+	private static Set<String> detectPotentialMatches(String propertyName, Class<?> type) {
 
-		List<String> result = new ArrayList<String>();
+		Set<String> result = new HashSet<String>();
 		result.addAll(Arrays.asList(PropertyMatches.forField(propertyName, type).getPossibleMatches()));
 		result.addAll(Arrays.asList(PropertyMatches.forProperty(propertyName, type).getPossibleMatches()));
 

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -403,7 +403,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 	@Override
 	public IdentifierAccessor getIdentifierAccessor(Object bean) {
 
-		Assert.notNull(bean, "Targte bean must not be null!");
+		Assert.notNull(bean, "Target bean must not be null!");
 		Assert.isTrue(getType().isInstance(bean), "Target bean is not of type of the persistent entity!");
 
 		return hasIdProperty() ? new IdPropertyIdentifierAccessor(this, bean) : NullReturningIdentifierAccessor.INSTANCE;

--- a/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
@@ -57,6 +57,13 @@ public class QuerydslPredicateBuilder {
 	private final Map<PropertyPath, Path<?>> paths;
 	private final EntityPathResolver resolver;
 
+	/**
+	 * Creates a new {@link QuerydslPredicateBuilder} for the given {@link ConversionService} and
+	 * {@link EntityPathResolver}.
+	 * 
+	 * @param conversionService must not be {@literal null}.
+	 * @param resolver can be {@literal null}.
+	 */
 	public QuerydslPredicateBuilder(ConversionService conversionService, EntityPathResolver resolver) {
 
 		Assert.notNull(conversionService, "ConversionService must not be null!");

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -335,8 +335,16 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware {
 		Constructor<?> constructor = ReflectionUtils.findConstructor(baseClass, constructorArguments);
 
 		if (constructor == null) {
+
+			List<Class<?>> argumentTypes = new ArrayList<Class<?>>(constructorArguments.length);
+
+			for (Object argument : constructorArguments) {
+				argumentTypes.add(argument.getClass());
+			}
+
 			throw new IllegalStateException(String.format(
-					"No suitable constructor found on %s to match the given arguments: %s", baseClass, constructorArguments));
+					"No suitable constructor found on %s to match the given arguments: %s. Make sure you implement a constructor taking these",
+					baseClass, argumentTypes));
 		}
 
 		return (R) BeanUtils.instantiateClass(constructor, constructorArguments);

--- a/src/main/java/org/springframework/data/repository/support/QueryMethodParameterConversionException.java
+++ b/src/main/java/org/springframework/data/repository/support/QueryMethodParameterConversionException.java
@@ -34,13 +34,16 @@ public class QueryMethodParameterConversionException extends RuntimeException {
 	private final MethodParameter parameter;
 
 	/**
+	 * Creates a new {@link QueryMethodParameterConversionException} for the given source object, {@link MethodParameter}
+	 * and root cause {@link ConversionException}.
+	 * 
 	 * @param source can be {@literal null}.
 	 * @param parameter the {@link MethodParameter} the value should've been converted for, must not be {@literal null}..
 	 * @param cause the original {@link ConversionException}, must not be {@literal null}.
 	 */
 	public QueryMethodParameterConversionException(Object source, MethodParameter parameter, ConversionException cause) {
 
-		super("message", cause);
+		super(String.format("Failed to convert %s into %s!", source, parameter.getParameterType().getName()), cause);
 
 		Assert.notNull(parameter, "Method parameter must not be null!");
 		Assert.notNull(cause, "ConversionException must not be null!");

--- a/src/main/java/org/springframework/data/repository/support/ReflectionRepositoryInvoker.java
+++ b/src/main/java/org/springframework/data/repository/support/ReflectionRepositoryInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.data.repository.core.CrudMethods;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.Param;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ReflectionUtils;
@@ -46,6 +47,7 @@ import org.springframework.util.StringUtils;
 class ReflectionRepositoryInvoker implements RepositoryInvoker {
 
 	private static final AnnotationAttribute PARAM_ANNOTATION = new AnnotationAttribute(Param.class);
+	private static final String NAME_NOT_FOUND = "Unable to detect parameter names for query method %s! Use @Param or compile with -parameters on JDK 8.";
 
 	private final Object repository;
 	private final CrudMethods methods;
@@ -60,7 +62,8 @@ class ReflectionRepositoryInvoker implements RepositoryInvoker {
 	 * @param metadata must not be {@literal null}.
 	 * @param conversionService must not be {@literal null}.
 	 */
-	public ReflectionRepositoryInvoker(Object repository, RepositoryMetadata metadata, ConversionService conversionService) {
+	public ReflectionRepositoryInvoker(Object repository, RepositoryMetadata metadata,
+			ConversionService conversionService) {
 
 		Assert.notNull(repository, "Repository must not be null!");
 		Assert.notNull(metadata, "RepositoryMetadata must not be null!");
@@ -229,8 +232,7 @@ class ReflectionRepositoryInvoker implements RepositoryInvoker {
 				String parameterName = param.getParameterName();
 
 				if (!StringUtils.hasText(parameterName)) {
-					throw new IllegalArgumentException("No @Param annotation found on query method " + method.getName()
-							+ " for parameter " + parameterName);
+					throw new IllegalArgumentException(String.format(NAME_NOT_FOUND, ClassUtils.getQualifiedMethodName(method)));
 				}
 
 				Object value = unwrapSingleElement(rawParameters.get(parameterName));

--- a/src/main/java/org/springframework/data/util/ClassTypeInformation.java
+++ b/src/main/java/org/springframework/data/util/ClassTypeInformation.java
@@ -167,6 +167,15 @@ public class ClassTypeInformation<S> extends TypeDiscoverer<S> {
 		return getType().isAssignableFrom(target.getType());
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#specialize(org.springframework.data.util.ClassTypeInformation)
+	 */
+	@Override
+	public TypeInformation<?> specialize(ClassTypeInformation<?> type) {
+		return type;
+	}
+
 	/* 
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()

--- a/src/main/java/org/springframework/data/util/TypeInformation.java
+++ b/src/main/java/org/springframework/data/util/TypeInformation.java
@@ -140,4 +140,14 @@ public interface TypeInformation<S> {
 	 * @return
 	 */
 	List<TypeInformation<?>> getTypeArguments();
+
+	/**
+	 * Specializes the given (raw) {@link ClassTypeInformation} using the context of the current potentially parameterized
+	 * type, basically turning the given raw type into a parameterized one. Will return the given type as is if no
+	 * generics are involved.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @return will never be {@literal null}.
+	 */
+	TypeInformation<?> specialize(ClassTypeInformation<?> type);
 }

--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,9 +235,9 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 			return null;
 		}
 
-		int page = StringUtils.hasText(pageString) ? parseAndApplyBoundaries(pageString, Integer.MAX_VALUE)
+		int page = StringUtils.hasText(pageString) ? parseAndApplyBoundaries(pageString, Integer.MAX_VALUE, true)
 				: defaultOrFallback.getPageNumber();
-		int pageSize = StringUtils.hasText(pageSizeString) ? parseAndApplyBoundaries(pageSizeString, maxPageSize)
+		int pageSize = StringUtils.hasText(pageSizeString) ? parseAndApplyBoundaries(pageSizeString, maxPageSize, false)
 				: defaultOrFallback.getPageSize();
 
 		// Limit lower bound
@@ -302,17 +302,18 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	}
 
 	/**
-	 * Tries to parse the given {@link String} into an integer and applies the given boundaries. Will return the lower
-	 * boundary if the {@link String} cannot be parsed.
+	 * Tries to parse the given {@link String} into an integer and applies the given boundaries. Will return 0 if the
+	 * {@link String} cannot be parsed.
 	 * 
-	 * @param parameter
-	 * @param upper
+	 * @param parameter the parameter value.
+	 * @param upper the upper bound to be applied.
+	 * @param shiftIndex whether to shift the index if {@link #oneIndexedParameters} is set to true.
 	 * @return
 	 */
-	private int parseAndApplyBoundaries(String parameter, int upper) {
+	private int parseAndApplyBoundaries(String parameter, int upper, boolean shiftIndex) {
 
 		try {
-			int parsed = Integer.parseInt(parameter) - (oneIndexedParameters ? 1 : 0);
+			int parsed = Integer.parseInt(parameter) - (oneIndexedParameters && shiftIndex ? 1 : 0);
 			return parsed < 0 ? 0 : parsed > upper ? upper : parsed;
 		} catch (NumberFormatException e) {
 			return 0;

--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,11 +108,17 @@ public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 
 		String[] directionParameter = webRequest.getParameterValues(getSortParameter(parameter));
 
-		if (directionParameter != null && directionParameter.length != 0) {
-			return parseParameterIntoSort(directionParameter, propertyDelimiter);
-		} else {
+		// No parameter
+		if (directionParameter == null) {
 			return getDefaultFromAnnotationOrFallback(parameter);
 		}
+
+		// Single empty parameter, e.g "sort="
+		if (directionParameter.length == 1 && !StringUtils.hasText(directionParameter[0])) {
+			return getDefaultFromAnnotationOrFallback(parameter);
+		}
+
+		return parseParameterIntoSort(directionParameter, propertyDelimiter);
 	}
 
 	/**
@@ -130,9 +136,9 @@ public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 		SortDefault annotatedDefault = parameter.getParameterAnnotation(SortDefault.class);
 
 		if (annotatedDefault != null && annotatedDefaults != null) {
-			throw new IllegalArgumentException(String.format(
-					"Cannot use both @%s and @%s on parameter %s! Move %s into %s to define sorting order!", SORT_DEFAULTS_NAME,
-					SORT_DEFAULT_NAME, parameter.toString(), SORT_DEFAULT_NAME, SORT_DEFAULTS_NAME));
+			throw new IllegalArgumentException(
+					String.format("Cannot use both @%s and @%s on parameter %s! Move %s into %s to define sorting order!",
+							SORT_DEFAULTS_NAME, SORT_DEFAULT_NAME, parameter.toString(), SORT_DEFAULT_NAME, SORT_DEFAULTS_NAME));
 		}
 
 		if (annotatedDefault != null) {

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,16 @@
 Spring Data Commons Changelog
 =============================
 
+Changes in version 1.11.2.RELEASE (2015-12-18)
+----------------------------------------------
+* DATACMNS-797 - Release 1.11.2 (Gosling).
+* DATACMNS-793 - Some inline code formatting broken in reference documentation.
+* DATACMNS-791 - Improve exception message in QueryMethodParameterConversionException and ReflectionRepositoryInvoker.
+* DATACMNS-789 - Fix typo in JavaDoc of Page.
+* DATACMNS-788 - template.mf should use placeholder for Slf4j version.
+* DATACMNS-786 - Typo in example of declaring Jackson repository populator of reference documentation.
+
+
 Changes in version 1.11.1.RELEASE (2015-11-15)
 ----------------------------------------------
 * DATACMNS-784 - Release 1.11.1 (Gosling).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,13 @@
 Spring Data Commons Changelog
 =============================
 
+Changes in version 1.9.4.RELEASE (2015-10-14)
+---------------------------------------------
+* DATACMNS-778 - Backport fix for @javax.transaction.Transactional support.
+* DATACMNS-777 - Release 1.9.4 (Evans).
+* DATACMNS-774 - Tweak Travis build to run the updated build profiles for Evans.
+
+
 Changes in version 1.11.0.RELEASE (2015-09-01)
 ----------------------------------------------
 * DATACMNS-760 - Remove cyclic dependency in querydsl packages.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,20 @@
 Spring Data Commons Changelog
 =============================
 
+Changes in version 1.11.1.RELEASE (2015-11-15)
+----------------------------------------------
+* DATACMNS-784 - Release 1.11.1 (Gosling).
+* DATACMNS-783 - TypeInformation should allow applying the generic context to a raw type.
+* DATACMNS-782 - ProxyProjectionFactory should support primitive attribute conversion in projections out of the box.
+* DATACMNS-779 - Fix JavaDoc of constructor of QuerydslPredicateBuilder.
+* DATACMNS-771 - Typo in exception in BasicPersistentEntity.
+* DATACMNS-769 - Cannot create auto-generated @Async method with pagination.
+* DATACMNS-763 - Custom repository implementation class not working as stated in the reference documentation.
+* DATACMNS-762 - Polish section about dependencies in the reference documentation.
+* DATACMNS-761 - PageableHandlerMethodArgumentResolver reduces page size by one if on-indexed parameters are used.
+* DATACMNS-753 - SortHandlerMethodArgumentResolver fails to fall back to default if empty parameter is given.
+
+
 Changes in version 1.9.4.RELEASE (2015-10-14)
 ---------------------------------------------
 * DATACMNS-778 - Backport fix for @javax.transaction.Transactional support.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Commons 1.11.1
+Spring Data Commons 1.11.2
 Copyright (c) [2010-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Commons 1.11 GA
+Spring Data Commons 1.11.1
 Copyright (c) [2010-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/springframework/data/mapping/PropertyReferenceExceptionUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PropertyReferenceExceptionUnitTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.TypeInformation;
+
+/**
+ * Unit tests for {@link PropertyReferenceException}
+ *
+ * @author Oliver Gierke
+ */
+public class PropertyReferenceExceptionUnitTests {
+
+	static final TypeInformation<Sample> TYPE_INFO = ClassTypeInformation.from(Sample.class);
+	static final List<PropertyPath> NO_PATHS = Collections.emptyList();
+
+	public @Rule ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void rejectsNullPropertyName() {
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("name");
+
+		new PropertyReferenceException(null, TYPE_INFO, NO_PATHS);
+	}
+
+	@Test
+	public void rejectsNullType() {
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Type");
+
+		new PropertyReferenceException("nme", null, NO_PATHS);
+	}
+
+	@Test
+	public void rejectsNullPaths() {
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("paths");
+
+		new PropertyReferenceException("nme", TYPE_INFO, null);
+	}
+
+	/**
+	 * @see DATACMNS-801
+	 */
+	@Test
+	public void exposesPotentialMatch() {
+
+		PropertyReferenceException exception = new PropertyReferenceException("nme", TYPE_INFO, NO_PATHS);
+
+		Collection<String> matches = exception.getPropertyMatches();
+
+		assertThat(matches, hasSize(1));
+		assertThat(matches, hasItem("name"));
+	}
+
+	static class Sample {
+
+		String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
@@ -157,7 +157,7 @@ public class ProxyProjectionFactoryUnitTests {
 
 		List<String> result = factory.getInputProperties(CustomerExcerpt.class);
 
-		assertThat(result, hasSize(4));
+		assertThat(result, hasSize(5));
 		assertThat(result, hasItems("firstname", "address", "shippingAddresses", "picture"));
 	}
 
@@ -220,8 +220,23 @@ public class ProxyProjectionFactoryUnitTests {
 		assertThat(excerpt.getShippingAddresses(), is(arrayWithSize(1)));
 	}
 
+	/**
+	 * @see DATACMNS-782
+	 */
+	@Test
+	public void convertsPrimitiveValues() {
+
+		Customer customer = new Customer();
+		customer.id = 1L;
+
+		CustomerExcerpt excerpt = factory.createProjection(CustomerExcerpt.class, customer);
+
+		assertThat(excerpt.getId(), is(customer.id.toString()));
+	}
+
 	static class Customer {
 
+		public Long id;
 		public String firstname, lastname;
 		public Address address;
 		public byte[] picture;
@@ -234,6 +249,8 @@ public class ProxyProjectionFactoryUnitTests {
 	}
 
 	interface CustomerExcerpt {
+
+		String getId();
 
 		String getFirstname();
 

--- a/src/test/java/org/springframework/data/repository/util/ClassUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/ClassUtilsUnitTests.java
@@ -19,13 +19,16 @@ import static org.junit.Assert.*;
 import static org.springframework.data.repository.util.ClassUtils.*;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 import org.junit.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Unit test for {@link ClassUtils}.
@@ -48,6 +51,17 @@ public class ClassUtilsUnitTests {
 		assertFalse(hasProperty(User.class, "address"));
 	}
 
+	/**
+	 * @see DATACMNS-769
+	 */
+	@Test
+	public void unwrapsWrapperTypesBeforeAssignmentCheck() throws Exception {
+
+		Method method = UserRepository.class.getMethod("findAsync", Pageable.class);
+
+		assertReturnTypeAssignable(method, Page.class);
+	}
+
 	@SuppressWarnings("unused")
 	private class User {
 
@@ -61,6 +75,8 @@ public class ClassUtilsUnitTests {
 
 	static interface UserRepository extends Repository<User, Integer> {
 
+		@Async
+		Future<Page<User>> findAsync(Pageable pageable);
 	}
 
 	interface SomeDao extends Serializable, UserRepository {

--- a/src/test/java/org/springframework/data/util/ClassTypeInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/util/ClassTypeInformationUnitTests.java
@@ -224,8 +224,8 @@ public class ClassTypeInformationUnitTests {
 		assertThat(parameterType.isAssignableFrom(stringInfo), is(true));
 		assertThat(stringInfo.getSuperTypeInformation(GenericInterface.class), is((Object) parameterType));
 		assertThat(parameterType.isAssignableFrom(from(LongImplementation.class)), is(false));
-		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(
-				GenericInterface.class)), is(true));
+		assertThat(parameterType
+				.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(GenericInterface.class)), is(true));
 	}
 
 	@Test
@@ -238,8 +238,8 @@ public class ClassTypeInformationUnitTests {
 
 		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class)), is(false));
 		assertThat(parameterType.isAssignableFrom(from(LongImplementation.class)), is(true));
-		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(
-				GenericInterface.class)), is(false));
+		assertThat(parameterType
+				.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(GenericInterface.class)), is(false));
 	}
 
 	@Test
@@ -252,8 +252,8 @@ public class ClassTypeInformationUnitTests {
 
 		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class)), is(false));
 		assertThat(parameterType.isAssignableFrom(from(LongImplementation.class)), is(true));
-		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(
-				GenericInterface.class)), is(false));
+		assertThat(parameterType
+				.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(GenericInterface.class)), is(false));
 	}
 
 	@Test
@@ -351,6 +351,35 @@ public class ClassTypeInformationUnitTests {
 		TypeInformation<?> leafType = customer.getProperty("intermediate.content.intermediate.content");
 
 		assertThat(leafType.getType(), is((Object) Leaf.class));
+	}
+
+	/**
+	 * @see DATACMNS-783
+	 */
+	@Test
+	public void specializesTypeUsingTypeVariableContext() {
+
+		ClassTypeInformation<Foo> root = ClassTypeInformation.from(Foo.class);
+		TypeInformation<?> property = root.getProperty("abstractBar");
+
+		TypeInformation<?> specialized = property.specialize(ClassTypeInformation.from(Bar.class));
+
+		assertThat(specialized.getType(), is((Object) Bar.class));
+		assertThat(specialized.getProperty("field").getType(), is((Object) Character.class));
+	}
+
+	/**
+	 * @see DATACMNS-783
+	 */
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void usesTargetTypeDirectlyIfNoGenericsAreInvolved() {
+
+		ClassTypeInformation<Foo> root = ClassTypeInformation.from(Foo.class);
+		TypeInformation<?> property = root.getProperty("object");
+
+		ClassTypeInformation<?> from = ClassTypeInformation.from(Bar.class);
+		assertThat(property.specialize(from), is((TypeInformation) from));
 	}
 
 	static class StringMapContainer extends MapContainer<String> {
@@ -527,4 +556,17 @@ public class ClassTypeInformationUnitTests {
 	static class ConcreteInnerIntermediate extends GenericInnerIntermediate<Leaf> {}
 
 	static class Leaf {}
+
+	static class TypeWithAbstractGenericType<T> {
+		AbstractBar<T> abstractBar;
+		Object object;
+	}
+
+	static class Foo extends TypeWithAbstractGenericType<Character> {}
+
+	static abstract class AbstractBar<T> {}
+
+	static class Bar<T> extends AbstractBar<T> {
+		T field;
+	}
 }

--- a/src/test/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverUnitTests.java
@@ -253,6 +253,23 @@ public class PageableHandlerMethodArgumentResolverUnitTests extends PageableDefa
 		assertThat(result.getPageNumber(), is(0));
 	}
 
+	/**
+	 * @see DATACMNS-761
+	 */
+	@Test
+	public void returnsCorrectPageSizeForOneIndexParameters() {
+
+		PageableHandlerMethodArgumentResolver resolver = getResolver();
+		resolver.setOneIndexedParameters(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("size", "10");
+
+		Pageable result = resolver.resolveArgument(supportedMethodParameter, null, new ServletWebRequest(request), null);
+
+		assertThat(result.getPageSize(), is(10));
+	}
+
 	@Override
 	protected PageableHandlerMethodArgumentResolver getResolver() {
 		PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();

--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -34,6 +34,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 
+import java.util.Arrays;
+
 /**
  * Unit tests for {@link SortHandlerMethodArgumentResolver}.
  * 
@@ -184,6 +186,26 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 		request.addParameter("sort", "");
 
 		assertThat(resolveSort(request, PARAMETER), is(new Sort(DESC, "property")));
+	}
+
+	@Test
+	public void sortParamHandlesSortOrderAndIgnoreCase() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "property,DESC,IgnoreCase");
+		request.addParameter("sort", "");
+
+		assertThat(resolveSort(request, PARAMETER), is(new Sort(Arrays.asList(new Order(DESC, "property").ignoreCase()))));
+	}
+
+	@Test
+	public void sortParamHandlesIgnoreCase() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "property,IgnoreCase");
+		request.addParameter("sort", "");
+
+		assertThat(resolveSort(request, PARAMETER), is(new Sort(Arrays.asList(new Order(ASC, "property").ignoreCase()))));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -150,6 +150,21 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 	}
 
 	/**
+	 *
+	 * @see DATACMNS-753
+	 * see also DATACMNS-408
+	 */
+	@Test
+	public void doesNotReturnNullWhenAnnotatedWithSortDefault() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", ""); //valid input
+
+		assertNotNull(resolveSort(request, getParameterOfMethod("simpleDefault")));
+		assertNotNull(resolveSort(request, getParameterOfMethod("containeredDefault")));
+	}
+
+	/**
 	 * @see DATACMNS-408
 	 */
 	@Test

--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,21 +150,6 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 	}
 
 	/**
-	 *
-	 * @see DATACMNS-753
-	 * see also DATACMNS-408
-	 */
-	@Test
-	public void doesNotReturnNullWhenAnnotatedWithSortDefault() throws Exception {
-
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addParameter("sort", ""); //valid input
-
-		assertNotNull(resolveSort(request, getParameterOfMethod("simpleDefault")));
-		assertNotNull(resolveSort(request, getParameterOfMethod("containeredDefault")));
-	}
-
-	/**
 	 * @see DATACMNS-408
 	 */
 	@Test
@@ -211,6 +196,19 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 		request.addParameter("sort", ",");
 
 		assertThat(resolveSort(request, PARAMETER), is(nullValue()));
+	}
+
+	/**
+	 * @see DATACMNS-753, DATACMNS-408
+	 */
+	@Test
+	public void doesNotReturnNullWhenAnnotatedWithSortDefault() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "");
+
+		assertThat(resolveSort(request, getParameterOfMethod("simpleDefault")), is(new Sort("firstname", "lastname")));
+		assertThat(resolveSort(request, getParameterOfMethod("containeredDefault")), is(new Sort("foo", "bar")));
 	}
 
 	private static Sort resolveSort(HttpServletRequest request, MethodParameter parameter) throws Exception {


### PR DESCRIPTION
I've found the need to be able to turn on ```Order#ignoreCase``` when using the sorting parameters from Spring Data REST. This pull request recognizes ```,ignorecase``` when added to the end of a web ```sort``` parameter to turn on this feature. For some examples:

```http://localhost/repository?sort=prop,ignorecase```: Returns all entries in the ```repository``` sorted (asc) by ```prop```, ignoring case.

```http://localhost/repository?sort=prop,desc,ignorecase```: Returns all entries in the ```repository``` sorted descending by ```prop```, ignoring case.

This pull request is backwards compatible when ```,ignorecase``` is not used.

As I mentioned above, I need this in support of Spring Data REST. I don't see why it would break anything else, but I don't have a very deep understanding of the entire Spring Data ecosystem to know for sure. If there are any problems with this pull request or my approach in general I'd be happy to fix them.