### PR TITLE
DATACMNS-988 - Provide RxJava 2 Repository interfaces.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-988-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
 	 * entity instance completely.
 	 *
-	 * @param entity
-	 * @return the saved entity
+	 * @param entity must not be {@literal null}.
+	 * @return the saved entity.
 	 */
 	<S extends T> Mono<S> save(S entity);
 
@@ -49,7 +49,7 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Saves all given entities.
 	 *
 	 * @param entities must not be {@literal null}.
-	 * @return the saved entities
+	 * @return the saved entities.
 	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
 	 */
 	<S extends T> Flux<S> save(Iterable<S> entities);
@@ -58,7 +58,7 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Saves all given entities.
 	 *
 	 * @param entityStream must not be {@literal null}.
-	 * @return the saved entities
+	 * @return the saved entities.
 	 * @throws IllegalArgumentException in case the given {@code Publisher} is {@literal null}.
 	 */
 	<S extends T> Flux<S> save(Publisher<S> entityStream);
@@ -67,8 +67,8 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Retrieves an entity by its id.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return the entity with the given id or {@literal null} if none found
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return the entity with the given id or {@link Mono#empty()} if none found.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Mono<T> findOne(ID id);
 
@@ -76,8 +76,8 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Retrieves an entity by its id supplied by a {@link Mono}.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return the entity with the given id or {@literal null} if none found
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return the entity with the given id or {@link Mono#empty()} if none found.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Mono<T> findOne(Mono<ID> id);
 
@@ -85,8 +85,8 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Returns whether an entity with the given id exists.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return true if an entity with the given id exists, {@literal false} otherwise
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Mono<Boolean> exists(ID id);
 
@@ -94,7 +94,7 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Returns whether an entity with the given id exists supplied by a {@link Mono}.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return true if an entity with the given id exists, {@literal false} otherwise
+	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise
 	 * @throws IllegalArgumentException if {@code id} is {@literal null}
 	 */
 	Mono<Boolean> exists(Mono<ID> id);
@@ -102,30 +102,30 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	/**
 	 * Returns all instances of the type.
 	 *
-	 * @return all entities
+	 * @return all entities.
 	 */
 	Flux<T> findAll();
 
 	/**
 	 * Returns all instances of the type with the given IDs.
 	 *
-	 * @param ids
-	 * @return
+	 * @param ids must not be {@literal null}.
+	 * @return the found entities.
 	 */
 	Flux<T> findAll(Iterable<ID> ids);
 
 	/**
 	 * Returns all instances of the type with the given IDs.
 	 *
-	 * @param idStream
-	 * @return
+	 * @param idStream must not be {@literal null}.
+	 * @return the found entities.
 	 */
 	Flux<T> findAll(Publisher<ID> idStream);
 
 	/**
 	 * Returns the number of entities available.
 	 *
-	 * @return the number of entities
+	 * @return the number of entities.
 	 */
 	Mono<Long> count();
 
@@ -133,14 +133,14 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	 * Deletes the entity with the given id.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}
+	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
 	 */
 	Mono<Void> delete(ID id);
 
 	/**
 	 * Deletes a given entity.
 	 *
-	 * @param entity
+	 * @param entity must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
 	 */
 	Mono<Void> delete(T entity);
@@ -148,7 +148,7 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	/**
 	 * Deletes the given entities.
 	 *
-	 * @param entities
+	 * @param entities must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given {@link Iterable} is {@literal null}.
 	 */
 	Mono<Void> delete(Iterable<? extends T> entities);
@@ -156,7 +156,7 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	/**
 	 * Deletes the given entities.
 	 *
-	 * @param entityStream
+	 * @param entityStream must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given {@link Publisher} is {@literal null}.
 	 */
 	Mono<Void> delete(Publisher<? extends T> entityStream);

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
@@ -91,7 +91,7 @@ public interface ReactiveCrudRepository<T, ID extends Serializable> extends Repo
 	Mono<Boolean> exists(ID id);
 
 	/**
-	 * Returns whether an entity with the given id exists supplied by a {@link Mono}.
+	 * Returns whether an entity with the given id, supplied by a {@link Mono}, exists.
 	 *
 	 * @param id must not be {@literal null}.
 	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveSortingRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveSortingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.springframework.data.repository.reactive;
 
 import java.io.Serializable;
 
-import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.NoRepositoryBean;
 
@@ -37,32 +36,11 @@ import reactor.core.publisher.Mono;
 @NoRepositoryBean
 public interface ReactiveSortingRepository<T, ID extends Serializable> extends ReactiveCrudRepository<T, ID> {
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#findAll()
-	 */
-	@Override
-	Flux<T> findAll();
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#findAll(java.lang.Iterable)
-	 */
-	@Override
-	Flux<T> findAll(Iterable<ID> ids);
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#findAll(org.reactivestreams.Publisher)
-	 */
-	@Override
-	Flux<T> findAll(Publisher<ID> idStream);
-
 	/**
 	 * Returns all entities sorted by the given options.
 	 *
-	 * @param sort
-	 * @return all entities sorted by the given options
+	 * @param sort must not be {@literal null}.
+	 * @return all entities sorted by the given options.
 	 */
 	Flux<T> findAll(Sort sort);
 }

