### PR TITLE
DATACMNS-999 - Improve resource extensive error message concatenation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.14.0.BUILD-SNAPSHOT</version>
+	<version>1.14.0.DATACMNS-999-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 by the original author(s).
+ * Copyright 2011-2017 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -420,9 +420,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 	public PersistentPropertyAccessor getPropertyAccessor(Object bean) {
 
 		Assert.notNull(bean, "Target bean must not be null!");
-
-		Assert.isTrue(getType().isInstance(bean),
-				String.format(TYPE_MISMATCH, bean.getClass().getName(), getType().getName()));
+		assertBeanType(bean);
 
 		return propertyAccessorFactory.getPropertyAccessor(this, bean);
 	}
@@ -435,9 +433,16 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 	public IdentifierAccessor getIdentifierAccessor(Object bean) {
 
 		Assert.notNull(bean, "Target bean must not be null!");
-		Assert.isTrue(getType().isInstance(bean), "Target bean is not of type of the persistent entity!");
+		assertBeanType(bean);
 
 		return hasIdProperty() ? new IdPropertyIdentifierAccessor(this, bean) : NullReturningIdentifierAccessor.INSTANCE;
+	}
+
+	private void assertBeanType(Object bean) {
+
+		if (!getType().isInstance(bean)) {
+			throw new IllegalArgumentException(String.format(TYPE_MISMATCH, bean.getClass().getName(), getType().getName()));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Use simple if manually throwing the `IllegalArgumentException` instead of an `Assert`.
Should be replaced with an `Assert` accepting `Supplier` when moving to Spring 5 and Java 8.