### PR TITLE
DATACMNS-853 - Support interface entity types using generated property accessors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.0.BUILD-SNAPSHOT</version>
+	<version>1.13.0.DATACMNS-853-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -876,8 +876,17 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 				} else {
 					// bean.get...
 					mv.visitVarInsn(ALOAD, 2);
-					mv.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(getter.getDeclaringClass()), getter.getName(),
-							String.format("()%s", signatureTypeName(getter.getReturnType())), false);
+
+					int invokeOpCode = INVOKEVIRTUAL;
+					Class<?> declaringClass = getter.getDeclaringClass();
+					boolean interfaceDefinition = declaringClass.isInterface();
+
+					if(interfaceDefinition){
+						invokeOpCode = INVOKEINTERFACE;
+					}
+
+					mv.visitMethodInsn(invokeOpCode, Type.getInternalName(declaringClass), getter.getName(),
+							String.format("()%s", signatureTypeName(getter.getReturnType())), interfaceDefinition);
 					autoboxIfNeeded(getter.getReturnType(), autoboxType(getter.getReturnType()), mv);
 				}
 			} else {
@@ -1051,8 +1060,17 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 					Class<?> parameterType = setter.getParameterTypes()[0];
 					mv.visitTypeInsn(CHECKCAST, Type.getInternalName(autoboxType(parameterType)));
 					autoboxIfNeeded(autoboxType(parameterType), parameterType, mv);
-					mv.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(setter.getDeclaringClass()), setter.getName(),
-							String.format("(%s)V", signatureTypeName(parameterType)), false);
+
+					int invokeOpCode = INVOKEVIRTUAL;
+					Class<?> declaringClass = setter.getDeclaringClass();
+					boolean interfaceDefinition = declaringClass.isInterface();
+
+					if(interfaceDefinition){
+						invokeOpCode = INVOKEINTERFACE;
+					}
+
+					mv.visitMethodInsn(invokeOpCode, Type.getInternalName(setter.getDeclaringClass()), setter.getName(),
+							String.format("(%s)V", signatureTypeName(parameterType)), interfaceDefinition);
 				}
 			} else {
 

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
@@ -43,7 +43,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  *
  * @author Mark Paluch
  * @author Oliver Gierke
- * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+ * @see DATACMNS-809
  */
 @RunWith(Parameterized.class)
 public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
@@ -121,7 +121,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+	 * @see DATACMNS-809
 	 */
 	@Test
 	public void shouldSetAndGetProperty() throws Exception {
@@ -134,7 +134,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+	 * @see DATACMNS-809
 	 */
 	@Test
 	public void shouldUseClassPropertyAccessorFactory() throws Exception {
@@ -158,7 +158,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+	 * @see DATACMNS-809
 	 */
 	@AccessType(Type.FIELD)
 	public static class FieldAccess {
@@ -208,7 +208,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+	 * @see DATACMNS-809
 	 */
 	@AccessType(Type.PROPERTY)
 	@Data

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
@@ -43,7 +43,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  *
  * @author Mark Paluch
  * @author Oliver Gierke
- * @see DATACMNS-809
+ * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
  */
 @RunWith(Parameterized.class)
 public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
@@ -121,7 +121,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see DATACMNS-809
+	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
 	 */
 	@Test
 	public void shouldSetAndGetProperty() throws Exception {
@@ -134,7 +134,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see DATACMNS-809
+	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
 	 */
 	@Test
 	public void shouldUseClassPropertyAccessorFactory() throws Exception {
@@ -158,7 +158,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see DATACMNS-809
+	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
 	 */
 	@AccessType(Type.FIELD)
 	public static class FieldAccess {
@@ -208,7 +208,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	}
 
 	/**
-	 * @see DATACMNS-809
+	 * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
 	 */
 	@AccessType(Type.PROPERTY)
 	@Data

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryEntityTypeTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryEntityTypeTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.mapping.model;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.Serializable;
+
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.context.SampleMappingContext;
+import org.springframework.data.mapping.context.SamplePersistentProperty;
+import org.springframework.data.repository.core.support.PersistentEntityInformation;
+
+/**
+ * Unit tests for {@link ClassGeneratingPropertyAccessorFactory} covering interface
+ * and concrete class entity types.
+ *
+ * @author John Blum
+ * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+ */
+public class ClassGeneratingPropertyAccessorFactoryEntityTypeTests {
+
+	private final SampleMappingContext mappingContext = new SampleMappingContext();
+
+	protected PersistentEntity<Object, SamplePersistentProperty> getPersistentEntity(Object entity) {
+		return getPersistentEntity(entity.getClass());
+	}
+
+	protected PersistentEntity<Object, SamplePersistentProperty> getPersistentEntity(Class<?> entityType) {
+		return mappingContext.getPersistentEntity(entityType);
+	}
+
+	protected PersistentEntityInformation<Object, ?> getPersistentEntityInformation(Object entity) {
+		return new PersistentEntityInformation<Object, Serializable>(getPersistentEntity(entity));
+	}
+
+	protected PersistentEntityInformation<Object, ?> getPersistentEntityInformation(Class<?> entityType) {
+		return new PersistentEntityInformation<Object, Serializable>(getPersistentEntity(entityType));
+	}
+
+	@Test
+	public void getIdentifierOfInterfaceBasedEntity() {
+		PersistentEntityInformation<Object, ?> quickSortEntityInfo =
+			getPersistentEntityInformation(Algorithm.class);
+
+		Algorithm quickSort = new QuickSort();
+
+		assertThat(String.valueOf(quickSortEntityInfo.getId(quickSort)), is(equalTo(quickSort.getName())));
+	}
+
+	@Test
+	public void getIdentifierOfClassBasedEntity() {
+		Person jonDoe = Person.newPerson("JonDoe");
+		PersistentEntityInformation<Object, ?> jonDoeEntityInfo = getPersistentEntityInformation(jonDoe);
+
+		assertThat(String.valueOf(jonDoeEntityInfo.getId(jonDoe)), is(equalTo(jonDoe.getName())));
+	}
+
+	interface Algorithm {
+		@Id String getName();
+	}
+
+	class QuickSort implements Algorithm {
+		@Override
+		public String getName() {
+			return getClass().toString();
+		}
+	}
+
+	static class Person {
+
+		@Id
+		private final String name;
+
+		static Person newPerson(String name) {
+			return new Person(name);
+		}
+
+		Person(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String toString() {
+			return getName();
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryEntityTypeTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryEntityTypeTests.java
@@ -34,7 +34,7 @@ import org.springframework.data.repository.core.support.PersistentEntityInformat
  * and concrete class entity types.
  *
  * @author John Blum
- * @see <a href="https://jira.spring.io/browse/DATACMNS-809">DATACMNS-809</a>
+ * @see DATACMNS-809
  */
 public class ClassGeneratingPropertyAccessorFactoryEntityTypeTests {
 


### PR DESCRIPTION
Property accessors (getter and setter) defined on an interface require a different instruction opcode for invoking methods. We now distinguish whether a property accessor is defined on an interface and use either INVOKEINTERFACE or INVOKEVIRTUAL otherwise.

----

Related tickets: [DATACMNS-853](https://jira.spring.io/browse/DATACMNS-853), [SGF-494](https://jira.spring.io/browse/SGF-494)
Related pull request: #160