### PR TITLE
DATACMNS-1021 - Add Order.asc(…) and Order.desc(…) factory methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1021-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -433,13 +433,22 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 		 * {@link Sort#DEFAULT_DIRECTION}.
 		 * 
 		 * @param property must not be {@literal null} or empty.
+		 * @deprecated since 2.0, use {@link Order#by(String)}.
 		 */
+		@Deprecated
 		public Order(String property) {
 			this(DEFAULT_DIRECTION, property);
 		}
 
+		/**
+		 * Creates a new {@link Order} instance. Takes a single property. Direction defaults to
+		 * {@link Sort#DEFAULT_DIRECTION}.
+		 * 
+		 * @param property must not be {@literal null} or empty.
+		 * @since 2.0
+		 */
 		public static Order by(String property) {
-			return new Order(property);
+			return new Order(DEFAULT_DIRECTION, property);
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class Sort implements Iterable<org.springframework.data.domain.Sort.Order>, Serializable {
 
@@ -439,6 +440,28 @@ public class Sort implements Iterable<org.springframework.data.domain.Sort.Order
 
 		public static Order by(String property) {
 			return new Order(property);
+		}
+
+		/**
+		 * Creates a new {@link Order} instance. Takes a single property. Direction is {@link Direction#ASC} and
+		 * NullHandling {@link NullHandling#NATIVE}.
+		 *
+		 * @param property must not be {@literal null} or empty.
+		 * @since 2.0
+		 */
+		public static Order asc(String property) {
+			return new Order(Direction.ASC, property, null);
+		}
+
+		/**
+		 * Creates a new {@link Order} instance. Takes a single property. Direction is {@link Direction#ASC} and
+		 * NullHandling {@link NullHandling#NATIVE}.
+		 *
+		 * @param property must not be {@literal null} or empty.
+		 * @since 2.0
+		 */
+		public static Order desc(String property) {
+			return new Order(Direction.DESC, property, null);
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/querydsl/QSort.java
+++ b/src/main/java/org/springframework/data/querydsl/QSort.java
@@ -33,6 +33,7 @@ import com.querydsl.core.types.Path;
  * 
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class QSort extends Sort implements Serializable {
 
@@ -99,7 +100,7 @@ public class QSort extends Sort implements Serializable {
 
 		Assert.notNull(targetElement, "Target element must not be null!");
 
-		return new Order(targetElement.toString()).with(orderSpecifier.isAscending() ? Direction.ASC : Direction.DESC);
+		return Order.by(targetElement.toString()).with(orderSpecifier.isAscending() ? Direction.ASC : Direction.DESC);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/query/parser/OrderBySource.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/OrderBySource.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 class OrderBySource {
 
@@ -110,11 +111,11 @@ class OrderBySource {
 
 			PropertyPath propertyPath = PropertyPath.from(propertySource, type);
 			return direction.map(it -> new Order(it, propertyPath.toDotPath()))
-					.orElseGet(() -> new Order(propertyPath.toDotPath()));
+					.orElseGet(() -> Order.by(propertyPath.toDotPath()));
 
 		}).orElseGet(() -> direction//
 				.map(it -> new Order(it, StringUtils.uncapitalize(propertySource)))
-				.orElseGet(() -> new Order(StringUtils.uncapitalize(propertySource))));
+				.orElseGet(() -> Order.by(StringUtils.uncapitalize(propertySource))));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
@@ -238,7 +238,7 @@ public class SortHandlerMethodArgumentResolver implements SortArgumentResolver {
 			return Optional.empty();
 		}
 
-		return Optional.of(direction.map(it -> new Order(it, property)).orElseGet(() -> new Order(property)));
+		return Optional.of(direction.map(it -> new Order(it, property)).orElseGet(() -> Order.by(property)));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/domain/SortUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/SortUnitTests.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Sort.Order;
  * @author Oliver Gierke
  * @author Kevin Raymond
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class SortUnitTests {
 
@@ -99,14 +100,24 @@ public class SortUnitTests {
 		assertThat(sort).containsExactly(new Sort.Order("foo"));
 	}
 
-	@Test // DATACMNS-281
+	@Test // DATACMNS-281, DATACMNS-1021
 	public void configuresIgnoreCaseForOrder() {
-		assertThat(new Order(Direction.ASC, "foo").ignoreCase().isIgnoreCase()).isTrue();
+		assertThat(Order.asc("foo").ignoreCase().isIgnoreCase()).isTrue();
 	}
 
-	@Test // DATACMNS-281
+	@Test // DATACMNS-281, DATACMNS-1021
 	public void orderDoesNotIgnoreCaseByDefault() {
+
 		assertThat(new Order(Direction.ASC, "foo").isIgnoreCase()).isFalse();
+		assertThat(Order.asc("foo").isIgnoreCase()).isFalse();
+		assertThat(Order.desc("foo").isIgnoreCase()).isFalse();
+	}
+
+	@Test // DATACMNS-1021
+	public void createsOrderWithDirection() {
+
+		assertThat(Order.asc("foo").getDirection()).isEqualTo(Direction.ASC);
+		assertThat(Order.desc("foo").getDirection()).isEqualTo(Direction.DESC);
 	}
 
 	@Test // DATACMNS-436


### PR DESCRIPTION
We now support `Order` creation with `Order.asc(String)` and Order.`desc(String)` factory methods as shortcut to constructor creation via `new Order(Direction, String).`

```java
  Sort.by(Order.asc("age"), Order.desc("name"));

  // with static imports
  Sort.by(asc("age"), desc("name"));
```

---

Related ticket: [DATACMNS-1021](https://jira.spring.io/browse/DATACMNS-1021).