### PR TITLE
DATACMNS-953 - Fix method ExampleMatcher.GenericPropertyMatchers.exact()

### DIFF
--- a/src/main/java/org/springframework/data/domain/ExampleMatcher.java
+++ b/src/main/java/org/springframework/data/domain/ExampleMatcher.java
@@ -608,7 +608,7 @@ public class ExampleMatcher {
 		 * @return
 		 */
 		public static GenericPropertyMatcher exact() {
-			return new GenericPropertyMatcher().startsWith();
+			return new GenericPropertyMatcher().exact();
 		}
 
 		/**

--- a/src/test/java/org/springframework/data/domain/ExampleMatcherUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/ExampleMatcherUnitTests.java
@@ -247,6 +247,27 @@ public class ExampleMatcherUnitTests {
 		assertThat(matcher, is(not(equalTo(different))));
 	}
 
+	/**
+	 * @see DATACMNS-953
+	 */
+	@Test
+	public void setRightStringMatcherInGenericPropertyMatchers() throws Exception {
+
+		GenericPropertyMatcher exactMatcher = GenericPropertyMatchers.exact();
+		GenericPropertyMatcher containsMatcher = GenericPropertyMatchers.contains();
+		GenericPropertyMatcher startsWithMatcher = GenericPropertyMatchers.startsWith();
+		GenericPropertyMatcher endsWithMatcher = GenericPropertyMatchers.endsWith();
+		GenericPropertyMatcher regexMatcher = GenericPropertyMatchers.regex();
+		GenericPropertyMatcher defaultMatcher = GenericPropertyMatchers.storeDefaultMatching();
+
+		assertThat(exactMatcher.stringMatcher, is(equalTo(StringMatcher.EXACT)));
+		assertThat(containsMatcher.stringMatcher, is(equalTo(StringMatcher.CONTAINING)));
+		assertThat(startsWithMatcher.stringMatcher, is(equalTo(StringMatcher.STARTING)));
+		assertThat(endsWithMatcher.stringMatcher, is(equalTo(StringMatcher.ENDING)));
+		assertThat(regexMatcher.stringMatcher, is(equalTo(StringMatcher.REGEX)));
+		assertThat(defaultMatcher.stringMatcher, is(equalTo(StringMatcher.DEFAULT)));
+	}
+
 	static class Person {
 
 		String firstname;


### PR DESCRIPTION
DATACMNS-953 - Fixed exact() method from ExampleMatcher.GenericPropertyMatchers class.
Tests added also.