### PR TITLE
DATACMNS-939 - Do not create queries for static interface methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-939-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java
@@ -22,6 +22,7 @@ import static org.springframework.util.ReflectionUtils.*;
 import java.io.Serializable;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Collections;
@@ -185,6 +186,7 @@ class DefaultRepositoryInformation implements RepositoryInformation {
 	 */
 	private boolean isQueryMethodCandidate(Method method) {
 		return !method.isBridge() && !ReflectionUtils.isDefaultMethod(method) //
+				&& !Modifier.isStatic(method.getModifiers()) //
 				&& (isQueryAnnotationPresentOn(method) || !isCustomMethod(method) && !isBaseClassMethod(method));
 	}
 

--- a/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
@@ -50,6 +50,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultRepositoryInformationUnitTests {
@@ -254,6 +255,36 @@ public class DefaultRepositoryInformationUnitTests {
 		assertThat(information.isCustomMethod(customBaseRepositoryMethod), is(true));
 	}
 
+	/**
+	 * @see DATACMNS-939
+	 */
+	@Test
+	public void ignoresStaticMethod() throws SecurityException, NoSuchMethodException {
+
+		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
+		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
+				customImplementation.getClass());
+
+		Method method = FooRepository.class.getMethod("staticMethod");
+
+		assertThat(information.getQueryMethods(), not(hasItem(method)));
+	}
+
+	/**
+	 * @see DATACMNS-939
+	 */
+	@Test
+	public void ignoresDefaultMethod() throws SecurityException, NoSuchMethodException {
+
+		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
+		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
+				customImplementation.getClass());
+
+		Method method = FooRepository.class.getMethod("defaultMethod");
+
+		assertThat(information.getQueryMethods(), not(hasItem(method)));
+	}
+
 	private static Method getMethodFrom(Class<?> type, String name) {
 
 		for (Method method : type.getMethods()) {
@@ -278,6 +309,10 @@ public class DefaultRepositoryInformationUnitTests {
 
 		// Not a redeclared method
 		User findOne(Long primaryKey);
+
+		static void staticMethod() {}
+
+		default void defaultMethod() {}
 	}
 
 	interface FooSuperInterfaceWithGenerics<T> {

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ import org.springframework.util.concurrent.ListenableFuture;
  * Unit tests for {@link RepositoryFactorySupport}.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RepositoryFactorySupportUnitTests {
@@ -325,6 +326,17 @@ public class RepositoryFactorySupportUnitTests {
 		factory.getTargetRepositoryViaReflection(information, entityInformation, "Foo");
 	}
 
+	@Test
+	public void callsStaticMethodOnInterface() {
+
+		ObjectRepository repository = factory.getRepository(ObjectRepository.class, customImplementation);
+
+		assertThat(repository.staticMethodDelegate(), is(equalTo("OK")));
+
+		verifyZeroInteractions(customImplementation);
+		verifyZeroInteractions(backingRepo);
+	}
+
 	private ConvertingRepository prepareConvertingRepository(final Object expectedValue) {
 
 		when(factory.queryOne.execute(Mockito.any(Object[].class))).then(new Answer<Object>() {
@@ -365,6 +377,14 @@ public class RepositoryFactorySupportUnitTests {
 		Object findByFoo();
 
 		Object save(Object entity);
+
+		static String staticMethod() {
+			return "OK";
+		}
+
+		default String staticMethodDelegate() {
+			return staticMethod();
+		}
 	}
 
 	interface ObjectRepositoryCustom {


### PR DESCRIPTION
We now no longer attempt query creation for static methods declared on a repository interface. This allows static method usage inside of repository interfaces.

```
interface PersonRepository extends CrudRepository<Person, String> {

    static String createId() {
        // …
    }

    default Person findPerson() {
        return findOne(createId());
    }
}
```

----

Related ticket: [DATACMNS-939](https://jira.spring.io/browse/DATACMNS-939)
a166083 should be backported to `1.13.x` and `1.12.x` and maybe even `1.11.x`. Tests are contained in a separate commit as they require Java 1.8 language level.