### PR TITLE
DATACMNS-658 - Add 'ignorecase' ordering option to SortHandlerMethodArgumentResolver

### DIFF
--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -34,6 +34,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 
+import java.util.Arrays;
+
 /**
  * Unit tests for {@link SortHandlerMethodArgumentResolver}.
  * 
@@ -184,6 +186,26 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 		request.addParameter("sort", "");
 
 		assertThat(resolveSort(request, PARAMETER), is(new Sort(DESC, "property")));
+	}
+
+	@Test
+	public void sortParamHandlesSortOrderAndIgnoreCase() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "property,DESC,IgnoreCase");
+		request.addParameter("sort", "");
+
+		assertThat(resolveSort(request, PARAMETER), is(new Sort(Arrays.asList(new Order(DESC, "property").ignoreCase()))));
+	}
+
+	@Test
+	public void sortParamHandlesIgnoreCase() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("sort", "property,IgnoreCase");
+		request.addParameter("sort", "");
+
+		assertThat(resolveSort(request, PARAMETER), is(new Sort(Arrays.asList(new Order(ASC, "property").ignoreCase()))));
 	}
 
 	/**


### PR DESCRIPTION
Updated version of https://github.com/spring-projects/spring-data-commons/pull/151 for the 1.12.x branch.

Please let me know what I can do to get similar functionality in to the next version. I understand that it's unlikely to be merged as-is, but comments on the `sort2` option in the previous pull request would be appreciated.
