### PR TITLE
DATACMNS-531 - Add support for a simplified syntax in request parameters

### DIFF
--- a/src/main/java/org/springframework/data/web/SimpleSortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SimpleSortHandlerMethodArgumentResolver.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link HandlerMethodArgumentResolver} to automatically create {@link Sort} instances from request parameters or
+ * {@link SortDefault} annotations.
+ *
+ * @since 1.6
+ * @author Muhammad Ichsan
+ */
+public class SimpleSortHandlerMethodArgumentResolver extends SortHandlerMethodArgumentResolver {
+
+    private static final String DEFAULT_ASCENDING_SIGN = "";
+
+    private String ascendingSign = DEFAULT_ASCENDING_SIGN;
+
+    /**
+     * Configures the sign used to mark ascending property. Defaults to {@code }, so a
+     * qualified sort property would look like {@code qualifier_sort}.
+     *
+     * @param ascendingSign must not be {@literal null} or empty.
+     */
+    public void setAscendingSign(String ascendingSign) {
+        Assert.hasText(ascendingSign);
+        this.ascendingSign = ascendingSign;
+    }
+
+    @Override
+    Sort parseParameterIntoSort(String[] source, String delimiter) {
+        throw new RuntimeException("Not implemented");
+    }
+
+    /**
+     * Parses the given sort expressions into a {@link Sort} instance. The implementation expects the sources to be a
+     * concatenation of Strings using the given delimiter. If the last element can be parsed into a {@link Direction} it's
+     * considered a {@link Direction} and a simple property otherwise.
+     *
+     * @param part will never be {@literal null}.
+     * @param delimiter the delimiter to be used to split up the source elements, will never be {@literal null}.
+     * @return
+     */
+    Sort parseParameterIntoSort(String part, String delimiter) {
+
+        List<Order> allOrders = new ArrayList<Order>();
+
+        if (part != null) {
+            String[] elements = part.split(delimiter);
+
+            for (int i = 0; i < elements.length; i++) {
+                String property = elements[i];
+
+                Direction direction = null;
+                if (property.startsWith("-")) {
+                    property = property.substring(1, property.length());
+                    direction = Direction.DESC;
+                } else if (ascendingSign.isEmpty() || property.startsWith(ascendingSign)) {
+                    property = property.substring(ascendingSign.length(), property.length());
+                    direction = Direction.ASC;
+                }
+
+                if (!StringUtils.hasText(property)) {
+                    continue;
+                }
+
+                if (direction != null) {
+                    allOrders.add(new Order(direction, property));
+                }
+            }
+        }
+
+        return allOrders.isEmpty() ? null : new Sort(allOrders);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.web.method.support.HandlerMethodArgumentResolver#resolveArgument(org.springframework.core.MethodParameter, org.springframework.web.method.support.ModelAndViewContainer, org.springframework.web.context.request.NativeWebRequest, org.springframework.web.bind.support.WebDataBinderFactory)
+     */
+    @Override
+    public Sort resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        String directionParameter = webRequest.getParameter(getSortParameter(parameter));
+
+        // No parameter
+        if (directionParameter == null) {
+            return getDefaultFromAnnotationOrFallback(parameter);
+        }
+
+        // Single empty parameter, e.g "sort="
+        if (!StringUtils.hasText(directionParameter)) {
+            return getDefaultFromAnnotationOrFallback(parameter);
+        }
+
+        return parseParameterIntoSort(directionParameter, propertyDelimiter);
+    }
+
+}

--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
@@ -53,7 +53,7 @@ public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 
 	private Sort fallbackSort = DEFAULT_SORT;
 	private String sortParameter = DEFAULT_PARAMETER;
-	private String propertyDelimiter = DEFAULT_PROPERTY_DELIMITER;
+	protected String propertyDelimiter = DEFAULT_PROPERTY_DELIMITER;
 	private String qualifierDelimiter = DEFAULT_QUALIFIER_DELIMITER;
 
 	/**
@@ -130,7 +130,7 @@ public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 	 * @return the default {@link Sort} instance derived from the parameter annotations or the configured fallback-sort
 	 *         {@link #setFallbackSort(Sort)}.
 	 */
-	private Sort getDefaultFromAnnotationOrFallback(MethodParameter parameter) {
+	protected Sort getDefaultFromAnnotationOrFallback(MethodParameter parameter) {
 
 		SortDefaults annotatedDefaults = parameter.getParameterAnnotation(SortDefaults.class);
 		SortDefault annotatedDefault = parameter.getParameterAnnotation(SortDefault.class);

--- a/src/test/java/org/springframework/data/web/SortDefaultUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortDefaultUnitTests.java
@@ -37,11 +37,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
  */
 public abstract class SortDefaultUnitTests {
 
-	static final String SORT_0 = "username";
-	static final String SORT_1 = "username,asc";
-	static final String[] SORT_2 = new String[] { "username,ASC", "lastname,firstname,DESC" };
-	static final String SORT_3 = "firstname,lastname";
-
 	static final String[] SORT_FIELDS = new String[] { "firstname", "lastname" };
 	static final Direction SORT_DIRECTION = Direction.DESC;
 
@@ -50,23 +45,6 @@ public abstract class SortDefaultUnitTests {
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
 
-	@Test
-	public void parsesSimpleSortStringCorrectly() {
-
-		assertSortStringParsedInto(new Sort(new Order("username")), SORT_1);
-		assertSortStringParsedInto(new Sort(new Order(ASC, "username")), SORT_1);
-		assertSortStringParsedInto(new Sort(new Order(ASC, "username"), //
-				new Order(DESC, "lastname"), new Order(DESC, "firstname")), SORT_2);
-		assertSortStringParsedInto(new Sort("firstname", "lastname"), SORT_3);
-	}
-
-	private static void assertSortStringParsedInto(Sort expected, String... source) {
-
-		SortHandlerMethodArgumentResolver resolver = new SortHandlerMethodArgumentResolver();
-		Sort sort = resolver.parseParameterIntoSort(source, ",");
-
-		assertThat(sort, is(expected));
-	}
 
 	@Test
 	public void supportsSortParameter() {
@@ -120,9 +98,7 @@ public abstract class SortDefaultUnitTests {
 		assertSupportedAndResolvedTo(parameter, reference);
 	}
 
-	protected HandlerMethodArgumentResolver getResolver() {
-		return new SortHandlerMethodArgumentResolver();
-	}
+	protected abstract HandlerMethodArgumentResolver getResolver();
 
 	protected abstract Class<?> getControllerClass();
 


### PR DESCRIPTION
Added new SimpleSortHandlerMethodArgumentResolver as an alternative to SortHandlerMethodArgumentResolver implementation.

This is for simplified sort parameter with sign.

On https://jira.spring.io/browse/DATACMNS-531, you said that you want clear separation. So, I made a separate class for simple sort option. This way, users still can either choose the existing SortHandlerMethodArgumentResolver or the new SimpleSortHandlerMethodArgumentResolver as both classes are there for them to choose.

I pulled out methods in the unit test which are specific to certain implementation. This way SortDefaultUniTests becomes agnostic.