--- a/src/main/java/org/springframework/data/repository/reactive/RxJava1CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/RxJava1CrudRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.springframework.data.repository.reactive;
 
 import java.io.Serializable;
 
-import org.reactivestreams.Publisher;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.Repository;
 
@@ -41,8 +40,8 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
 	 * entity instance completely.
 	 *
-	 * @param entity
-	 * @return the saved entity
+	 * @param entity must not be {@literal null}.
+	 * @return the saved entity.
 	 */
 	<S extends T> Single<S> save(S entity);
 
@@ -50,7 +49,7 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Saves all given entities.
 	 *
 	 * @param entities must not be {@literal null}.
-	 * @return the saved entities
+	 * @return the saved entities.
 	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
 	 */
 	<S extends T> Observable<S> save(Iterable<S> entities);
@@ -59,7 +58,7 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Saves all given entities.
 	 *
 	 * @param entityStream must not be {@literal null}.
-	 * @return the saved entities
+	 * @return the saved entities.
 	 * @throws IllegalArgumentException in case the given {@code Publisher} is {@literal null}.
 	 */
 	<S extends T> Observable<S> save(Observable<S> entityStream);
@@ -68,8 +67,8 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Retrieves an entity by its id.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return the entity with the given id or {@literal null} if none found
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return the entity with the given id or {@link Observable#empty()} if none found.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Observable<T> findOne(ID id);
 
@@ -77,8 +76,8 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Retrieves an entity by its id supplied by a {@link Single}.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return the entity with the given id or {@literal null} if none found
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return the entity with the given id or {@link Observable#empty()} if none found.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Observable<T> findOne(Single<ID> id);
 
@@ -86,8 +85,8 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Returns whether an entity with the given id exists.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return true if an entity with the given id exists, {@literal false} otherwise
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Single<Boolean> exists(ID id);
 
@@ -95,38 +94,38 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Returns whether an entity with the given id exists supplied by a {@link Single}.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return true if an entity with the given id exists, {@literal false} otherwise
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
 	Single<Boolean> exists(Single<ID> id);
 
 	/**
 	 * Returns all instances of the type.
 	 *
-	 * @return all entities
+	 * @return all entities.
 	 */
 	Observable<T> findAll();
 
 	/**
 	 * Returns all instances of the type with the given IDs.
 	 *
-	 * @param ids
-	 * @return
+	 * @param ids must not be {@literal null}.
+	 * @return the found entities.
 	 */
 	Observable<T> findAll(Iterable<ID> ids);
 
 	/**
 	 * Returns all instances of the type with the given IDs.
 	 *
-	 * @param idStream
-	 * @return
+	 * @param idStream must not be {@literal null}.
+	 * @return the found entities.
 	 */
 	Observable<T> findAll(Observable<ID> idStream);
 
 	/**
 	 * Returns the number of entities available.
 	 *
-	 * @return the number of entities
+	 * @return the number of entities.
 	 */
 	Single<Long> count();
 
@@ -134,14 +133,14 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	 * Deletes the entity with the given id.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}
+	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
 	 */
 	Completable delete(ID id);
 
 	/**
 	 * Deletes a given entity.
 	 *
-	 * @param entity
+	 * @param entity must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
 	 */
 	Completable delete(T entity);
@@ -149,7 +148,7 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	/**
 	 * Deletes the given entities.
 	 *
-	 * @param entities
+	 * @param entities must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given {@link Iterable} is {@literal null}.
 	 */
 	Completable delete(Iterable<? extends T> entities);
@@ -157,8 +156,8 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	/**
 	 * Deletes the given entities.
 	 *
-	 * @param entityStream
-	 * @throws IllegalArgumentException in case the given {@link Publisher} is {@literal null}.
+	 * @param entityStream must not be {@literal null}.
+	 * @throws IllegalArgumentException in case the given {@link Observable} is {@literal null}.
 	 */
 	Completable delete(Observable<? extends T> entityStream);
 

--- a/src/main/java/org/springframework/data/repository/reactive/RxJava1CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/RxJava1CrudRepository.java
@@ -91,7 +91,7 @@ public interface RxJava1CrudRepository<T, ID extends Serializable> extends Repos
 	Single<Boolean> exists(ID id);
 
 	/**
-	 * Returns whether an entity with the given id exists supplied by a {@link Single}.
+	 * Returns whether an entity with the given id, supplied by a {@link Single}, exists.
 	 *
 	 * @param id must not be {@literal null}.
 	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.

--- a/src/main/java/org/springframework/data/repository/reactive/RxJava1SortingRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/RxJava1SortingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,32 +37,11 @@ import rx.Single;
 @NoRepositoryBean
 public interface RxJava1SortingRepository<T, ID extends Serializable> extends RxJava1CrudRepository<T, ID> {
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#findAll()
-	 */
-	@Override
-	Observable<T> findAll();
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#findAll(java.lang.Iterable)
-	 */
-	@Override
-	Observable<T> findAll(Iterable<ID> ids);
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.reactive.ReactiveCrudRepository#findAll(org.reactivestreams.Publisher)
-	 */
-	@Override
-	Observable<T> findAll(Observable<ID> idStream);
-
 	/**
 	 * Returns all entities sorted by the given options.
 	 *
-	 * @param sort
-	 * @return all entities sorted by the given options
+	 * @param sort must not be {@literal null}.
+	 * @return all entities sorted by the given options.
 	 */
 	Observable<T> findAll(Sort sort);
 }

