### PR TITLE
DATACMNS-900 - Add equals/hashCode methods for ExampleMatcher utility classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.0.BUILD-SNAPSHOT</version>
+	<version>1.13.0.DATACMNS-900-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/domain/ExampleMatcher.java
+++ b/src/main/java/org/springframework/data/domain/ExampleMatcher.java
@@ -389,6 +389,7 @@ public class ExampleMatcher {
 	 *
 	 * @author Mark Paluch
 	 */
+	@EqualsAndHashCode
 	public static class GenericPropertyMatcher {
 
 		StringMatcher stringMatcher = null;
@@ -686,10 +687,12 @@ public class ExampleMatcher {
 	 * Define specific property handling for a Dot-Path.
 	 *
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 1.12
 	 */
 	@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+	@EqualsAndHashCode
 	public static class PropertySpecifier {
 
 		String path;
@@ -798,8 +801,10 @@ public class ExampleMatcher {
 	 * Define specific property handling for Dot-Paths.
 	 *
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 1.12
 	 */
+	@EqualsAndHashCode
 	public static class PropertySpecifiers {
 
 		private final Map<String, PropertySpecifier> propertySpecifiers = new LinkedHashMap<String, PropertySpecifier>();

--- a/src/test/java/org/springframework/data/domain/ExampleMatcherUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/ExampleMatcherUnitTests.java
@@ -22,8 +22,7 @@ import static org.springframework.data.domain.ExampleMatcher.*;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.data.domain.ExampleMatcher.NullHandler;
-import org.springframework.data.domain.ExampleMatcher.StringMatcher;
+import org.springframework.data.domain.ExampleMatcher.*;
 
 /**
  * Unit test for {@link ExampleMatcher}.
@@ -205,6 +204,47 @@ public class ExampleMatcherUnitTests {
 
 		assertThat(matchingAny().isAnyMatching(), is(true));
 		assertThat(matchingAny().isAllMatching(), is(false));
+	}
+
+	/**
+	 * @see DATACMNS-900
+	 */
+	@Test
+	public void shouldCompareUsingHashCodeAndEquals() throws Exception {
+
+		matcher = matching() //
+				.withIgnorePaths("foo", "bar", "baz") //
+				.withNullHandler(NullHandler.IGNORE) //
+				.withIgnoreCase("ignored-case") //
+				.withMatcher("hello", GenericPropertyMatchers.contains().caseSensitive()) //
+				.withMatcher("world", new MatcherConfigurer<GenericPropertyMatcher>() {
+					@Override
+					public void configureMatcher(GenericPropertyMatcher matcher) {
+						matcher.endsWith();
+					}
+				});
+
+		ExampleMatcher sameAsMatcher = matching() //
+				.withIgnorePaths("foo", "bar", "baz") //
+				.withNullHandler(NullHandler.IGNORE) //
+				.withIgnoreCase("ignored-case") //
+				.withMatcher("hello", GenericPropertyMatchers.contains().caseSensitive()) //
+				.withMatcher("world", new MatcherConfigurer<GenericPropertyMatcher>() {
+					@Override
+					public void configureMatcher(GenericPropertyMatcher matcher) {
+						matcher.endsWith();
+					}
+				});
+
+		ExampleMatcher different = matching() //
+				.withIgnorePaths("foo", "bar", "baz") //
+				.withNullHandler(NullHandler.IGNORE) //
+				.withMatcher("hello", GenericPropertyMatchers.contains().ignoreCase());
+
+		assertThat(matcher.hashCode(), is(sameAsMatcher.hashCode()));
+		assertThat(matcher.hashCode(), is(not(different.hashCode())));
+		assertThat(matcher, is(equalTo(sameAsMatcher)));
+		assertThat(matcher, is(not(equalTo(different))));
 	}
 
 	static class Person {

--- a/src/test/java/org/springframework/data/domain/ExampleUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/ExampleUnitTests.java
@@ -17,9 +17,11 @@ package org.springframework.data.domain;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.data.domain.ExampleMatcher.*;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.data.domain.ExampleMatcher.*;
 
 /**
  * Test for {@link Example}.
@@ -54,8 +56,26 @@ public class ExampleUnitTests {
 	 * @see DATACMNS-810
 	 */
 	@Test
-	public void retunsSampleObjectsClassAsProbeType() {
+	public void returnsSampleObjectsClassAsProbeType() {
 		assertThat(example.getProbeType(), is(equalTo(Person.class)));
+	}
+
+	/**
+	 * @see DATACMNS-900
+	 */
+	@Test
+	public void shouldCompareUsingHashCodeAndEquals() throws Exception {
+
+		Example<Person> example = Example.of(person, matching().withIgnoreCase("firstname"));
+		Example<Person> sameAsExample = Example.of(person, matching().withIgnoreCase("firstname"));
+
+		Example<Person> different = Example.of(person,
+				matching().withMatcher("firstname", GenericPropertyMatchers.contains()));
+
+		assertThat(example.hashCode(), is(sameAsExample.hashCode()));
+		assertThat(example.hashCode(), is(not(different.hashCode())));
+		assertThat(example, is(equalTo(sameAsExample)));
+		assertThat(example, is(not(equalTo(different))));
 	}
 
 	static class Person {


### PR DESCRIPTION
We now provide `equals` and `hashCode` methods for `GenericPropertyMatcher`, `PropertySpecifier` and `PropertySpecifiers`. Equalling `Example` and `ExampleMatcher` instances can be compared using `hashCode` and `equals`.

----

Related ticket: [DATACMNS-900](https://jira.spring.io/browse/DATACMNS-900)