### PR TITLE
DATACMNS-874 - Fix Scala Option unwrapping.

### DIFF
--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.repository.util;
 
+import scala.Function0;
 import scala.Option;
+import scala.runtime.AbstractFunction0;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -48,6 +50,7 @@ import com.google.common.base.Optional;
  * </ul>
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @since 1.8
  */
 public abstract class QueryExecutionConverters {
@@ -416,19 +419,27 @@ public abstract class QueryExecutionConverters {
 	 * A {@link Converter} to unwrap a Scala {@link Option} instance.
 	 *
 	 * @author Oliver Gierke
+	 * @author Mark Paluch
 	 * @author 1.13
 	 */
 	private static enum ScalOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
-		/* 
+		private final Function0<Object> alternative = new AbstractFunction0<Object>() {
+			@Override
+			public Option<Object> apply() {
+				return null;
+			}
+		};
+
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
 		 */
 		@Override
 		public Object convert(Object source) {
-			return source instanceof Option ? ((Option<?>) source).orNull(null) : source;
+			return source instanceof Option ? ((Option<?>) source).getOrElse(alternative) : source;
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import com.google.common.base.Optional;
  * Unit tests for {@link QueryExecutionConverters}.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class QueryExecutionConvertersUnitTests {
 
@@ -162,5 +163,13 @@ public class QueryExecutionConvertersUnitTests {
 	@Test
 	public void unwrapsScalaOption() {
 		assertThat(QueryExecutionConverters.unwrap(Option.apply("foo")), is((Object) "foo"));
+	}
+
+	/**
+	 * @see DATACMNS-874
+	 */
+	@Test
+	public void unwrapsEmptyScalaOption() {
+		assertThat(QueryExecutionConverters.unwrap(Option.empty()), is((Object) null));
 	}
 }


### PR DESCRIPTION
We now correctly unwrap empty Scala Options so the unwrapping no longer fails.

----

Related ticket: [DATACMNS-874](https://jira.spring.io/browse/DATACMNS-874)