### PR TITLE
DATACMNS-902 - Fix attribute name in example showing how to define a custom repository base class

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -732,7 +732,7 @@ A corresponding attribute is available in the XML namespace.
 [source, xml]
 ----
 <repositories base-package="com.acme.repository"
-     repository-base-class="….MyRepositoryImpl" />
+     base-class="….MyRepositoryImpl" />
 ----
 ====
 


### PR DESCRIPTION
DATAJPA-924 - fix error in Example 30 of reference documentation - attribute named repository-base-class changed to base-class