--- a/src/main/java/org/springframework/data/repository/reactive/RxJava2CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/RxJava2CrudRepository.java
@@ -31,6 +31,7 @@ import org.springframework.data.repository.Repository;
  *
  * @author Mark Paluch
  * @since 2.0
+ * @see Maybe
  * @see Single
  * @see Flowable
  * @see Completable
@@ -93,7 +94,7 @@ public interface RxJava2CrudRepository<T, ID extends Serializable> extends Repos
 	Single<Boolean> exists(ID id);
 
 	/**
-	 * Returns whether an entity with the given id exists supplied by a {@link Single}.
+	 * Returns whether an entity with the given id, supplied by a {@link Single}, exists.
 	 *
 	 * @param id must not be {@literal null}.
 	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.

--- a/src/main/java/org/springframework/data/repository/reactive/RxJava2CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/RxJava2CrudRepository.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.reactive;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+
+import java.io.Serializable;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
+
+/**
+ * Interface for generic CRUD operations on a repository for a specific type. This repository follows reactive paradigms
+ * and uses RxJava 2 types.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see Single
+ * @see Flowable
+ * @see Completable
+ */
+@NoRepositoryBean
+public interface RxJava2CrudRepository<T, ID extends Serializable> extends Repository<T, ID> {
+
+	/**
+	 * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
+	 * entity instance completely.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @return the saved entity.
+	 */
+	<S extends T> Single<S> save(S entity);
+
+	/**
+	 * Saves all given entities.
+	 *
+	 * @param entities must not be {@literal null}.
+	 * @return the saved entities.
+	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
+	 */
+	<S extends T> Flowable<S> save(Iterable<S> entities);
+
+	/**
+	 * Saves all given entities.
+	 *
+	 * @param entityStream must not be {@literal null}.
+	 * @return the saved entities.
+	 * @throws IllegalArgumentException in case the given {@code Publisher} is {@literal null}.
+	 */
+	<S extends T> Flowable<S> save(Flowable<S> entityStream);
+
+	/**
+	 * Retrieves an entity by its id.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return the entity with the given id or {@link Maybe#empty()} if none found.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
+	 */
+	Maybe<T> findOne(ID id);
+
+	/**
+	 * Retrieves an entity by its id supplied by a {@link Single}.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return the entity with the given id or {@link Maybe#empty()} if none found.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
+	 */
+	Maybe<T> findOne(Single<ID> id);
+
+	/**
+	 * Returns whether an entity with the given id exists.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
+	 */
+	Single<Boolean> exists(ID id);
+
+	/**
+	 * Returns whether an entity with the given id exists supplied by a {@link Single}.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
+	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 */
+	Single<Boolean> exists(Single<ID> id);
+
+	/**
+	 * Returns all instances of the type.
+	 *
+	 * @return all entities.
+	 */
+	Flowable<T> findAll();
+
+	/**
+	 * Returns all instances of the type with the given IDs.
+	 *
+	 * @param ids must not be {@literal null}.
+	 * @return the found entities.
+	 */
+	Flowable<T> findAll(Iterable<ID> ids);
+
+	/**
+	 * Returns all instances of the type with the given IDs.
+	 *
+	 * @param idStream must not be {@literal null}.
+	 * @return the found entities.
+	 */
+	Flowable<T> findAll(Flowable<ID> idStream);
+
+	/**
+	 * Returns the number of entities available.
+	 *
+	 * @return the number of entities.
+	 */
+	Single<Long> count();
+
+	/**
+	 * Deletes the entity with the given id.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
+	 */
+	Completable delete(ID id);
+
+	/**
+	 * Deletes a given entity.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
+	 */
+	Completable delete(T entity);
+
+	/**
+	 * Deletes the given entities.
+	 *
+	 * @param entities must not be {@literal null}.
+	 * @throws IllegalArgumentException in case the given {@link Iterable} is {@literal null}.
+	 */
+	Completable delete(Iterable<? extends T> entities);
+
+	/**
+	 * Deletes the given entities.
+	 *
+	 * @param entityStream must not be {@literal null}.
+	 * @throws IllegalArgumentException in case the given {@link Flowable} is {@literal null}.
+	 */
+	Completable delete(Flowable<? extends T> entityStream);
+
+	/**
+	 * Deletes all entities managed by the repository.
+	 */
+	Completable deleteAll();
+}

