### PR TITLE
DATACMNS-918 - Provide interfaces for Pageable and Sort method argument resolvers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.0.BUILD-SNAPSHOT</version>
+	<version>1.13.0.DATACMNS-918-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
@@ -40,7 +40,7 @@ public class HateoasSortHandlerMethodArgumentResolver extends SortHandlerMethodA
 		UriComponentsContributor {
 
 	/**
-	 * Returns the tempalte variables for the sort parameter.
+	 * Returns the template variables for the sort parameter.
 	 * 
 	 * @param parameter must not be {@literal null}.
 	 * @return

--- a/src/main/java/org/springframework/data/web/PageableArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PageableArgumentResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * Argument resolver to extract a {@link Pageable} object from a {@link NativeWebRequest} for a particular
+ * {@link MethodParameter}. A {@link PageableArgumentResolver} can either resolve {@link Pageable} itself or wrap
+ * another {@link PageableArgumentResolver} to post-process {@link Pageable}. {@link Pageable} resolution yields either
+ * in a {@link Pageable} object or {@literal null} if {@link Pageable} cannot be resolved.
+ *
+ * @author Mark Paluch
+ * @since 1.13
+ * @see org.springframework.web.method.support.HandlerMethodArgumentResolver
+ */
+public interface PageableArgumentResolver extends HandlerMethodArgumentResolver {
+
+	/**
+	 * Resolves a {@link Pageable} method parameter into an argument value from a given request.
+	 *
+	 * @param parameter the method parameter to resolve. This parameter must have previously been passed to
+	 *          {@link #supportsParameter} which must have returned {@code true}.
+	 * @param mavContainer the ModelAndViewContainer for the current request
+	 * @param webRequest the current request
+	 * @param binderFactory a factory for creating {@link WebDataBinder} instances
+	 * @return the resolved argument value, or {@code null}
+	 */
+	@Override
+	Pageable resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory);
+}

--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
@@ -39,9 +39,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * @since 1.6
  * @author Oliver Gierke
  * @author Nick Williams
+ * @author Mark Paluch
  */
-public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+public class PageableHandlerMethodArgumentResolver implements PageableArgumentResolver {
 
+	private static final SortHandlerMethodArgumentResolver DEFAULT_SORT_RESOLVER = new SortHandlerMethodArgumentResolver();
 	private static final String INVALID_DEFAULT_PAGE_SIZE = "Invalid default page size configured for method %s! Must not be less than one!";
 
 	private static final String DEFAULT_PAGE_PARAMETER = "page";
@@ -52,7 +54,7 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	static final Pageable DEFAULT_PAGE_REQUEST = new PageRequest(0, 20);
 
 	private Pageable fallbackPageable = DEFAULT_PAGE_REQUEST;
-	private SortHandlerMethodArgumentResolver sortResolver;
+	private SortArgumentResolver sortResolver;
 	private String pageParameterName = DEFAULT_PAGE_PARAMETER;
 	private String sizeParameterName = DEFAULT_SIZE_PARAMETER;
 	private String prefix = DEFAULT_PREFIX;
@@ -64,7 +66,7 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	 * Constructs an instance of this resolved with a default {@link SortHandlerMethodArgumentResolver}.
 	 */
 	public PageableHandlerMethodArgumentResolver() {
-		this(null);
+		this((SortArgumentResolver) null);
 	}
 
 	/**
@@ -73,7 +75,17 @@ public class PageableHandlerMethodArgumentResolver implements HandlerMethodArgum
 	 * @param sortResolver The sort resolver to use
 	 */
 	public PageableHandlerMethodArgumentResolver(SortHandlerMethodArgumentResolver sortResolver) {
-		this.sortResolver = sortResolver == null ? new SortHandlerMethodArgumentResolver() : sortResolver;
+		this((SortArgumentResolver) sortResolver);
+	}
+
+	/**
+	 * Constructs an instance of this resolver with the specified {@link SortArgumentResolver}.
+	 *
+	 * @param sortResolver The sort resolver to use
+	 * @since 1.13
+	 */
+	public PageableHandlerMethodArgumentResolver(SortArgumentResolver sortResolver) {
+		this.sortResolver = sortResolver == null ? DEFAULT_SORT_RESOLVER : sortResolver;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/web/SortArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortArgumentResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * Argument resolver to extract a {@link Sort} object from a {@link NativeWebRequest} for a particular
+ * {@link MethodParameter}. A {@link SortArgumentResolver} can either resolve {@link Sort} itself or wrap another
+ * {@link SortArgumentResolver} to post-process {@link Sort}. {@link Sort} resolution yields either in a {@link Sort}
+ * object or {@literal null} if {@link Sort} cannot be resolved.
+ *
+ * @author Mark Paluch
+ * @since 1.13
+ * @see org.springframework.web.method.support.HandlerMethodArgumentResolver
+ */
+public interface SortArgumentResolver extends HandlerMethodArgumentResolver {
+
+	/**
+	 * Resolves a {@link Sort} method parameter into an argument value from a given request.
+	 * 
+	 * @param parameter the method parameter to resolve. This parameter must have previously been passed to
+	 *          {@link #supportsParameter} which must have returned {@code true}.
+	 * @param mavContainer the ModelAndViewContainer for the current request
+	 * @param webRequest the current request
+	 * @param binderFactory a factory for creating {@link WebDataBinder} instances
+	 * @return the resolved argument value, or {@code null}
+	 */
+	@Override
+	Sort resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory);
+}

--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
@@ -40,8 +40,9 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Nick Williams
+ * @author Mark Paluch
  */
-public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+public class SortHandlerMethodArgumentResolver implements SortArgumentResolver {
 
 	private static final String DEFAULT_PARAMETER = "sort";
 	private static final String DEFAULT_PROPERTY_DELIMITER = ",";
@@ -260,7 +261,7 @@ public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 			builder.add(order.getProperty());
 		}
 
-		return builder == null ? Collections.<String> emptyList() : builder.dumpExpressionIfPresentInto(expressions);
+		return builder == null ? Collections.<String>emptyList() : builder.dumpExpressionIfPresentInto(expressions);
 	}
 
 	/**
@@ -290,7 +291,7 @@ public class SortHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 			builder.add(order.getProperty());
 		}
 
-		return builder == null ? Collections.<String> emptyList() : builder.dumpExpressionIfPresentInto(expressions);
+		return builder == null ? Collections.<String>emptyList() : builder.dumpExpressionIfPresentInto(expressions);
 	}
 
 	/**


### PR DESCRIPTION
We now provide `PageableArgumentResolver` and `SortArgumentResolver` to enable wrapping of actual resolvers and simplify `Pageable` and `Sort` post processing.

---

Related ticket: [DATACMNS-918](https://jira.spring.io/browse/DATACMNS-918)
