### PR TITLE
DATACMNS-995 - Create ReactiveQueryByExampleExecutor allowing reactive query by example.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
+	<version>2.0.0.DATACMNS-995-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/query/QueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryByExampleExecutor.java
@@ -35,7 +35,7 @@ public interface QueryByExampleExecutor<T> {
 	/**
 	 * Returns a single entity matching the given {@link Example} or {@literal null} if none was found.
 	 *
-	 * @param example can be {@literal null}.
+	 * @param example must not be {@literal null}.
 	 * @return a single entity matching the given {@link Example} or {@link Optional#empty()} if none was found.
 	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if the Example yields more than one result.
 	 */
@@ -45,7 +45,7 @@ public interface QueryByExampleExecutor<T> {
 	 * Returns all entities matching the given {@link Example}. In case no match could be found an empty {@link Iterable}
 	 * is returned.
 	 *
-	 * @param example can be {@literal null}.
+	 * @param example must not be {@literal null}.
 	 * @return all entities matching the given {@link Example}.
 	 */
 	<S extends T> Iterable<S> findAll(Example<S> example);
@@ -54,7 +54,7 @@ public interface QueryByExampleExecutor<T> {
 	 * Returns all entities matching the given {@link Example} applying the given {@link Sort}. In case no match could be
 	 * found an empty {@link Iterable} is returned.
 	 *
-	 * @param example can be {@literal null}.
+	 * @param example must not be {@literal null}.
 	 * @param sort the {@link Sort} specification to sort the results by, must not be {@literal null}.
 	 * @return all entities matching the given {@link Example}.
 	 * @since 1.10
@@ -65,7 +65,7 @@ public interface QueryByExampleExecutor<T> {
 	 * Returns a {@link Page} of entities matching the given {@link Example}. In case no match could be found, an empty
 	 * {@link Page} is returned.
 	 *
-	 * @param example can be {@literal null}.
+	 * @param example must not be {@literal null}.
 	 * @param pageable can be {@literal null}.
 	 * @return a {@link Page} of entities matching the given {@link Example}.
 	 */
@@ -74,7 +74,7 @@ public interface QueryByExampleExecutor<T> {
 	/**
 	 * Returns the number of instances matching the given {@link Example}.
 	 *
-	 * @param example the {@link Example} to count instances for, can be {@literal null}.
+	 * @param example the {@link Example} to count instances for. Must not be {@literal null}.
 	 * @return the number of instances matching the {@link Example}.
 	 */
 	<S extends T> long count(Example<S> example);
@@ -82,7 +82,7 @@ public interface QueryByExampleExecutor<T> {
 	/**
 	 * Checks whether the data store contains elements that match the given {@link Example}.
 	 *
-	 * @param example the {@link Example} to use for the existence check, can be {@literal null}.
+	 * @param example the {@link Example} to use for the existence check. Must not be {@literal null}.
 	 * @return {@literal true} if the data store contains elements that match the given {@link Example}.
 	 */
 	<S extends T> boolean exists(Example<S> example);

--- a/src/main/java/org/springframework/data/repository/query/ReactiveQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveQueryByExampleExecutor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Interface to allow execution of Query by Example {@link Example} instances using a reactive infrastructure.
+ *
+ * @param <T>
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public interface ReactiveQueryByExampleExecutor<T> {
+
+	/**
+	 * Returns a single entity matching the given {@link Example} or {@literal null} if none was found.
+	 *
+	 * @param example can be {@literal null}.
+	 * @return a single entity matching the given {@link Example} or {@literal null} if none was found.
+	 */
+	<S extends T> Mono<S> findOne(Example<S> example);
+
+	/**
+	 * Returns all entities matching the given {@link Example}. In case no match could be found an empty {@link Iterable}
+	 * is returned.
+	 *
+	 * @param example can be {@literal null}.
+	 * @return all entities matching the given {@link Example}.
+	 */
+	<S extends T> Flux<S> findAll(Example<S> example);
+
+	/**
+	 * Returns all entities matching the given {@link Example} applying the given {@link Sort}. In case no match could be
+	 * found an empty {@link Iterable} is returned.
+	 *
+	 * @param example can be {@literal null}.
+	 * @param sort the {@link Sort} specification to sort the results by, must not be {@literal null}.
+	 * @return all entities matching the given {@link Example}.
+	 */
+	<S extends T> Flux<S> findAll(Example<S> example, Sort sort);
+
+	/**
+	 * Returns the number of instances matching the given {@link Example}.
+	 *
+	 * @param example the {@link Example} to count instances for, can be {@literal null}.
+	 * @return the number of instances matching the {@link Example}.
+	 */
+	<S extends T> Mono<Long> count(Example<S> example);
+
+	/**
+	 * Checks whether the data store contains elements that match the given {@link Example}.
+	 *
+	 * @param example the {@link Example} to use for the existence check, can be {@literal null}.
+	 * @return {@literal true} if the data store contains elements that match the given {@link Example}.
+	 */
+	<S extends T> Mono<Boolean> exists(Example<S> example);
+}

--- a/src/main/java/org/springframework/data/repository/query/ReactiveQueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveQueryByExampleExecutor.java
@@ -26,32 +26,35 @@ import org.springframework.data.domain.Sort;
  *
  * @param <T>
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 public interface ReactiveQueryByExampleExecutor<T> {
 
 	/**
-	 * Returns a single entity matching the given {@link Example} or {@literal null} if none was found.
+	 * Returns a single entity matching the given {@link Example} or {@link Mono#empty()} if none was found.
 	 *
-	 * @param example can be {@literal null}.
-	 * @return a single entity matching the given {@link Example} or {@literal null} if none was found.
+	 * @param example must not be {@literal null}.
+	 * @return a single entity matching the given {@link Example} or {@link Mono#empty()} if none was found.
+	 * @throws @throws org.springframework.dao.IncorrectResultSizeDataAccessException if the example yields more than one
+	 *           result.
 	 */
 	<S extends T> Mono<S> findOne(Example<S> example);
 
 	/**
-	 * Returns all entities matching the given {@link Example}. In case no match could be found an empty {@link Iterable}
-	 * is returned.
+	 * Returns all entities matching the given {@link Example}. In case no match could be found {@link Flux#empty()} is
+	 * returned.
 	 *
-	 * @param example can be {@literal null}.
+	 * @param example must not be {@literal null}.
 	 * @return all entities matching the given {@link Example}.
 	 */
 	<S extends T> Flux<S> findAll(Example<S> example);
 
 	/**
 	 * Returns all entities matching the given {@link Example} applying the given {@link Sort}. In case no match could be
-	 * found an empty {@link Iterable} is returned.
+	 * found {@link Flux#empty()} is returned.
 	 *
-	 * @param example can be {@literal null}.
+	 * @param example must not be {@literal null}.
 	 * @param sort the {@link Sort} specification to sort the results by, must not be {@literal null}.
 	 * @return all entities matching the given {@link Example}.
 	 */
@@ -60,7 +63,7 @@ public interface ReactiveQueryByExampleExecutor<T> {
 	/**
 	 * Returns the number of instances matching the given {@link Example}.
 	 *
-	 * @param example the {@link Example} to count instances for, can be {@literal null}.
+	 * @param example the {@link Example} to count instances for. Must not be {@literal null}.
 	 * @return the number of instances matching the {@link Example}.
 	 */
 	<S extends T> Mono<Long> count(Example<S> example);
@@ -68,7 +71,7 @@ public interface ReactiveQueryByExampleExecutor<T> {
 	/**
 	 * Checks whether the data store contains elements that match the given {@link Example}.
 	 *
-	 * @param example the {@link Example} to use for the existence check, can be {@literal null}.
+	 * @param example the {@link Example} to use for the existence check. Must not be {@literal null}.
 	 * @return {@literal true} if the data store contains elements that match the given {@link Example}.
 	 */
 	<S extends T> Mono<Boolean> exists(Example<S> example);


### PR DESCRIPTION
Provide a mix-in interface to be used in store modules providing reactive Query by Example query execution.

---

Related ticket: [DATACMNS-995](https://jira.spring.io/browse/DATACMNS-995).