### PR TITLE
DATACMNS-899 - Fix recursion in ParameterizedTypeInformation.getMapValueType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.0.BUILD-SNAPSHOT</version>
+	<version>1.13.0.DATACMNS-899-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/util/ParameterizedTypeInformation.java
+++ b/src/main/java/org/springframework/data/util/ParameterizedTypeInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * class we will have to resolve generic parameters against.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 class ParameterizedTypeInformation<T> extends ParentTypeAwareTypeInformation<T> {
 
@@ -85,7 +86,7 @@ class ParameterizedTypeInformation<T> extends ParentTypeAwareTypeInformation<T> 
 			}
 		}
 
-		return super.getMapValueType();
+		return super.doGetMapValueType();
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/util/ParameterizedTypeUnitTests.java
+++ b/src/test/java/org/springframework/data/util/ParameterizedTypeUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.mockito.runners.MockitoJUnitRunner;
  * Unit tests for {@link ParameterizedTypeInformation}.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ParameterizedTypeUnitTests {
@@ -137,6 +138,19 @@ public class ParameterizedTypeUnitTests {
 		assertThat(valueType.getProperty("value").getType(), is(typeCompatibleWith(Education.class)));
 	}
 
+	/**
+	 * @see DATACMNS-899
+	 */
+	@Test
+	public void returnsNullMapValueTypeForNonMapProperties(){
+
+		TypeInformation<?> valueType = ClassTypeInformation.from(Bar.class).getProperty("param");
+		TypeInformation<?> mapValueType = valueType.getMapValueType();
+
+		assertThat(valueType, instanceOf(ParameterizedTypeInformation.class));
+		assertThat(mapValueType, is(nullValue()));
+	}
+
 	@SuppressWarnings("serial")
 	class Localized<S> extends HashMap<Locale, S> {
 		S value;
@@ -150,6 +164,10 @@ public class ParameterizedTypeUnitTests {
 	class Foo {
 		Localized<String> param;
 		Localized2<String> param2;
+	}
+
+	class Bar {
+		List<String> param;
 	}
 
 	class Parameterized<T> {


### PR DESCRIPTION
Previously, calls to `ParameterizedTypeInformation#getMapValueType` caused an infinite recursion when invoked on a type information that was not a map type. This lead to a `StackOverflowError`.

 We now call the super method `doGetMapValueType()` instead of calling the entry super method `getMapValueType()` and return by that `null` in case the map value type is not resolvable.

----

Related ticket: [DATACMNS-899](https://jira.spring.io/browse/DATACMNS-899)