### PR TITLE
Added possibility to register custom converters of NullableWrapper

### DIFF
--- a/src/main/java/org/springframework/data/repository/util/NullableWrapperConverter.java
+++ b/src/main/java/org/springframework/data/repository/util/NullableWrapperConverter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.util;
+
+import org.springframework.core.convert.ConversionService;
+
+/**
+ * Defines a {@link NullableWrapper} converter to be used by {@link QueryExecutionConverters}.
+ * {@link java.util.ServiceLoader} pattern can be used to register custom implementations of this interface.
+ *
+ * @author Darek Kaczynski
+ */
+public interface NullableWrapperConverter {
+
+	/**
+	 * Returns the types of wrappers supported by this converter.
+	 *
+	 * @return list of converter types.
+	 */
+	Class<?>[] getWrapperTypes();
+
+	/**
+	 * Returns the wrapped representation of {@code null} value.
+	 *
+	 * @return wrapped {@code null}.
+	 */
+	Object getNullValue();
+
+	/**
+	 * Decides if this converter can unwrap the value.
+	 *
+	 * @return true if unwrapping is possible, false otherwise.
+	 */
+	boolean canUnwrap();
+
+	/**
+	 * Performs wrapping.
+	 *
+	 * @param source the value to wrap.
+	 * @param conversionService {@link ConversionService} to use if needed.
+	 * @return wrapped value.
+	 */
+	Object wrap(Object source, ConversionService conversionService);
+
+	/**
+	 * Performs unwrapping.
+	 *
+	 * @param source wrapped value to unwrap.
+	 * @return unwrapped value.
+	 */
+	Object unwrap(Object source);
+}

--- a/src/test/java/org/springframework/data/repository/util/NullableWrapperToTestOptionalConverter.java
+++ b/src/test/java/org/springframework/data/repository/util/NullableWrapperToTestOptionalConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.util;
+
+import org.springframework.core.convert.ConversionService;
+
+/**
+ * Helper type for unit tests for {@link QueryExecutionConverters}.
+ *
+ * @author Darek Kaczynski
+ */
+public class NullableWrapperToTestOptionalConverter implements NullableWrapperConverter {
+
+	@Override
+	public Class<?>[] getWrapperTypes() {
+		return new Class<?>[]{TestOptional.class};
+	}
+
+	@Override
+	public Object getNullValue() {
+		return TestOptional.nullValue();
+	}
+
+	@Override
+	public boolean canUnwrap() {
+		return true;
+	}
+
+	@Override
+	public Object wrap(Object source, ConversionService conversionService) {
+		return TestOptional.of(source);
+	}
+
+	@Override
+	public Object unwrap(Object source) {
+		return ((TestOptional) source).get();
+	}
+
+	public abstract static class TestOptional {
+
+		public static TestOptional nullValue() {
+			return NullTestOptional.NULL_VALUE;
+		}
+
+		public static TestOptional of(Object wrapped) {
+			return wrapped == null ? nullValue() : new SomeTestOptional(wrapped);
+		}
+
+		public abstract Object get();
+	}
+
+	public static class NullTestOptional extends TestOptional {
+
+		private static final TestOptional NULL_VALUE = new NullTestOptional();
+
+		@Override
+		public Object get() {
+			return null;
+		}
+	}
+
+	public static class SomeTestOptional extends TestOptional {
+
+		private final Object wrapped;
+
+		public SomeTestOptional(Object wrapped) {
+			this.wrapped = wrapped;
+		}
+
+		@Override
+		public Object get() {
+			return wrapped;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
@@ -19,25 +19,25 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
-import scala.Option;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.core.SpringVersion;
 import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.repository.util.NullableWrapperToTestOptionalConverter.TestOptional;
 import org.springframework.data.util.Version;
 import org.springframework.util.concurrent.ListenableFuture;
-
-import com.google.common.base.Optional;
+import scala.Option;
 
 /**
  * Unit tests for {@link QueryExecutionConverters}.
- * 
+ *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Darek Kaczynski
  */
 public class QueryExecutionConvertersUnitTests {
 
@@ -64,6 +64,7 @@ public class QueryExecutionConvertersUnitTests {
 		assertThat(QueryExecutionConverters.supports(Future.class), is(true));
 		assertThat(QueryExecutionConverters.supports(ListenableFuture.class), is(true));
 		assertThat(QueryExecutionConverters.supports(Option.class), is(true));
+		assertThat(QueryExecutionConverters.supports(TestOptional.class), is(true));
 	}
 
 	/**
@@ -85,7 +86,7 @@ public class QueryExecutionConvertersUnitTests {
 	public void turnsNullIntoGuavaOptional() {
 
 		Optional<Object> optional = conversionService.convert(new NullableWrapper(null), Optional.class);
-		assertThat(optional, is(Optional.<Object> absent()));
+		assertThat(optional, is(Optional.<Object>absent()));
 	}
 
 	/**
@@ -97,7 +98,7 @@ public class QueryExecutionConvertersUnitTests {
 
 		java.util.Optional<Object> optional = conversionService.convert(new NullableWrapper(null),
 				java.util.Optional.class);
-		assertThat(optional, is(java.util.Optional.<Object> empty()));
+		assertThat(optional, is(java.util.Optional.<Object>empty()));
 	}
 
 	/**
@@ -154,7 +155,7 @@ public class QueryExecutionConvertersUnitTests {
 	public void turnsNullIntoScalaOptionEmpty() {
 
 		assertThat((Option<Object>) conversionService.convert(new NullableWrapper(null), Option.class),
-				is(Option.<Object> empty()));
+				is(Option.<Object>empty()));
 	}
 
 	/**
@@ -171,5 +172,16 @@ public class QueryExecutionConvertersUnitTests {
 	@Test
 	public void unwrapsEmptyScalaOption() {
 		assertThat(QueryExecutionConverters.unwrap(Option.empty()), is((Object) null));
+	}
+
+	@Test
+	public void turnsNullIntoTestOptional() {
+		TestOptional optional = conversionService.convert(new NullableWrapper(null), TestOptional.class);
+		assertThat(optional, is(TestOptional.nullValue()));
+	}
+
+	@Test
+	public void unwrapsEmptyTestOptional() {
+		assertThat(QueryExecutionConverters.unwrap(TestOptional.nullValue()), is((Object) null));
 	}
 }

--- a/src/test/resources/META-INF/services/org.springframework.data.repository.util.NullableWrapperConverter
+++ b/src/test/resources/META-INF/services/org.springframework.data.repository.util.NullableWrapperConverter
@@ -1,0 +1,1 @@
+org.springframework.data.repository.util.NullableWrapperToTestOptionalConverter


### PR DESCRIPTION
This is a re-write of `QueryExecutionConverters` to allow registration of custom converters for wrapper types. This came from the need to use JavaSlang types as return types of query methods. It was not possible to add support for JavaSlang types directly, as it's not compatible with `1.6` source level. Therefore an extension point was implemented using `ServiceLoader` pattern.