### PR TITLE
Add support for providing default querydsl bindings

### DIFF
--- a/src/main/java/org/springframework/data/querydsl/binding/QuerydslBindingsFactory.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/QuerydslBindingsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import com.querydsl.core.types.EntityPath;
  * Factory to create {@link QuerydslBindings} using an {@link EntityPathResolver}.
  * 
  * @author Oliver Gierke
+ * @author Marcel Overdijk
  * @since 1.11
  */
 public class QuerydslBindingsFactory implements ApplicationContextAware {

--- a/src/main/java/org/springframework/data/querydsl/binding/QuerydslBindingsFactory.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/QuerydslBindingsFactory.java
@@ -44,6 +44,8 @@ public class QuerydslBindingsFactory implements ApplicationContextAware {
 	private final EntityPathResolver entityPathResolver;
 	private final Map<TypeInformation<?>, EntityPath<?>> entityPaths;
 
+	private QuerydslBinderCustomizer defaultBindings;
+
 	private AutowireCapableBeanFactory beanFactory;
 	private Repositories repositories;
 
@@ -58,6 +60,20 @@ public class QuerydslBindingsFactory implements ApplicationContextAware {
 
 		this.entityPathResolver = entityPathResolver;
 		this.entityPaths = new ConcurrentReferenceHashMap<TypeInformation<?>, EntityPath<?>>();
+	}
+
+	/**
+	 * Creates a new {@link QuerydslBindingsFactory} using the given {@link EntityPathResolver} and default bindings
+	 * {@link QuerydslBinderCustomizer}.
+	 *
+	 * @param entityPathResolver must not be {@literal null}.
+	 * @param defaultBindings the default bindings {@link QuerydslBinderCustomizer} to apply to each {@link QuerydslBindings}
+	 *                        created by this factory.
+	 */
+	public QuerydslBindingsFactory(EntityPathResolver entityPathResolver, QuerydslBinderCustomizer defaultBindings) {
+		this(entityPathResolver);
+
+		this.defaultBindings = defaultBindings;
 	}
 
 	/* 
@@ -97,6 +113,11 @@ public class QuerydslBindingsFactory implements ApplicationContextAware {
 		EntityPath<?> path = verifyEntityPathPresent(domainType);
 
 		QuerydslBindings bindings = new QuerydslBindings();
+
+		if (defaultBindings != null) {
+			defaultBindings.customize(bindings, path);
+		}
+
 		findCustomizerForDomainType(customizer, domainType.getType()).customize(bindings, path);
 
 		return bindings;


### PR DESCRIPTION
I would like to be able to provide default querydsl bindings for all `@QuerydslPredicate` being used.

You could think about excluding unlisted properties by default or add default behaviour for certain types.

Of course it should still be possible to provide a custom `QuerydslBinderCustomizer` via the `@QuerydslPredicate` but it should also apply the default bindings.

Something like this:

```
public class QuerydslWebConfig extends QuerydslWebConfiguration {

    @Bean
    public QuerydslBindingsFactory querydslBindingsFactory() {
        return new QuerydslBindingsFactory(SimpleEntityPathResolver.INSTANCE, defaultBindings());
    }

    public QuerydslBinderCustomizer<?> defaultBindings() {
        return new QuerydslBinderCustomizer<?>() {
            
            @Override
            public void customize(final QuerydslBindings bindings, final EntityPath root) {
                bindings.excludeUnlistedProperties(true);
                bindings.bind(String.class).first((StringPath path, String value) -> {
                    // default logic for String type.
                });
            }
        };
    }
}

```

https://jira.spring.io/browse/DATACMNS-1022