### PR TITLE
DATACMNS-1002 - Generic class parameter not being bound to query.

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * Class to abstract a single parameter of a query method. It is held in the context of a {@link Parameters} instance.
  * 
  * @author Oliver Gierke
+ * @author Michael Bragg
  */
 public class Parameter {
 
@@ -76,7 +77,7 @@ public class Parameter {
 	 * @return
 	 */
 	public boolean isBindable() {
-		return !isSpecialParameter();
+		return this.isExplicitlyNamed() || !isSpecialParameter();
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/query/ParametersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ParametersUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * Unit test for {@link Parameters}.
  * 
  * @author Oliver Gierke
+ * @author Michael Bragg
  */
 public class ParametersUnitTests {
 
@@ -131,6 +132,16 @@ public class ParametersUnitTests {
 		assertThat(parameter.isExplicitlyNamed(), is(true));
 	}
 
+	@Test // DATACMNS-1002
+	public void detectsAndBindsDynamicProjectionParameter() throws Exception {
+
+		Parameter parameter = getParametersFor("validWithDynamicBind", Class.class).getBindableParameter(0);
+
+		assertThat(parameter.getName(), is(notNullValue()));
+		assertThat(parameter.isBindable(), is(true));
+		assertThat(parameter.isExplicitlyNamed(), is(true));
+	}
+
 	@Test // DATACMNS-731
 	public void doesNotConsiderParameterExplicitlyNamedEvenIfNamePresent() throws Exception {
 
@@ -192,6 +203,8 @@ public class ParametersUnitTests {
 		User emptyParameters();
 
 		<T> T dynamicBind(Class<T> type, Class<?> one, Class<Object> two);
+
+		<T> T validWithDynamicBind(@Param("type") Class<T> type);
 
 		void methodWithOptional(Optional<String> optional);
 	}


### PR DESCRIPTION
Marks a Parameter as bindable if it is explicitly named.

Related ticket: https://jira.spring.io/browse/DATACMNS-1002