### PR TITLE
DATACMNS-531 - More concise sort syntax for sort request parameters.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-531-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
@@ -232,13 +232,32 @@ public class SortHandlerMethodArgumentResolver implements SortArgumentResolver {
 		return allOrders.isEmpty() ? Sort.unsorted() : Sort.by(allOrders);
 	}
 
+	/**
+	 * Return an {@link Order} for the given {@code property}.
+	 * 
+	 * If the given {@code property} is prefixed with {@code '+'} or {@code '-'} 
+	 * the {@link Direction} will resolve to{@value Direction#ASC} or {@link Direction#DESC} 
+	 * effectively ignoring the provided {@code direction}.  
+	 *  
+	 * @param property
+	 * @param direction
+	 * @return
+	 */
 	private static Optional<Order> toOrder(String property, Optional<Direction> direction) {
 
 		if (!StringUtils.hasText(property)) {
 			return Optional.empty();
 		}
-
-		return Optional.of(direction.map(it -> new Order(it, property)).orElseGet(() -> new Order(property)));
+		
+		String trimmed = property.trim();
+		switch (trimmed.charAt(0)) {
+		case '+':
+			return Optional.of(new Order(Direction.ASC, trimmed.substring(1)));
+		case '-':
+			return Optional.of(new Order(Direction.DESC, trimmed.substring(1)));
+		default:
+			return Optional.of(direction.map(it -> new Order(it, trimmed)).orElseGet(() -> new Order(trimmed)));
+		}
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/web/SortDefaultUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortDefaultUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
  * 
  * @since 1.6
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public abstract class SortDefaultUnitTests {
 
@@ -41,6 +42,14 @@ public abstract class SortDefaultUnitTests {
 	static final String[] SORT_2 = new String[] { "username,ASC", "lastname,firstname,DESC" };
 	static final String SORT_3 = "firstname,lastname";
 
+	static final String SORT_1_COMPACT_ASC = "+username";
+	static final String SORT_1_COMPACT_DESC = "-username";
+	static final String SORT_2_COMPACT_DESC_ASC = "-firstname,+lastname";
+	static final String SORT_2_COMPACT_DEFAULT_AT_END = "-firstname,lastname";
+	static final String SORT_2_COMPACT_DEFAULT_AT_START = "firstname,-lastname";
+	static final String SORT_2_COMPACT_DEFAULT_SPACES = "   firstname    ,    -lastname   ";
+	static final String SORT_3_COMPACT_MIXED = "-field1,+field2,field3,DESC";
+	
 	static final String[] SORT_FIELDS = new String[] { "firstname", "lastname" };
 	static final Direction SORT_DIRECTION = Direction.DESC;
 
@@ -56,6 +65,23 @@ public abstract class SortDefaultUnitTests {
 		assertSortStringParsedInto(Sort.by(new Order(ASC, "username"), //
 				new Order(DESC, "lastname"), new Order(DESC, "firstname")), SORT_2);
 		assertSortStringParsedInto(Sort.by("firstname", "lastname"), SORT_3);
+	}
+	
+	@Test //DATACMNS-531 
+	public void parsesCompactSortStringCorrectly() {
+
+		assertSortStringParsedInto(Sort.by(new Order(ASC, "username")), SORT_1_COMPACT_ASC);
+		assertSortStringParsedInto(Sort.by(new Order(DESC, "username")), SORT_1_COMPACT_DESC);
+		assertSortStringParsedInto(Sort.by(new Order(DESC, "firstname"), // 
+				new Order(ASC, "lastname")), SORT_2_COMPACT_DESC_ASC);
+		assertSortStringParsedInto(Sort.by(new Order(DESC, "firstname"), //
+				new Order(ASC, "lastname")), SORT_2_COMPACT_DEFAULT_AT_END);
+		assertSortStringParsedInto(Sort.by(new Order(ASC, "firstname"), // 
+				new Order(DESC, "lastname")), SORT_2_COMPACT_DEFAULT_AT_START);
+		assertSortStringParsedInto(Sort.by(new Order(ASC, "firstname"), // 
+				new Order(DESC, "lastname")), SORT_2_COMPACT_DEFAULT_SPACES);
+		assertSortStringParsedInto(Sort.by(new Order(DESC, "field1"), // 
+				new Order(ASC, "field2"), new Order(DESC, "field3")), SORT_3_COMPACT_MIXED);
 	}
 
 	private static void assertSortStringParsedInto(Sort expected, String... source) {


### PR DESCRIPTION
Sort orders provided via `sort` request parameter can now be defined
in a more concise way by prefixing a property with `+` and `-` which
marks it to be sorted in `ASC` or `DESC` order respectively.
If a property is not prefixed the default order resolution applies.

A parameter like `sort=-field1,+field2,field3,DESC`
yields the sort order `field1 DESC, field2 ASC, field3 DESC`
