### PR TITLE
DATACMNS-1034 - Introduced API to easily register bidirectional, type-based converters.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1034-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/ConverterBuilder.java
+++ b/src/main/java/org/springframework/data/convert/ConverterBuilder.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
+import org.springframework.util.Assert;
+
+/**
+ * API to easily set up {@link GenericConverter} instances using Java 8 lambdas, mostly in bidirectional fashion for
+ * easy registration as custom type converters of the SPring Data mapping subsystem. The registration starts either with
+ * the definition of a reading or writing converter that can then be completed
+ * 
+ * @author Oliver Gierke
+ * @since 2.0
+ * @see #reading(Class, Class, Function)
+ * @see #writing(Class, Class, Function)
+ * @soundtrack John Mayer - Moving On and Getting Over (The Search for Everything)
+ */
+public interface ConverterBuilder {
+
+	/**
+	 * Creates a new {@link ReadingConverterBuilder} to produce a converter to read values of the given source (the store
+	 * type) into the given target (the domain type).
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param target must not be {@literal null}.
+	 * @param function must not be {@literal null}.
+	 * @return
+	 */
+	static <S, T> ReadingConverterBuilder<T, S> reading(Class<T> source, Class<S> target,
+			Function<? super T, ? extends S> function) {
+
+		Assert.notNull(source, "Source type must not be null!");
+		Assert.notNull(target, "Target type must not be null!");
+		Assert.notNull(function, "Conversion function must not be null!");
+
+		return new DefaultConverterBuilder<>(new ConvertiblePair(source, target), Optional.empty(), Optional.of(function));
+	}
+
+	/**
+	 * Creates a new {@link WritingConverterBuilder} to produce a converter to write values of the given source (the
+	 * domain type type) into the given target (the store type).
+	 * 
+	 * @param source must not be {@literal null}.
+	 * @param target must not be {@literal null}.
+	 * @param function must not be {@literal null}.
+	 * @return
+	 */
+	static <S, T> WritingConverterBuilder<S, T> writing(Class<S> source, Class<T> target,
+			Function<? super S, ? extends T> function) {
+
+		Assert.notNull(source, "Source type must not be null!");
+		Assert.notNull(target, "Target type must not be null!");
+		Assert.notNull(function, "Conversion function must not be null!");
+
+		return new DefaultConverterBuilder<>(new ConvertiblePair(target, source), Optional.of(function), Optional.empty());
+	}
+
+	/**
+	 * Returns all {@link GenericConverter} instances to be registered for the current {@link ConverterBuilder}.
+	 * 
+	 * @return
+	 */
+	Set<GenericConverter> getConverters();
+
+	/**
+	 * Exposes a writing converter.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.0
+	 */
+	interface WritingConverterAware {
+
+		/**
+		 * Returns the writing converter already created.
+		 * 
+		 * @return
+		 */
+		GenericConverter getWritingConverter();
+	}
+
+	/**
+	 * Exposes a reading converter.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.0
+	 */
+	interface ReadingConverterAware {
+
+		/**
+		 * Returns the reading converter already created.
+		 * 
+		 * @return
+		 */
+		GenericConverter getReadingConverter();
+	}
+
+	/**
+	 * Interface to represent an intermediate setup step of {@link ConverterAware} defining a reading converter first.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.0
+	 */
+	interface ReadingConverterBuilder<T, S> extends ConverterBuilder, ReadingConverterAware {
+
+		/**
+		 * Creates a new {@link ConverterAware} by registering the given {@link Function} to add a write converter.
+		 * 
+		 * @param function must not be {@literal null}.
+		 * @return
+		 */
+		ConverterAware andWriting(Function<? super S, ? extends T> function);
+	}
+
+	/**
+	 * Interface to represent an intermediate setup step of {@link ConverterAware} defining a writing converter first.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.0
+	 */
+	interface WritingConverterBuilder<S, T> extends ConverterBuilder, WritingConverterAware {
+
+		/**
+		 * Creates a new {@link ConverterAware} by registering the given {@link Function} to add a write converter.
+		 * 
+		 * @param function must not be {@literal null}.
+		 * @return
+		 */
+		ConverterAware andReading(Function<? super T, ? extends S> function);
+	}
+
+	/**
+	 * A {@link ConverterBuilder} ware of both a reading and writing converter.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.0
+	 */
+	interface ConverterAware extends ConverterBuilder, ReadingConverterAware, WritingConverterAware {}
+}

