### PR TITLE
DATACMNS-764 - Disambiguate custom repository implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
 							<goal>test-process</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.directory}/generated-sources/test-annotations</outputDirectory>
+							<outputDirectory>${project.build.directory}/generated-test-sources/test-annotations</outputDirectory>
 							<processor>com.querydsl.apt.QuerydslAnnotationProcessor</processor>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-764-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -649,6 +649,37 @@ If you use namespace configuration, the repository infrastructure tries to autod
 
 The first configuration example will try to look up a class `com.acme.repository.UserRepositoryImpl` to act as custom repository implementation, whereas the second example will try to lookup `com.acme.repository.UserRepositoryFooBar`.
 
+===== Resolution of ambiguity
+
+If multiple implementations with matching class names get found in different packages Spring Data uses the bean names to identify the correct on to use.
+
+Given the following two custom implementations for the `UserRepository` introduced above the first implementation will get picked. It's bean name is `userRepositoryImpl` matches that of the repository interface (`userRepository`) plus the postfix `Impl`.
+
+.Resolution of amibiguous implementations
+====
+[source, java]
+----
+package com.acme.impl.one;
+
+class UserRepositoryImpl implements UserRepositoryCustom {
+
+  // Your custom implementation
+}
+----
+[source, java]
+----
+package com.acme.impl.two;
+
+@Component("specialCustomImpl")
+class UserRepositoryImpl implements UserRepositoryCustom {
+
+  // Your custom implementation
+}
+----
+====
+
+If you annotate the `UserRepository` interface with `Component("specialCustom")' the bean name plus `Impl` matches that of the second Repository and it will be picked instead of the first one.
+
 ===== Manual wiring
 
 The approach just shown works well if your custom implementation uses annotation-based configuration and autowiring only, as it will be treated as any other Spring bean. If your custom implementation bean needs special wiring, you simply declare the bean and name it after the conventions just described. The infrastructure will then refer to the manually defined bean definition by name instead of creating one itself.

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -651,9 +651,9 @@ The first configuration example will try to look up a class `com.acme.repository
 
 ===== Resolution of ambiguity
 
-If multiple implementations with matching class names get found in different packages Spring Data uses the bean names to identify the correct on to use.
+If multiple implementations with matching class names get found in different packages Spring Data uses the bean names to identify the correct one to use.
 
-Given the following two custom implementations for the `UserRepository` introduced above the first implementation will get picked. It's bean name is `userRepositoryImpl` matches that of the repository interface (`userRepository`) plus the postfix `Impl`.
+Given the following two custom implementations for the `UserRepository` introduced above the first implementation will get picked. Its bean name is `userRepositoryImpl` matches that of the repository interface (`userRepository`) plus the postfix `Impl`.
 
 .Resolution of amibiguous implementations
 ====