--- a/src/main/java/org/springframework/data/repository/reactive/RxJava2SortingRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/RxJava2SortingRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.reactive;
+
+import io.reactivex.Flowable;
+
+import java.io.Serializable;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.NoRepositoryBean;
+
+/**
+ * Extension of {@link RxJava2CrudRepository} to provide additional methods to retrieve entities using the sorting
+ * abstraction.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see Sort
+ * @see Flowable
+ * @see RxJava2CrudRepository
+ */
+@NoRepositoryBean
+public interface RxJava2SortingRepository<T, ID extends Serializable> extends RxJava2CrudRepository<T, ID> {
+
+	/**
+	 * Returns all entities sorted by the given options.
+	 *
+	 * @param sort must not be {@literal null}.
+	 * @return all entities sorted by the given options.
+	 */
+	Flowable<T> findAll(Sort sort);
+}

--- a/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -722,7 +722,7 @@ public class ReactiveWrapperConverters {
 
 		@Override
 		public io.reactivex.Observable<?> convert(Publisher<?> source) {
-			return (io.reactivex.Observable<?>) REACTIVE_ADAPTER_REGISTRY.getAdapter(io.reactivex.Single.class)
+			return (io.reactivex.Observable<?>) REACTIVE_ADAPTER_REGISTRY.getAdapter(io.reactivex.Observable.class)
 					.fromPublisher(source);
 		}
 	}