--- a/src/main/java/org/springframework/data/convert/ConverterBuilder.java
+++ b/src/main/java/org/springframework/data/convert/ConverterBuilder.java
@@ -87,7 +87,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	interface WritingConverterAware {
+	public interface WritingConverterAware {
 
 		/**
 		 * Returns the writing converter already created.
@@ -103,7 +103,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	interface ReadingConverterAware {
+	public interface ReadingConverterAware {
 
 		/**
 		 * Returns the reading converter already created.
@@ -119,7 +119,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	interface ReadingConverterBuilder<T, S> extends ConverterBuilder, ReadingConverterAware {
+	public interface ReadingConverterBuilder<T, S> extends ConverterBuilder, ReadingConverterAware {
 
 		/**
 		 * Creates a new {@link ConverterAware} by registering the given {@link Function} to add a write converter.
@@ -136,7 +136,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	interface WritingConverterBuilder<S, T> extends ConverterBuilder, WritingConverterAware {
+	public interface WritingConverterBuilder<S, T> extends ConverterBuilder, WritingConverterAware {
 
 		/**
 		 * Creates a new {@link ConverterAware} by registering the given {@link Function} to add a write converter.
@@ -153,5 +153,5 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	interface ConverterAware extends ConverterBuilder, ReadingConverterAware, WritingConverterAware {}
+	public interface ConverterAware extends ConverterBuilder, ReadingConverterAware, WritingConverterAware {}
 }

--- a/src/main/java/org/springframework/data/convert/ConverterBuilder.java
+++ b/src/main/java/org/springframework/data/convert/ConverterBuilder.java
@@ -25,8 +25,8 @@ import org.springframework.util.Assert;
 
 /**
  * API to easily set up {@link GenericConverter} instances using Java 8 lambdas, mostly in bidirectional fashion for
- * easy registration as custom type converters of the SPring Data mapping subsystem. The registration starts either with
- * the definition of a reading or writing converter that can then be completed
+ * easy registration as custom type converters of the Spring Data mapping subsystem. The registration starts either with
+ * the definition of a reading or writing converter that can then be completed.
  * 
  * @author Oliver Gierke
  * @since 2.0
@@ -57,7 +57,7 @@ public interface ConverterBuilder {
 
 	/**
 	 * Creates a new {@link WritingConverterBuilder} to produce a converter to write values of the given source (the
-	 * domain type type) into the given target (the store type).
+	 * domain type) into the given target (the store type).
 	 * 
 	 * @param source must not be {@literal null}.
 	 * @param target must not be {@literal null}.
@@ -87,7 +87,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	public interface WritingConverterAware {
+	interface WritingConverterAware {
 
 		/**
 		 * Returns the writing converter already created.
@@ -103,7 +103,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	public interface ReadingConverterAware {
+	interface ReadingConverterAware {
 
 		/**
 		 * Returns the reading converter already created.
@@ -119,7 +119,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	public interface ReadingConverterBuilder<T, S> extends ConverterBuilder, ReadingConverterAware {
+	interface ReadingConverterBuilder<T, S> extends ConverterBuilder, ReadingConverterAware {
 
 		/**
 		 * Creates a new {@link ConverterAware} by registering the given {@link Function} to add a write converter.
@@ -136,7 +136,7 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	public interface WritingConverterBuilder<S, T> extends ConverterBuilder, WritingConverterAware {
+	interface WritingConverterBuilder<S, T> extends ConverterBuilder, WritingConverterAware {
 
 		/**
 		 * Creates a new {@link ConverterAware} by registering the given {@link Function} to add a write converter.
@@ -153,5 +153,5 @@ public interface ConverterBuilder {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	public interface ConverterAware extends ConverterBuilder, ReadingConverterAware, WritingConverterAware {}
+	interface ConverterAware extends ConverterBuilder, ReadingConverterAware, WritingConverterAware {}
 }

--- a/src/main/java/org/springframework/data/convert/ConverterBuilder.java
+++ b/src/main/java/org/springframework/data/convert/ConverterBuilder.java
@@ -45,8 +45,8 @@ public interface ConverterBuilder {
 	 * @param function must not be {@literal null}.
 	 * @return
 	 */
-	static <S, T> ReadingConverterBuilder<T, S> reading(Class<T> source, Class<S> target,
-			Function<? super T, ? extends S> function) {
+	static <S, T> ReadingConverterBuilder<S, T> reading(Class<S> source, Class<T> target,
+			Function<? super S, ? extends T> function) {
 
 		Assert.notNull(source, "Source type must not be null!");
 		Assert.notNull(target, "Target type must not be null!");
@@ -148,7 +148,7 @@ public interface ConverterBuilder {
 	}
 
 	/**
-	 * A {@link ConverterBuilder} ware of both a reading and writing converter.
+	 * A {@link ConverterBuilder} aware of both a reading and writing converter.
 	 *
 	 * @author Oliver Gierke
 	 * @since 2.0

--- a/src/main/java/org/springframework/data/convert/DefaultConverterBuilder.java
+++ b/src/main/java/org/springframework/data/convert/DefaultConverterBuilder.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Wither;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
+import org.springframework.data.convert.ConverterBuilder.ConverterAware;
+import org.springframework.data.convert.ConverterBuilder.ReadingConverterBuilder;
+import org.springframework.data.convert.ConverterBuilder.WritingConverterBuilder;
+import org.springframework.data.util.Optionals;
+
+/**
+ * Builder to easily set up (bi-directional) {@link Converter} instances for Spring Data type mapping using Lambdas. Use
+ * factory methods on {@link ConverterBuilder} to create instances of this class.
+ * 
+ * @author Oliver Gierke
+ * @since 2.0
+ * @see ConverterBuilder#writing(Class, Class, Function)
+ * @see ConverterBuilder#reading(Class, Class, Function)
+ * @soundtrack John Mayer - Still Feel Like Your Man (The Search for Everything)
+ */
+@Wither(AccessLevel.PACKAGE)
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class DefaultConverterBuilder<S, T>
+		implements ConverterAware, ReadingConverterBuilder<T, S>, WritingConverterBuilder<S, T> {
+
+	private final @NonNull ConvertiblePair convertiblePair;
+	private final @NonNull Optional<Function<? super S, ? extends T>> writing;
+	private final @NonNull Optional<Function<? super T, ? extends S>> reading;
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.WritingConverterBuilder#andReading(java.util.function.Function)
+	 */
+	@Override
+	public ConverterAware andReading(Function<? super T, ? extends S> function) {
+		return withReading(Optional.of(function));
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.ReadingConverterBuilder#andWriting(java.util.function.Function)
+	 */
+	@Override
+	public ConverterAware andWriting(Function<? super S, ? extends T> function) {
+		return withWriting(Optional.of(function));
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.ReadingConverterBuilder#getRequiredReadingConverter()
+	 */
+	@Override
+	public GenericConverter getReadingConverter() {
+		return getOptionalReadingConverter()
+				.orElseThrow(() -> new IllegalStateException("No reading converter specified!"));
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.WritingConverterBuilder#getRequiredWritingConverter()
+	 */
+	@Override
+	public GenericConverter getWritingConverter() {
+		return getOptionalWritingConverter()
+				.orElseThrow(() -> new IllegalStateException("No writing converter specified!"));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.ConverterBuilder#getConverters()
+	 */
+	@Override
+	public Set<GenericConverter> getConverters() {
+		return Optionals.toStream(getOptionalReadingConverter(), getOptionalWritingConverter()).collect(Collectors.toSet());
+	}
+
+	private Optional<GenericConverter> getOptionalReadingConverter() {
+		return reading.map(it -> new ConfigurableGenericConverter.Reading<>(convertiblePair, it));
+	}
+
+	private Optional<GenericConverter> getOptionalWritingConverter() {
+		return writing.map(it -> new ConfigurableGenericConverter.Writing<>(invertedPair(), it));
+	}
+
+	private ConvertiblePair invertedPair() {
+		return new ConvertiblePair(convertiblePair.getTargetType(), convertiblePair.getSourceType());
+	}
+
+	@RequiredArgsConstructor
+	@EqualsAndHashCode
+	private static class ConfigurableGenericConverter<S, T> implements GenericConverter {
+
+		private final ConvertiblePair convertiblePair;
+		private final Function<? super S, ? extends T> function;
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.GenericConverter#convert(java.lang.Object, org.springframework.core.convert.TypeDescriptor, org.springframework.core.convert.TypeDescriptor)
+		 */
+		@Override
+		@SuppressWarnings("unchecked")
+		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+			return function.apply((S) source);
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.GenericConverter#getConvertibleTypes()
+		 */
+		@Override
+		public Set<ConvertiblePair> getConvertibleTypes() {
+			return Collections.singleton(convertiblePair);
+		}
+
+		@WritingConverter
+		private static class Writing<S, T> extends ConfigurableGenericConverter<S, T> {
+
+			public Writing(ConvertiblePair convertiblePair, Function<? super S, ? extends T> function) {
+				super(convertiblePair, function);
+			}
+		}
+
+		@ReadingConverter
+		private static class Reading<S, T> extends ConfigurableGenericConverter<S, T> {
+
+			public Reading(ConvertiblePair convertiblePair, Function<? super S, ? extends T> function) {
+				super(convertiblePair, function);
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/convert/DefaultConverterBuilder.java
+++ b/src/main/java/org/springframework/data/convert/DefaultConverterBuilder.java
@@ -99,7 +99,10 @@ class DefaultConverterBuilder<S, T>
 	 */
 	@Override
 	public Set<GenericConverter> getConverters() {
-		return Optionals.toStream(getOptionalReadingConverter(), getOptionalWritingConverter()).collect(Collectors.toSet());
+
+		return Optionals//
+				.toStream(getOptionalReadingConverter(), getOptionalWritingConverter())//
+				.collect(Collectors.toSet());
 	}
 
 	private Optional<GenericConverter> getOptionalReadingConverter() {
@@ -143,7 +146,7 @@ class DefaultConverterBuilder<S, T>
 		@WritingConverter
 		private static class Writing<S, T> extends ConfigurableGenericConverter<S, T> {
 
-			public Writing(ConvertiblePair convertiblePair, Function<? super S, ? extends T> function) {
+			Writing(ConvertiblePair convertiblePair, Function<? super S, ? extends T> function) {
 				super(convertiblePair, function);
 			}
 		}
@@ -151,7 +154,7 @@ class DefaultConverterBuilder<S, T>
 		@ReadingConverter
 		private static class Reading<S, T> extends ConfigurableGenericConverter<S, T> {
 
-			public Reading(ConvertiblePair convertiblePair, Function<? super S, ? extends T> function) {
+			Reading(ConvertiblePair convertiblePair, Function<? super S, ? extends T> function) {
 				super(convertiblePair, function);
 			}
 		}

--- a/src/test/java/org/springframework/data/convert/ConverterBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/ConverterBuilderUnitTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.mockito.internal.util.Supplier;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
+import org.springframework.data.convert.ConverterBuilder.ConverterAware;
+import org.springframework.data.convert.ConverterBuilder.ReadingConverterBuilder;
+import org.springframework.data.convert.ConverterBuilder.WritingConverterBuilder;
+
+/**
+ * Unit tests for {@link DefaultConverterBuilder}.
+ * 
+ * @author Oliver Gierke
+ * @since 2.0
+ * @soundtrack John Mayer - In the Blood (The Search for Everything)
+ */
+public class ConverterBuilderUnitTests {
+
+	@Test // DATACMNS-1034
+	public void setsUpBidirectionalConvertersFromReading() {
+
+		ConverterAware builder = ConverterBuilder.reading(String.class, Long.class, it -> Long.valueOf(it))
+				.andWriting(Object::toString);
+
+		assertConverter(builder.getReadingConverter(), "1", 1L);
+		assertConverter(builder.getWritingConverter(), 1L, "1");
+	}
+
+	@Test // DATACMNS-1034
+	public void setsUpBidirectionalConvertersFromWriting() {
+
+		ConverterAware builder = ConverterBuilder.writing(Long.class, String.class, Object::toString)
+				.andReading(it -> Long.valueOf(it));
+
+		assertConverter(builder.getReadingConverter(), "1", 1L);
+		assertConverter(builder.getWritingConverter(), 1L, "1");
+	}
+
+	@Test // DATACMNS-1034
+	public void setsUpReadingConverter() {
+
+		ReadingConverterBuilder<String, Long> builder = ConverterBuilder.reading(String.class, Long.class,
+				string -> Long.valueOf(string));
+
+		assertConverter(builder.getReadingConverter(), "1", 1L);
+		assertOnlyConverter(builder, builder::getReadingConverter);
+	}
+
+	@Test // DATACMNS-1034
+	public void setsUpWritingConverter() {
+
+		WritingConverterBuilder<Long, String> builder = ConverterBuilder.writing(Long.class, String.class,
+				Object::toString);
+
+		assertConverter(builder.getWritingConverter(), 1L, "1");
+		assertOnlyConverter(builder, builder::getWritingConverter);
+	}
+
+	private static void assertConverter(GenericConverter converter, Object source, Object target) {
+
+		assertThat(converter.getConvertibleTypes())
+				.containsExactly(new ConvertiblePair(source.getClass(), target.getClass()));
+		assertThat(converter.convert(source, TypeDescriptor.forObject(source), TypeDescriptor.forObject(target)))
+				.isEqualTo(target);
+	}
+
+	private static void assertOnlyConverter(ConverterBuilder builder, Supplier<GenericConverter> supplier) {
+		assertThat(builder.getConverters()).containsExactly(supplier.get());
+	}
+}


### PR DESCRIPTION
Introduced `ConverterBuilder` which exposes API to register Spring `GenericConverter`s for the use with a store module's `CustomConversions`. This allows simple registration of such converters using Java 8 lambdas.

```java
ConverterAware converters = ConverterBuilder
  .reading(String.class, Long.class, it -> Long.valueOf(it))
  .andWriting(it -> Object::toString);
```

The setup can also be done from the reading side which would just need the method invocations inverted. The resulting `ConverterAware` will expose the registered converters so that they can be easily handed to a `CustomConversions` instance. Partial creation of either reading or writing converters is possible, too with the returned instance then only exposing one of the two converters.