--- a/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
@@ -47,6 +47,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Peter Rietzler
+ * @author Jens Schauder
  */
 public class AnnotationRepositoryConfigurationSource extends RepositoryConfigurationSourceSupport {
 
@@ -77,7 +78,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	public AnnotationRepositoryConfigurationSource(AnnotationMetadata metadata, Class<? extends Annotation> annotation,
 			ResourceLoader resourceLoader, Environment environment) {
 
-		super(environment);
+		super(environment, resourceLoader.getClassLoader());
 
 		Assert.notNull(metadata, "Metadata must not be null!");
 		Assert.notNull(annotation, "Annotation must not be null!");

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -28,8 +28,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of {@link RepositoryConfiguration}.
- * 
+ *
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 @RequiredArgsConstructor
 public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSource>
@@ -104,7 +105,8 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	 * @see org.springframework.data.repository.config.RepositoryConfiguration#getImplementationBeanName()
 	 */
 	public String getImplementationBeanName() {
-		return StringUtils.uncapitalize(getImplementationClassName());
+		return configurationSource.generateBeanName(definition)
+				+ configurationSource.getRepositoryImplementationPostfix().orElse("Impl");
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -124,8 +124,7 @@ class RepositoryBeanDefinitionBuilder {
 			return Optional.of(beanName);
 		}
 
-		Optional<AbstractBeanDefinition> beanDefinition = implementationDetector.detectCustomImplementation(
-				configuration.getImplementationClassName(), configuration.getBasePackages(), configuration.getExcludeFilters());
+		Optional<AbstractBeanDefinition> beanDefinition = implementationDetector.detectCustomImplementation(configuration);
 
 		return beanDefinition.map(it -> {
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.EnvironmentCapable;
 import org.springframework.core.env.StandardEnvironment;
@@ -38,8 +37,9 @@ import org.springframework.util.Assert;
  * providing a configuration format specific {@link RepositoryConfigurationSource} (currently either XML or annotations
  * are supported). The actual registration can then be triggered for different {@link RepositoryConfigurationExtension}
  * s.
- * 
+ *
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 public class RepositoryConfigurationDelegate {
 
@@ -53,7 +53,6 @@ public class RepositoryConfigurationDelegate {
 	private final RepositoryConfigurationSource configurationSource;
 	private final ResourceLoader resourceLoader;
 	private final Environment environment;
-	private final BeanNameGenerator beanNameGenerator;
 	private final boolean isXml;
 	private final boolean inMultiStoreMode;
 
@@ -75,10 +74,6 @@ public class RepositoryConfigurationDelegate {
 				"Configuration source must either be an Xml- or an AnnotationBasedConfigurationSource!");
 		Assert.notNull(resourceLoader, "ResourceLoader must not be null!");
 
-		RepositoryBeanNameGenerator generator = new RepositoryBeanNameGenerator();
-		generator.setBeanClassLoader(resourceLoader.getClassLoader());
-
-		this.beanNameGenerator = generator;
 		this.configurationSource = configurationSource;
 		this.resourceLoader = resourceLoader;
 		this.environment = defaultEnvironment(environment, resourceLoader);
@@ -133,7 +128,7 @@ public class RepositoryConfigurationDelegate {
 			}
 
 			AbstractBeanDefinition beanDefinition = definitionBuilder.getBeanDefinition();
-			String beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
+			String beanName = configurationSource.generateBeanName(beanDefinition);
 
 			if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug(REPOSITORY_REGISTRATION, extension.getModuleName(), beanName,

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Peter Rietzler
+ * @author Jens Schauder
  */
 public interface RepositoryConfigurationSource {
 
@@ -115,4 +116,13 @@ public interface RepositoryConfigurationSource {
 	 * @return must not be {@literal null}.
 	 */
 	Iterable<TypeFilter> getExcludeFilters();
+
+	/**
+	 * Returns a name for the beanDefinition.
+	 *
+	 * @param beanDefinition Must not be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	String generateBeanName(BeanDefinition beanDefinition);
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSourceSupport.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSourceSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,26 +28,32 @@ import org.springframework.util.Assert;
 
 /**
  * Base class to implement {@link RepositoryConfigurationSource}s.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Peter Rietzler
+ * @author Jens Schauder
  */
 public abstract class RepositoryConfigurationSourceSupport implements RepositoryConfigurationSource {
 
 	protected static final String DEFAULT_REPOSITORY_IMPL_POSTFIX = "Impl";
 
 	private final Environment environment;
+	private final RepositoryBeanNameGenerator beanNameGenerator;
 
 	/**
 	 * Creates a new {@link RepositoryConfigurationSourceSupport} with the given environment.
-	 * 
+	 *
 	 * @param environment must not be {@literal null}.
+	 * @param classLoader must not be {@literal null}.
 	 */
-	public RepositoryConfigurationSourceSupport(Environment environment) {
+	public RepositoryConfigurationSourceSupport(Environment environment, ClassLoader classLoader) {
 
 		Assert.notNull(environment, "Environment must not be null!");
+		Assert.notNull(classLoader, "ClassLoader must not be null!");
+
 		this.environment = environment;
+		this.beanNameGenerator = new RepositoryBeanNameGenerator(classLoader);
 	}
 
 	/* 
@@ -78,7 +84,7 @@ public abstract class RepositoryConfigurationSourceSupport implements Repository
 	/**
 	 * Return the {@link TypeFilter}s to define which types to exclude when scanning for repositories. Default
 	 * implementation returns an empty collection.
-	 * 
+	 *
 	 * @return must not be {@literal null}.
 	 */
 	public Iterable<TypeFilter> getExcludeFilters() {
@@ -88,7 +94,7 @@ public abstract class RepositoryConfigurationSourceSupport implements Repository
 	/**
 	 * Return the {@link TypeFilter}s to define which types to include when scanning for repositories. Default
 	 * implementation returns an empty collection.
-	 * 
+	 *
 	 * @return must not be {@literal null}.
 	 */
 	protected Iterable<TypeFilter> getIncludeFilters() {
@@ -98,10 +104,19 @@ public abstract class RepositoryConfigurationSourceSupport implements Repository
 	/**
 	 * Returns whether we should consider nested repositories, i.e. repository interface definitions nested in other
 	 * classes.
-	 * 
+	 *
 	 * @return {@literal true} if the container should look for nested repository interface definitions.
 	 */
 	public boolean shouldConsiderNestedRepositories() {
 		return false;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationSource#getBeanNameGenerator()
+	 */
+	@Override
+	public String generateBeanName(BeanDefinition beanDefinition) {
+		return beanNameGenerator.generateBeanName(beanDefinition);
 	}
 }

--- a/src/main/java/org/springframework/data/repository/config/SelectionSet.java
+++ b/src/main/java/org/springframework/data/repository/config/SelectionSet.java
@@ -51,9 +51,9 @@ class SelectionSet<T> {
 	}
 
 	/**
-	 * Get the result after applying all filters sequentially until a unique result is identified. If no unique result can
-	 * be identified the callback passed in at the constructor gets called and its return value becomes the return value
-	 * of this method.
+	 * If this <code>SelectionSet</code> contains exactly one element it gets returned. If no unique result can
+	 * be identified the fallback function passed in at the constructor gets called and its return value becomes
+	 * the return value of this method.
 	 *
 	 * @return a unique result, or the result of the callback provided in the constructor.
 	 */

--- a/src/main/java/org/springframework/data/repository/config/SelectionSet.java
+++ b/src/main/java/org/springframework/data/repository/config/SelectionSet.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Allows filtering of a collection in order to select a unique element. Once a unique element is found all further
+ * filters are ignored.
+ *
+ * @author Jens Schauder
+ */
+class SelectionSet<T> {
+
+	private final Collection<T> collection;
+	private final Function<Collection<T>, T> fallback;
+
+	/**
+	 * creates a {@link SelectionSet} with a default fallback of {@literal null}, when no element is found and an
+	 * {@link IllegalStateException} when no element is found.
+	 */
+	SelectionSet(Collection<T> collection) {
+		this(collection, defaultFallback());
+	}
+
+	/**
+	 * @param collection The collection from which a unique element will get picked.
+	 * @param fallback Will get called once {@literal #uniqueResult} gets called if no unique result can be determined.
+	 */
+	SelectionSet(Collection<T> collection, Function<Collection<T>, T> fallback) {
+
+		this.collection = collection;
+		this.fallback = fallback;
+	}
+
+	/**
+	 * Get the result after applying all filters sequentially until a unique result is identified. If no unique result can
+	 * be identified the callback passed in at the constructor gets called and its return value becomes the return value
+	 * of this method.
+	 *
+	 * @return a unique result, or the result of the callback provided in the constructor.
+	 */
+	T uniqueResult() {
+		T uniqueResult = findUniqueResult();
+
+		return uniqueResult != null ? uniqueResult : fallback.apply(collection);
+	}
+
+	/**
+	 * Filters the collection with the predicate if there are still more then one elements in the collection.
+	 *
+	 * @param predicate To be used for filtering.
+	 */
+	SelectionSet<T> filterIfNecessary(Predicate<T> predicate) {
+
+		if (findUniqueResult() != null) {
+			return this;
+		}
+
+		List<T> fillteredList = collection.stream().filter(predicate).collect(Collectors.toList());
+		return new SelectionSet<T>(fillteredList, fallback);
+	}
+
+	private static <S> Function<Collection<S>, S> defaultFallback() {
+
+		return c -> {
+			if (c.isEmpty()) {
+				return null;
+			} else {
+				throw new IllegalStateException("More then one element in collection.");
+			}
+		};
+	}
+
+	private T findUniqueResult() {
+		return collection.size() == 1 ? collection.iterator().next() : null;
+	}
+}

--- a/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
@@ -37,6 +37,7 @@ import org.w3c.dom.Element;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Peter Rietzler
+ * @author Jens Schauder
  */
 public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSourceSupport {
 
@@ -63,7 +64,7 @@ public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSou
 	 */
 	public XmlRepositoryConfigurationSource(Element element, ParserContext context, Environment environment) {
 
-		super(environment);
+		super(environment, context.getReaderContext().getBeanClassLoader());
 
 		Assert.notNull(element, "Element must not be null!");
 		Assert.notNull(context, "Context must not be null!");
@@ -128,7 +129,7 @@ public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSou
 		return excludeFilters;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationSourceSupport#getIncludeFilters()
 	 */

--- a/src/test/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetectorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetectorUnitTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * tests {@link CustomRepositoryImplementationDetector}
+ *
+ * @author Jens Schauder
+ */
+public class CustomRepositoryImplementationDetectorUnitTests {
+
+	MetadataReaderFactory metadataFactory = new SimpleMetadataReaderFactory();
+	Environment environment = new MockEnvironment();
+	ResourceLoader resourceLoader = new DefaultResourceLoader();
+	Function<BeanDefinition, String> nameGenerator = mock(Function.class);
+
+	CustomRepositoryImplementationDetector detector = spy(
+			new CustomRepositoryImplementationDetector(metadataFactory, environment, resourceLoader));
+
+	{
+		doReturn("notTheBeanYouAreLookingFor").when(nameGenerator).apply(any(BeanDefinition.class));
+	}
+
+	@Test // DATACMNS-764
+	public void returnsNullWhenNoImplementationFound() {
+
+		doReturn(emptySet()).when(detector).findCandidateBeanDefinitions(anyString(), anyListOf(String.class),
+				anyListOf(TypeFilter.class));
+
+		Optional<AbstractBeanDefinition> beanDefinition = detector.detectCustomImplementation("className", "beanName", emptyList(),
+				emptyList(), nameGenerator);
+
+		assertThat(beanDefinition).isEmpty();
+	}
+
+	@Test // DATACMNS-764
+	public void returnsBeanDefinitionWhenOneImplementationIsFound() {
+
+		AbstractBeanDefinition expectedBeanDefinition = mock(AbstractBeanDefinition.class);
+
+		doReturn(new HashSet<>(singleton(expectedBeanDefinition))).when(detector).findCandidateBeanDefinitions(anyString(),
+				anyListOf(String.class), anyListOf(TypeFilter.class));
+
+		Optional<AbstractBeanDefinition> beanDefinition = detector.detectCustomImplementation("className", "beanName", emptyList(),
+				emptyList(), nameGenerator);
+
+		assertThat(beanDefinition).contains(expectedBeanDefinition);
+	}
+
+	@Test // DATACMNS-764
+	public void returnsBeanDefinitionMatchingByNameWhenMultipleImplementationAreFound() {
+
+		AbstractBeanDefinition wrongBeanDefinition = mock(AbstractBeanDefinition.class);
+		AbstractBeanDefinition expectedBeanDefinition = mock(AbstractBeanDefinition.class);
+
+		doReturn("expected").when(nameGenerator).apply(expectedBeanDefinition);
+
+		doReturn(new HashSet<>(asList(wrongBeanDefinition, expectedBeanDefinition))).when(detector)
+				.findCandidateBeanDefinitions(anyString(), anyListOf(String.class), anyListOf(TypeFilter.class));
+
+		Optional<AbstractBeanDefinition> beanDefinition = detector.detectCustomImplementation("className", "expected", emptyList(),
+				emptyList(), nameGenerator);
+
+		assertThat( beanDefinition).contains(expectedBeanDefinition);
+	}
+
+	@Test(expected = IllegalStateException.class) // DATACMNS-764
+	public void throwsExceptionWhenMultipleImplementationAreFound() {
+
+		AbstractBeanDefinition wrongBeanDefinition = mock(AbstractBeanDefinition.class);
+		AbstractBeanDefinition expectedBeanDefinition = mock(AbstractBeanDefinition.class);
+
+		doReturn("expected").when(nameGenerator).apply(any(BeanDefinition.class));
+
+		doReturn(new HashSet<>(asList(wrongBeanDefinition, expectedBeanDefinition))).when(detector)
+				.findCandidateBeanDefinitions(anyString(), anyListOf(String.class), anyListOf(TypeFilter.class));
+
+		Optional<AbstractBeanDefinition> beanDefinition = detector.detectCustomImplementation("className", "expected", emptyList(),
+				emptyList(), nameGenerator);
+	}
+}

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanNameGeneratorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanNameGeneratorUnitTests.java
@@ -32,30 +32,27 @@ import org.springframework.data.repository.core.support.RepositoryFactoryBeanSup
  * Unit tests for {@link RepositoryBeanNameGenerator}.
  * 
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 public class RepositoryBeanNameGeneratorUnitTests {
 
-	BeanNameGenerator generator;
+	RepositoryBeanNameGenerator generator;
 	BeanDefinitionRegistry registry;
 
 	@Before
 	public void setUp() {
 
-		RepositoryBeanNameGenerator generator = new RepositoryBeanNameGenerator();
-		generator.setBeanClassLoader(Thread.currentThread().getContextClassLoader());
-
-		this.generator = generator;
-		this.registry = new DefaultListableBeanFactory();
+		this.generator = new RepositoryBeanNameGenerator(Thread.currentThread().getContextClassLoader());
 	}
 
 	@Test
 	public void usesPlainClassNameIfNoAnnotationPresent() {
-		assertThat(generator.generateBeanName(getBeanDefinitionFor(MyRepository.class), registry)).isEqualTo("myRepository");
+		assertThat(generator.generateBeanName(getBeanDefinitionFor(MyRepository.class))).isEqualTo("myRepository");
 	}
 
 	@Test
 	public void usesAnnotationValueIfAnnotationPresent() {
-		assertThat(generator.generateBeanName(getBeanDefinitionFor(AnnotatedInterface.class), registry)).isEqualTo("specialName");
+		assertThat(generator.generateBeanName(getBeanDefinitionFor(AnnotatedInterface.class))).isEqualTo("specialName");
 	}
 
 	private BeanDefinition getBeanDefinitionFor(Class<?> repositoryInterface) {

--- a/src/test/java/org/springframework/data/repository/config/SelectionSetUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/SelectionSetUnitTests.java
@@ -1,0 +1,62 @@
+package org.springframework.data.repository.config;
+
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SelectionSet}
+ *
+ * @author Jens Schauder
+ */
+public class SelectionSetUnitTests {
+
+	@Test // DATACMNS-764
+	public void returnsUniqueResult() {
+		assertEquals("single value", new SelectionSet<>(singleton("single value")).uniqueResult());
+	}
+
+	@Test // DATACMNS-764
+	public void emptyCollectionReturnsNull() {
+		assertNull(new SelectionSet<Object>(emptySet()).uniqueResult());
+	}
+
+	@Test(expected = IllegalStateException.class) // DATACMNS-764
+	public void multipleElementsThrowException() {
+		new SelectionSet<>(asList("one", "two")).uniqueResult();
+	}
+
+	@Test(expected = NullPointerException.class) // DATACMNS-764
+	public void throwsCustomExceptionWhenConfigured() {
+
+		new SelectionSet<>(asList("one", "two"), c -> {
+			throw new NullPointerException();
+		}).uniqueResult();
+	}
+
+	@Test // DATACMNS-764
+	public void useseFallbackWhenConfigured() {
+
+		String value = new SelectionSet<>(asList("one", "two"), c -> String.valueOf(c.size())).uniqueResult();
+
+		assertEquals("2", value);
+	}
+
+	@Test // DATACMNS-764
+	public void returnsUniqueResultAfterFilter() {
+
+		SelectionSet<String> selection = new SelectionSet<>(asList("one", "two", "three")).filterIfNecessary(s -> s.contains("w"));
+
+		assertEquals("two", selection.uniqueResult());
+	}
+
+	@Test // DATACMNS-764
+	public void ignoresFilterWhenResultIsAlreadyUnique() {
+
+		SelectionSet<String> selection = new SelectionSet<>(asList("one")).filterIfNecessary(s -> s.contains("w"));
+
+		assertEquals("one", selection.uniqueResult());
+	}
+}

--- a/src/test/java/org/springframework/data/repository/config/SelectionSetUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/SelectionSetUnitTests.java
@@ -37,7 +37,7 @@ public class SelectionSetUnitTests {
 	}
 
 	@Test // DATACMNS-764
-	public void useseFallbackWhenConfigured() {
+	public void usesFallbackWhenConfigured() {
 
 		String value = new SelectionSet<>(asList("one", "two"), c -> String.valueOf(c.size())).uniqueResult();
 


### PR DESCRIPTION
Disambiguates custom implementations of repositories by comparing the bean names of the candidate implementations with the bean name of the repository.

Therefore naming the unwanted implementations or naming the repository interface and the required implementation can be used to break ambiguities.

Also, fixes the path on which test sources get generated. 