--- a/src/test/java/org/springframework/data/repository/query/ResultProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ResultProcessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.repository.query;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import io.reactivex.Flowable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import rx.Observable;
@@ -48,6 +49,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  * 
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class ResultProcessorUnitTests {
 
@@ -290,6 +292,22 @@ public class ResultProcessorUnitTests {
 		assertThat(content.get(0)).isInstanceOf(SampleProjection.class);
 	}
 
+	@Test // DATACMNS-988
+	@SuppressWarnings("unchecked")
+	public void supportsFlowableProjections() throws Exception {
+
+		Flowable<Sample> samples = Flowable.just(new Sample("Dave", "Matthews"));
+
+		Object result = getProcessor("findFlowableProjection").processResult(samples);
+
+		assertThat(result).isInstanceOf(Flowable.class);
+
+		List<Object> content = ((Flowable<Object>) result).toList().blockingGet();
+
+		assertThat(content).isNotEmpty();
+		assertThat(content.get(0)).isInstanceOf(SampleProjection.class);
+	}
+
 	private static ResultProcessor getProcessor(String methodName, Class<?>... parameters) throws Exception {
 		return getQueryMethod(methodName, parameters).getResultProcessor();
 	}
@@ -336,6 +354,8 @@ public class ResultProcessorUnitTests {
 		Flux<SampleProjection> findFluxProjection();
 
 		Observable<SampleProjection> findObservableProjection();
+
+		Flowable<SampleProjection> findFlowableProjection();
 	}
 
 	static class Sample {

--- a/src/test/java/org/springframework/data/repository/util/ReactiveWrapperConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/ReactiveWrapperConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,6 +173,22 @@ public class ReactiveWrapperConvertersUnitTests {
 
 		io.reactivex.Observable<String> foo = io.reactivex.Observable.just("foo");
 		assertThat(ReactiveWrapperConverters.toWrapper(foo, Publisher.class)).isInstanceOf(Publisher.class);
+	}
+
+	@Test // DATACMNS-988
+	public void toWrapperShouldConvertPublisherToRxJava2Observable() {
+
+		Flux<String> foo = Flux.just("foo");
+		assertThat(ReactiveWrapperConverters.toWrapper(foo, io.reactivex.Observable.class))
+				.isInstanceOf(io.reactivex.Observable.class);
+	}
+
+	@Test // DATACMNS-988
+	public void toWrapperShouldConvertPublisherToRxJava2Flowable() {
+
+		Flux<String> foo = Flux.just("foo");
+		assertThat(ReactiveWrapperConverters.toWrapper(foo, io.reactivex.Flowable.class))
+				.isInstanceOf(io.reactivex.Flowable.class);
 	}
 
 	@Test // DATACMNS-836


### PR DESCRIPTION
Provide RxJava 2 Repository interfaces using back-pressure enabled `Flowable` as default return type for multi-element queries and `Maybe` for queries that can complete without emitting a value.

---

Related ticket: [DATACMNS-988](https://jira.spring.io/browse/DATACMNS-988).