### PR TITLE
DATACMNS-989 - Use exclude filters when scanning for custom repositor…

### DIFF
--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryBean.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryBean.java
@@ -37,6 +37,7 @@ import javax.enterprise.inject.spi.PassivationCapable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.repository.config.CustomRepositoryImplementationDetector;
 import org.springframework.data.repository.config.DefaultRepositoryConfiguration;
 import org.springframework.util.Assert;
@@ -49,6 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Dirk Mahler
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Peter Rietzler
  */
 public abstract class CdiRepositoryBean<T> implements Bean<T>, PassivationCapable {
 
@@ -244,7 +246,7 @@ public abstract class CdiRepositoryBean<T> implements Bean<T>, PassivationCapabl
 
 		String className = getCustomImplementationClassName(repositoryType, cdiRepositoryConfiguration);
 		AbstractBeanDefinition beanDefinition = detector.detectCustomImplementation(className,
-				Collections.singleton(repositoryType.getPackage().getName()));
+				Collections.singleton(repositoryType.getPackage().getName()), Collections.<TypeFilter>emptySet());
 
 		if (beanDefinition == null) {
 			return null;

--- a/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
@@ -42,9 +42,10 @@ import org.springframework.util.StringUtils;
 
 /**
  * Annotation based {@link RepositoryConfigurationSource}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Peter Rietzler
  */
 public class AnnotationRepositoryConfigurationSource extends RepositoryConfigurationSourceSupport {
 
@@ -66,7 +67,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	/**
 	 * Creates a new {@link AnnotationRepositoryConfigurationSource} from the given {@link AnnotationMetadata} and
 	 * annotation.
-	 * 
+	 *
 	 * @param metadata must not be {@literal null}.
 	 * @param annotation must not be {@literal null}.
 	 * @param resourceLoader must not be {@literal null}.
@@ -90,7 +91,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 
 	/**
 	 * Returns whether there's explicit configuration of include- or exclude filters.
-	 * 
+	 *
 	 * @param attributes must not be {@literal null}.
 	 * @return
 	 */
@@ -179,7 +180,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationSourceSupport#getExcludeFilters()
 	 */
 	@Override
-	protected Iterable<TypeFilter> getExcludeFilters() {
+	public Iterable<TypeFilter> getExcludeFilters() {
 		return parseFilters("excludeFilters");
 	}
 
@@ -197,7 +198,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 
 	/**
 	 * Returns the {@link String} attribute with the given name and defaults it to {@literal null} in case it's empty.
-	 * 
+	 *
 	 * @param attributeName
 	 * @return
 	 */
@@ -231,7 +232,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 
 	/**
 	 * Returns the {@link AnnotationAttributes} of the annotation configured.
-	 * 
+	 *
 	 * @return the attributes will never be {@literal null}.
 	 */
 	public AnnotationAttributes getAttributes() {
@@ -240,7 +241,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 
 	/**
 	 * Returns the {@link AnnotationMetadata} for the {@code @Enable} annotation that triggered the configuration.
-	 * 
+	 *
 	 * @return the enableAnnotationMetadata
 	 */
 	public AnnotationMetadata getEnableAnnotationMetadata() {
@@ -249,7 +250,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 
 	/**
 	 * Copy of {@code ComponentScanAnnotationParser#typeFiltersFor}.
-	 * 
+	 *
 	 * @param filterAttributes
 	 * @return
 	 */
@@ -328,7 +329,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	/**
 	 * Safely reads the {@code pattern} attribute from the given {@link AnnotationAttributes} and returns an empty list if
 	 * the attribute is not present.
-	 * 
+	 *
 	 * @param filterAttributes must not be {@literal null}.
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetector.java
+++ b/src/main/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetector.java
@@ -29,6 +29,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.filter.RegexPatternTypeFilter;
+import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -37,6 +38,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Peter Rietzler
  */
 public class CustomRepositoryImplementationDetector {
 
@@ -74,7 +76,7 @@ public class CustomRepositoryImplementationDetector {
 	 * @param basePackages must not be {@literal null}.
 	 * @return the {@code AbstractBeanDefinition} of the custom implementation or {@literal null} if none found
 	 */
-	public AbstractBeanDefinition detectCustomImplementation(String className, Iterable<String> basePackages) {
+	public AbstractBeanDefinition detectCustomImplementation(String className, Iterable<String> basePackages, Iterable<TypeFilter> excludeFilters) {
 
 		Assert.notNull(className, "ClassName must not be null!");
 		Assert.notNull(basePackages, "BasePackages must not be null!");
@@ -89,6 +91,9 @@ public class CustomRepositoryImplementationDetector {
 		provider.setResourcePattern(String.format(CUSTOM_IMPLEMENTATION_RESOURCE_PATTERN, className));
 		provider.setMetadataReaderFactory(metadataReaderFactory);
 		provider.addIncludeFilter(new RegexPatternTypeFilter(pattern));
+		for(TypeFilter excludeFilter : excludeFilters) {
+			provider.addExcludeFilter(excludeFilter);
+		}
 
 		Set<BeanDefinition> definitions = new HashSet<BeanDefinition>();
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -33,6 +33,7 @@ import org.springframework.util.StringUtils;
  * Builder to create {@link BeanDefinitionBuilder} instance to eventually create Spring Data repository instances.
  * 
  * @author Oliver Gierke
+ * @author Peter Rietzler
  */
 class RepositoryBeanDefinitionBuilder {
 
@@ -128,7 +129,7 @@ class RepositoryBeanDefinitionBuilder {
 		}
 
 		AbstractBeanDefinition beanDefinition = implementationDetector
-				.detectCustomImplementation(configuration.getImplementationClassName(), configuration.getBasePackages());
+				.detectCustomImplementation(configuration.getImplementationClassName(), configuration.getBasePackages(), configuration.getConfigurationSource().getExcludeFilters());
 
 		if (null == beanDefinition) {
 			return null;

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Peter Rietzler
  */
 public interface RepositoryConfigurationSource {
 
@@ -108,4 +110,13 @@ public interface RepositoryConfigurationSource {
 	 * @since 1.9
 	 */
 	boolean usesExplicitFilters();
+
+	/**
+	 * Return the {@link TypeFilter}s to define which types to exclude when scanning for repositories or repository implementations.
+	 *
+	 * @return must not be {@literal null}.
+	 */
+	Iterable<TypeFilter> getExcludeFilters();
+
+
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSourceSupport.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSourceSupport.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Peter Rietzler
  */
 public abstract class RepositoryConfigurationSourceSupport implements RepositoryConfigurationSource {
 
@@ -80,7 +81,7 @@ public abstract class RepositoryConfigurationSourceSupport implements Repository
 	 * 
 	 * @return must not be {@literal null}.
 	 */
-	protected Iterable<TypeFilter> getExcludeFilters() {
+	public Iterable<TypeFilter> getExcludeFilters() {
 		return Collections.emptySet();
 	}
 

--- a/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
@@ -34,6 +34,7 @@ import org.w3c.dom.Element;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Peter Rietzler
  */
 public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSourceSupport {
 
@@ -121,7 +122,7 @@ public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSou
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationSourceSupport#getExcludeFilters()
 	 */
 	@Override
-	protected Iterable<TypeFilter> getExcludeFilters() {
+	public Iterable<TypeFilter> getExcludeFilters() {
 		return excludeFilters;
 	}
 

--- a/src/test/java/org/springframework/data/repository/config/MyOtherRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/MyOtherRepository.java
@@ -18,6 +18,6 @@ package org.springframework.data.repository.config;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSourceUnitTests.Person;
 
-interface MyOtherRepository extends Repository<Person, Long> {
+interface MyOtherRepository extends Repository<Person, Long>, MyOtherRepositoryExtensions {
 
 }

--- a/src/test/java/org/springframework/data/repository/config/MyOtherRepositoryExtensions.java
+++ b/src/test/java/org/springframework/data/repository/config/MyOtherRepositoryExtensions.java
@@ -1,0 +1,5 @@
+package org.springframework.data.repository.config;
+
+public interface MyOtherRepositoryExtensions {
+    String getImplementationId();
+}

--- a/src/test/java/org/springframework/data/repository/config/MyOtherRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/MyOtherRepositoryImpl.java
@@ -1,0 +1,8 @@
+package org.springframework.data.repository.config;
+
+public class MyOtherRepositoryImpl implements MyOtherRepositoryExtensions {
+    @Override
+    public String getImplementationId() {
+        return getClass().getName();
+    }
+}

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportIntegrationTests.java
@@ -23,18 +23,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupportUnitTests.DummyConfigurationExtension;
 
 /**
  * Integration tests for {@link RepositoryBeanDefinitionRegistrarSupport}.
  * 
  * @author Oliver Gierke
+ * @author Peter Rietzler
  */
 public class RepositoryBeanDefinitionRegistrarSupportIntegrationTests {
 
 	@Configuration
-	@EnableRepositories
+	@EnableRepositories(excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.excluded\\..*"))
 	static class SampleConfig {
 
 	}
@@ -57,6 +60,11 @@ public class RepositoryBeanDefinitionRegistrarSupportIntegrationTests {
 		if (context != null) {
 			this.context.close();
 		}
+	}
+
+	@Test // DATACMNS-989
+	public void duplicateImplementationsMayBeExcludedViaFilters() {
+		assertThat(context.getBean(MyOtherRepository.class).getImplementationId(), is(MyOtherRepositoryImpl.class.getName()));
 	}
 
 	@Test // DATACMNS-47

--- a/src/test/java/org/springframework/data/repository/config/excluded/MyOtherRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/excluded/MyOtherRepositoryImpl.java
@@ -1,0 +1,10 @@
+package org.springframework.data.repository.config.excluded;
+
+import org.springframework.data.repository.config.MyOtherRepositoryExtensions;
+
+public class MyOtherRepositoryImpl implements MyOtherRepositoryExtensions {
+    @Override
+    public String getImplementationId() {
+        return getClass().getName();
+    }
+}


### PR DESCRIPTION
I've added a new method to `RepositoryConfigurationSource` in order to pass the required arguments. Though, the method is already implemented in `RepositoryConfigurationSourceSupport` it might not be desirable because it must be changed from `protected` to `public`.