### PR TITLE
DATACMNS-916 - Fix setter lookup in ClassGeneratingPropertyAccessorFactory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.0.BUILD-SNAPSHOT</version>
+	<version>1.13.0.DATACMNS-916-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 
 import lombok.Data;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -68,7 +69,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	public static List<Object[]> parameters() throws Exception {
 
 		List<Object[]> parameters = new ArrayList<Object[]>();
-		List<Class<?>> types = Arrays.asList(FieldAccess.class, PropertyAccess.class);
+		List<Class<?>> types = Arrays.asList(FieldAccess.class, PropertyAccess.class, PrivateFinalFieldAccess.class, PrivateFinalPropertyAccess.class);
 
 		parameters.addAll(parameters(types, "primitiveInteger", Integer.valueOf(1)));
 		parameters.addAll(parameters(types, "primitiveIntegerArray", new int[] { 1, 2, 3 }));
@@ -113,8 +114,11 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 		List<Object[]> parameters = new ArrayList<Object[]>();
 
 		for (Class<?> type : types) {
+
+			Constructor<?>[] constructors = type.getDeclaredConstructors();
+			constructors[0].setAccessible(true);
 			parameters
-					.add(new Object[] { type.newInstance(), propertyName, value, type.getSimpleName() + "/" + propertyName });
+					.add(new Object[] { constructors[0].newInstance(), propertyName, value, type.getSimpleName() + "/" + propertyName });
 		}
 
 		return parameters;
@@ -213,6 +217,107 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 	@AccessType(Type.PROPERTY)
 	@Data
 	public static class PropertyAccess {
+
+		int primitiveInteger;
+		int primitiveIntegerArray[];
+		Integer boxedInteger;
+		Integer boxedIntegerArray[];
+
+		short primitiveShort;
+		short primitiveShortArray[];
+		Short boxedShort;
+		Short boxedShortArray[];
+
+		byte primitiveByte;
+		byte primitiveByteArray[];
+		Byte boxedByte;
+		Byte boxedByteArray[];
+
+		char primitiveChar;
+		char primitiveCharArray[];
+		Character boxedChar;
+		Character boxedCharArray[];
+
+		boolean primitiveBoolean;
+		boolean primitiveBooleanArray[];
+		Boolean boxedBoolean;
+		Boolean boxedBooleanArray[];
+
+		float primitiveFloat;
+		float primitiveFloatArray[];
+		Float boxedFloat;
+		Float boxedFloatArray[];
+
+		double primitiveDouble;
+		double primitiveDoubleArray[];
+		Double boxedDouble;
+		Double boxedDoubleArray[];
+
+		long primitiveLong;
+		long primitiveLongArray[];
+		Long boxedLong;
+		Long boxedLongArray[];
+
+		String string;
+		String stringArray[];
+	}
+
+	/**
+	 * @see DATACMNS-916
+	 */
+	@AccessType(Type.FIELD)
+	private final static class PrivateFinalFieldAccess {
+
+		int primitiveInteger;
+		int primitiveIntegerArray[];
+		Integer boxedInteger;
+		Integer boxedIntegerArray[];
+
+		short primitiveShort;
+		short primitiveShortArray[];
+		Short boxedShort;
+		Short boxedShortArray[];
+
+		byte primitiveByte;
+		byte primitiveByteArray[];
+		Byte boxedByte;
+		Byte boxedByteArray[];
+
+		char primitiveChar;
+		char primitiveCharArray[];
+		Character boxedChar;
+		Character boxedCharArray[];
+
+		boolean primitiveBoolean;
+		boolean primitiveBooleanArray[];
+		Boolean boxedBoolean;
+		Boolean boxedBooleanArray[];
+
+		float primitiveFloat;
+		float primitiveFloatArray[];
+		Float boxedFloat;
+		Float boxedFloatArray[];
+
+		double primitiveDouble;
+		double primitiveDoubleArray[];
+		Double boxedDouble;
+		Double boxedDoubleArray[];
+
+		long primitiveLong;
+		long primitiveLongArray[];
+		Long boxedLong;
+		Long boxedLongArray[];
+
+		String string;
+		String stringArray[];
+	}
+
+	/**
+	 * @see DATACMNS-916
+	 */
+	@AccessType(Type.PROPERTY)
+	@Data
+	private final static class PrivateFinalPropertyAccess {
 
 		int primitiveInteger;
 		int primitiveIntegerArray[];

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryTests.java
@@ -71,7 +71,7 @@ public class ClassGeneratingPropertyAccessorFactoryTests {
 				"privateProperty", "packageDefaultProperty", "protectedProperty", "publicProperty", "syntheticProperty");
 
 		parameters.addAll(parameters(new InnerPrivateType(), propertyNames, Object.class));
-		parameters.addAll(parameters(new InnerTypeWithPrivateAncesor(), propertyNames, InnerTypeWithPrivateAncesor.class));
+		parameters.addAll(parameters(new InnerTypeWithPrivateAncestor(), propertyNames, InnerTypeWithPrivateAncestor.class));
 		parameters.addAll(parameters(new InnerPackageDefaultType(), propertyNames, InnerPackageDefaultType.class));
 		parameters.addAll(parameters(new InnerProtectedType(), propertyNames, InnerProtectedType.class));
 		parameters.addAll(parameters(new InnerPublicType(), propertyNames, InnerPublicType.class));
@@ -247,7 +247,7 @@ public class ClassGeneratingPropertyAccessorFactoryTests {
 	/**
 	 * @see DATACMNS-809
 	 */
-	public static class InnerTypeWithPrivateAncesor extends InnerPrivateType {
+	public static class InnerTypeWithPrivateAncestor extends InnerPrivateType {
 
 	}
 


### PR DESCRIPTION
Previously, ClassGeneratingPropertyAccessorFactory uses boxed types for primitive type setters. This threw NoSuchMethodException and caused ExceptionInInitializerError as the generated class could not be initialized.

We now use the appropriate argument type to look up setters.

----

Related ticket: [DATACMNS-916](https://jira.spring.io/browse/DATACMNS-916)