### PR TITLE
DATACMNS-1050 - Encapsulate boundaries in value objects for Range.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1050-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/domain/Range.java
+++ b/src/main/java/org/springframework/data/domain/Range.java
@@ -31,23 +31,23 @@ import org.springframework.util.Assert;
 @Value
 public class Range<T extends Comparable<T>> {
 
-	private final static Range<?> UNBOUNDED = Range.of(Boundary.unbounded(), Boundary.UNBOUNDED);
+	private final static Range<?> UNBOUNDED = Range.of(Bound.unbounded(), Bound.UNBOUNDED);
 
 	/**
 	 * The lower bound of the range.
 	 */
-	private final Boundary<T> lowerBound;
+	private final Bound<T> lowerBound;
 
 	/**
 	 * The upper bound of the range.
 	 */
-	private final Boundary<T> upperBound;
+	private final Bound<T> upperBound;
 
 	/**
 	 * Creates a new {@link Range} with the given lower and upper bound. Treats the given values as inclusive bounds. Use
 	 * {@link #Range(Comparable, Comparable, boolean, boolean)} to configure different bound behavior.
 	 * 
-	 * @see Range#of(Boundary, Boundary)
+	 * @see Range#of(Bound, Bound)
 	 * @param lowerBound can be {@literal null} in case upperBound is not {@literal null}.
 	 * @param upperBound can be {@literal null} in case lowerBound is not {@literal null}.
 	 */
@@ -63,21 +63,20 @@ public class Range<T extends Comparable<T>> {
 	 * @param upperBound can be {@literal null}.
 	 * @param lowerInclusive
 	 * @param upperInclusive
-	 * @deprecated since 2.0. Use {@link Range#of(Boundary, Boundary)} and {@link Boundary} factory methods:
-	 *             {@link Boundary#inclusive(Comparable)},
-	 *             {@link Boundary#exclusive(Comparable)}/{@link Boundary#unbounded()}.
+	 * @deprecated since 2.0. Use {@link Range#of(Bound, Bound)} and {@link Bound} factory methods:
+	 *             {@link Bound#inclusive(Comparable)}, {@link Bound#exclusive(Comparable)}/{@link Bound#unbounded()}.
 	 */
 	@Deprecated
 	public Range(T lowerBound, T upperBound, boolean lowerInclusive, boolean upperInclusive) {
 
-		this.lowerBound = lowerBound == null ? Boundary.unbounded()
-				: lowerInclusive ? Boundary.inclusive(lowerBound) : Boundary.exclusive(lowerBound);
+		this.lowerBound = lowerBound == null ? Bound.unbounded()
+				: lowerInclusive ? Bound.inclusive(lowerBound) : Bound.exclusive(lowerBound);
 
-		this.upperBound = upperBound == null ? Boundary.unbounded()
-				: upperInclusive ? Boundary.inclusive(upperBound) : Boundary.exclusive(upperBound);
+		this.upperBound = upperBound == null ? Bound.unbounded()
+				: upperInclusive ? Bound.inclusive(upperBound) : Bound.exclusive(upperBound);
 	}
 
-	private Range(Boundary<T> lowerBound, Boundary<T> upperBound) {
+	private Range(Bound<T> lowerBound, Bound<T> upperBound) {
 
 		Assert.notNull(lowerBound, "Lower boundary must not be null!");
 		Assert.notNull(upperBound, "Upper boundary must not be null!");
@@ -98,25 +97,16 @@ public class Range<T extends Comparable<T>> {
 	}
 
 	/**
-	 * Create a {@link UpperRangeBuilder} for values greater than or equals {@code min} value.
+	 * Create a {@link RangeBuilder} given the lower {@link Bound}.
 	 * 
-	 * @param min must not be {@literal null}.
+	 * @param lower must not be {@literal null}.
 	 * @return
 	 * @since 2.0
 	 */
-	public static <T extends Comparable<T>> UpperRangeBuilder<T> greaterThanOrEquals(T min) {
-		return new UpperRangeBuilder<T>(Boundary.inclusive(min));
-	}
+	public static <T extends Comparable<T>> RangeBuilder<T> from(Bound<T> lower) {
 
-	/**
-	 * Create a {@link UpperRangeBuilder} for values greater than {@code min} value.
-	 * 
-	 * @param min must not be {@literal null}.
-	 * @return
-	 * @since 2.0
-	 */
-	public static <T extends Comparable<T>> UpperRangeBuilder<T> greaterThan(T min) {
-		return new UpperRangeBuilder<T>(Boundary.exclusive(min));
+		Assert.notNull(lower, "Lower bound must not be null!");
+		return new RangeBuilder<>(lower);
 	}
 
 	/**
@@ -126,61 +116,61 @@ public class Range<T extends Comparable<T>> {
 	 * @param upperBound must not be {@literal null}.
 	 * @since 2.0
 	 */
-	public static <T extends Comparable<T>> Range<T> of(Boundary<T> lowerBound, Boundary<T> upperBound) {
+	public static <T extends Comparable<T>> Range<T> of(Bound<T> lowerBound, Bound<T> upperBound) {
 		return new Range<>(lowerBound, upperBound);
 	}
 
 	/**
 	 * Creates a new {@link Integer} {@link Range} with the given lower and upper bound. Treats the given values as
-	 * including bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * including bounds. Use {@link #of(Bound, Bound)} to configure different bound behavior.
 	 * 
 	 * @param lowerBound
 	 * @param upperBound
 	 * @since 2.0
 	 */
 	public static Range<Integer> from(int lowerBoundInclusive, int upperBoundInclusive) {
-		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+		return of(Bound.inclusive(lowerBoundInclusive), Bound.inclusive(upperBoundInclusive));
 	}
 
 	/**
 	 * Creates a new {@link Long} {@link Range} with the given lower and upper bound. Treats the given values as including
-	 * bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * bounds. Use {@link #of(Bound, Bound)} to configure different bound behavior.
 	 * 
 	 * @param lowerBound
 	 * @param upperBound
 	 * @since 2.0
 	 */
 	public static Range<Long> from(long lowerBoundInclusive, long upperBoundInclusive) {
-		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+		return of(Bound.inclusive(lowerBoundInclusive), Bound.inclusive(upperBoundInclusive));
 	}
 
 	/**
 	 * Creates a new {@link Float} {@link Range} with the given lower and upper bound. Treats the given values as
-	 * including bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * including bounds. Use {@link #of(Bound, Bound)} to configure different bound behavior.
 	 * 
 	 * @param lowerBound
 	 * @param upperBound
 	 * @since 2.0
 	 */
 	public static Range<Float> from(float lowerBoundInclusive, float upperBoundInclusive) {
-		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+		return of(Bound.inclusive(lowerBoundInclusive), Bound.inclusive(upperBoundInclusive));
 	}
 
 	/**
 	 * Creates a new {@link Double} {@link Range} with the given lower and upper bound. Treats the given values as
-	 * including bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * including bounds. Use {@link #of(Bound, Bound)} to configure different bound behavior.
 	 * 
 	 * @param lowerBound
 	 * @param upperBound
 	 * @since 2.0
 	 */
 	public static Range<Double> from(double lowerBoundInclusive, double upperBoundInclusive) {
-		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+		return of(Bound.inclusive(lowerBoundInclusive), Bound.inclusive(upperBoundInclusive));
 	}
 
 	/**
 	 * @return
-	 * @deprecated since 2.0, use {@link #getLowerBound()} and {@link Boundary#isInclusive()}.
+	 * @deprecated since 2.0, use {@link #getLowerBound()} and {@link Bound#isInclusive()}.
 	 */
 	@Deprecated
 	public boolean isLowerInclusive() {
@@ -189,7 +179,7 @@ public class Range<T extends Comparable<T>> {
 
 	/**
 	 * @return
-	 * @deprecated since 2.0, use {@link #getUpperBound()} and {@link Boundary#isInclusive()}.
+	 * @deprecated since 2.0, use {@link #getUpperBound()} and {@link Bound#isInclusive()}.
 	 */
 	@Deprecated
 	public boolean isUpperInclusive() {
@@ -223,24 +213,7 @@ public class Range<T extends Comparable<T>> {
 	 */
 	@Override
 	public String toString() {
-
-		String lower = this.lowerBound.getValue().map(Object::toString).map(it -> {
-
-			if (this.lowerBound.isInclusive()) {
-				return "[".concat(it);
-			}
-			return "(".concat(it);
-		}).orElse("unbounded");
-
-		String upper = this.upperBound.getValue().map(Object::toString).map(it -> {
-
-			if (this.upperBound.isInclusive()) {
-				return it.concat("]");
-			}
-			return it.concat(")");
-		}).orElse("unbounded");
-
-		return String.format("%s-%s", lower, upper);
+		return String.format("%s-%s", lowerBound.toPrefixString(), upperBound.toSuffixString());
 	}
 
 	/**
@@ -252,26 +225,20 @@ public class Range<T extends Comparable<T>> {
 	 * @soundtrack Mohamed Ragab - Excelsior Sessions (March 2017)
 	 */
 	@Value
-	public static class Boundary<T extends Comparable<T>> {
+	public static class Bound<T extends Comparable<T>> {
 
-		@SuppressWarnings({ "rawtypes",
-				"unchecked" }) private static final Range.Boundary<?> UNBOUNDED = new Boundary(Optional.empty(), true);
+		@SuppressWarnings({ "rawtypes", "unchecked" }) //
+		private static final Bound<?> UNBOUNDED = new Bound(Optional.empty(), true);
 
 		private final Optional<T> value;
 		private final boolean inclusive;
 
-		private Boundary(Optional<T> value, boolean inclusive) {
-
-			this.value = value;
-			this.inclusive = inclusive;
-		}
-
 		/**
-		 * Creates an unbounded {@link Boundary}.
+		 * Creates an unbounded {@link Bound}.
 		 */
 		@SuppressWarnings("unchecked")
-		public static <T extends Comparable<T>> Boundary<T> unbounded() {
-			return (Boundary<T>) UNBOUNDED;
+		public static <T extends Comparable<T>> Bound<T> unbounded() {
+			return (Bound<T>) UNBOUNDED;
 		}
 
 		/**
@@ -289,10 +256,10 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static <T extends Comparable<T>> Boundary<T> inclusive(T value) {
+		public static <T extends Comparable<T>> Bound<T> inclusive(T value) {
 
 			Assert.notNull(value, "Value must not be null!");
-			return new Boundary<>(Optional.of(value), true);
+			return new Bound<>(Optional.of(value), true);
 		}
 
 		/**
@@ -301,7 +268,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Integer> inclusive(int value) {
+		public static Bound<Integer> inclusive(int value) {
 			return inclusive((Integer) value);
 		}
 
@@ -311,7 +278,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Long> inclusive(long value) {
+		public static Bound<Long> inclusive(long value) {
 			return inclusive((Long) value);
 		}
 
@@ -321,7 +288,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Float> inclusive(float value) {
+		public static Bound<Float> inclusive(float value) {
 			return inclusive((Float) value);
 		}
 
@@ -331,7 +298,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Double> inclusive(double value) {
+		public static Bound<Double> inclusive(double value) {
 			return inclusive((Double) value);
 		}
 
@@ -341,10 +308,10 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static <T extends Comparable<T>> Boundary<T> exclusive(T value) {
+		public static <T extends Comparable<T>> Bound<T> exclusive(T value) {
 
 			Assert.notNull(value, "Value must not be null!");
-			return new Boundary<>(Optional.of(value), false);
+			return new Bound<>(Optional.of(value), false);
 		}
 
 		/**
@@ -353,7 +320,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Integer> exclusive(int value) {
+		public static Bound<Integer> exclusive(int value) {
 			return exclusive((Integer) value);
 		}
 
@@ -363,7 +330,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Long> exclusive(long value) {
+		public static Bound<Long> exclusive(long value) {
 			return exclusive((Long) value);
 		}
 
@@ -373,7 +340,7 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Float> exclusive(float value) {
+		public static Bound<Float> exclusive(float value) {
 			return exclusive((Float) value);
 		}
 
@@ -383,8 +350,24 @@ public class Range<T extends Comparable<T>> {
 		 * @param value must not be {@literal null}.
 		 * @return
 		 */
-		public static Boundary<Double> exclusive(double value) {
+		public static Bound<Double> exclusive(double value) {
 			return exclusive((Double) value);
+		}
+
+		String toPrefixString() {
+
+			return getValue() //
+					.map(Object::toString) //
+					.map(it -> isInclusive() ? "[".concat(it) : "(".concat(it)) //
+					.orElse("unbounded");
+		}
+
+		String toSuffixString() {
+
+			return getValue() //
+					.map(Object::toString) //
+					.map(it -> isInclusive() ? it.concat("]") : it.concat(")")) //
+					.orElse("unbounded");
 		}
 
 		/* 
@@ -395,6 +378,7 @@ public class Range<T extends Comparable<T>> {
 		public String toString() {
 			return value.map(Object::toString).orElse("unbounded");
 		}
+
 	}
 
 	/**
@@ -404,32 +388,24 @@ public class Range<T extends Comparable<T>> {
 	 * @since 2.0
 	 * @soundtrack Aly and Fila - Future Sound Of Egypt 493
 	 */
-	public static class UpperRangeBuilder<T extends Comparable<T>> {
+	public static class RangeBuilder<T extends Comparable<T>> {
 
-		private final Boundary<T> lower;
+		private final Bound<T> lower;
 
-		UpperRangeBuilder(Boundary<T> lower) {
+		RangeBuilder(Bound<T> lower) {
 			this.lower = lower;
 		}
 
 		/**
-		 * Create a {@link Range} for values less than or equals {@code max} value.
+		 * Create a {@link Range} given the upper {@link Bound}.
 		 * 
-		 * @param max must not be {@literal null}.
+		 * @param upper must not be {@literal null}.
 		 * @return
 		 */
-		public Range<T> andLessThanOrEquals(T max) {
-			return new Range<>(lower, Boundary.inclusive(max));
-		}
+		public Range<T> to(Bound<T> upper) {
 
-		/**
-		 * Create a {@link Range} for values less than {@code max} value.
-		 * 
-		 * @param max must not be {@literal null}.
-		 * @return
-		 */
-		public Range<T> andLessThan(T max) {
-			return new Range<>(lower, Boundary.exclusive(max));
+			Assert.notNull(upper, "Upper bound must not be null!");
+			return new Range<>(lower, upper);
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/domain/Range.java
+++ b/src/main/java/org/springframework/data/domain/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,42 +17,37 @@ package org.springframework.data.domain;
 
 import lombok.Value;
 
+import java.util.Optional;
+
 import org.springframework.util.Assert;
 
 /**
- * Simple value object to work with ranges.
+ * Simple value object to work with ranges and boundaries.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @since 1.10
  */
 @Value
 public class Range<T extends Comparable<T>> {
 
+	private final static Range<?> UNBOUNDED = Range.of(Boundary.unbounded(), Boundary.UNBOUNDED);
+
 	/**
 	 * The lower bound of the range.
 	 */
-	private final T lowerBound;
+	private final Boundary<T> lowerBound;
 
 	/**
 	 * The upper bound of the range.
 	 */
-	private final T upperBound;
-
-	/**
-	 * Whether the lower bound is considered inclusive.
-	 */
-	private final boolean lowerInclusive;
-
-	/**
-	 * Whether the lower bound is considered inclusive.
-	 */
-	private final boolean upperInclusive;
+	private final Boundary<T> upperBound;
 
 	/**
 	 * Creates a new {@link Range} with the given lower and upper bound. Treats the given values as inclusive bounds. Use
 	 * {@link #Range(Comparable, Comparable, boolean, boolean)} to configure different bound behavior.
 	 * 
-	 * @see #Range(Comparable, Comparable, boolean, boolean)
+	 * @see Range#of(Boundary, Boundary)
 	 * @param lowerBound can be {@literal null} in case upperBound is not {@literal null}.
 	 * @param upperBound can be {@literal null} in case lowerBound is not {@literal null}.
 	 */
@@ -68,13 +63,137 @@ public class Range<T extends Comparable<T>> {
 	 * @param upperBound can be {@literal null}.
 	 * @param lowerInclusive
 	 * @param upperInclusive
+	 * @deprecated since 2.0. Use {@link Range#of(Boundary, Boundary)} and {@link Boundary} factory methods:
+	 *             {@link Boundary#inclusive(Comparable)},
+	 *             {@link Boundary#exclusive(Comparable)}/{@link Boundary#unbounded()}.
 	 */
+	@Deprecated
 	public Range(T lowerBound, T upperBound, boolean lowerInclusive, boolean upperInclusive) {
+
+		this.lowerBound = lowerBound == null ? Boundary.unbounded()
+				: lowerInclusive ? Boundary.inclusive(lowerBound) : Boundary.exclusive(lowerBound);
+
+		this.upperBound = upperBound == null ? Boundary.unbounded()
+				: upperInclusive ? Boundary.inclusive(upperBound) : Boundary.exclusive(upperBound);
+	}
+
+	private Range(Boundary<T> lowerBound, Boundary<T> upperBound) {
+
+		Assert.notNull(lowerBound, "Lower boundary must not be null!");
+		Assert.notNull(upperBound, "Upper boundary must not be null!");
 
 		this.lowerBound = lowerBound;
 		this.upperBound = upperBound;
-		this.lowerInclusive = lowerInclusive;
-		this.upperInclusive = upperInclusive;
+	}
+
+	/**
+	 * Returns an unbounded {@link Range}.
+	 * 
+	 * @return
+	 * @since 2.0
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends Comparable<T>> Range<T> unbounded() {
+		return (Range<T>) UNBOUNDED;
+	}
+
+	/**
+	 * Create a {@link UpperRangeBuilder} for values greater than or equals {@code min} value.
+	 * 
+	 * @param min must not be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	public static <T extends Comparable<T>> UpperRangeBuilder<T> greaterThanOrEquals(T min) {
+		return new UpperRangeBuilder<T>(Boundary.inclusive(min));
+	}
+
+	/**
+	 * Create a {@link UpperRangeBuilder} for values greater than {@code min} value.
+	 * 
+	 * @param min must not be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	public static <T extends Comparable<T>> UpperRangeBuilder<T> greaterThan(T min) {
+		return new UpperRangeBuilder<T>(Boundary.exclusive(min));
+	}
+
+	/**
+	 * Creates a new {@link Range} with the given lower and upper bound.
+	 * 
+	 * @param lowerBound must not be {@literal null}.
+	 * @param upperBound must not be {@literal null}.
+	 * @since 2.0
+	 */
+	public static <T extends Comparable<T>> Range<T> of(Boundary<T> lowerBound, Boundary<T> upperBound) {
+		return new Range<>(lowerBound, upperBound);
+	}
+
+	/**
+	 * Creates a new {@link Integer} {@link Range} with the given lower and upper bound. Treats the given values as
+	 * including bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * 
+	 * @param lowerBound
+	 * @param upperBound
+	 * @since 2.0
+	 */
+	public static Range<Integer> from(int lowerBoundInclusive, int upperBoundInclusive) {
+		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+	}
+
+	/**
+	 * Creates a new {@link Long} {@link Range} with the given lower and upper bound. Treats the given values as including
+	 * bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * 
+	 * @param lowerBound
+	 * @param upperBound
+	 * @since 2.0
+	 */
+	public static Range<Long> from(long lowerBoundInclusive, long upperBoundInclusive) {
+		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+	}
+
+	/**
+	 * Creates a new {@link Float} {@link Range} with the given lower and upper bound. Treats the given values as
+	 * including bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * 
+	 * @param lowerBound
+	 * @param upperBound
+	 * @since 2.0
+	 */
+	public static Range<Float> from(float lowerBoundInclusive, float upperBoundInclusive) {
+		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+	}
+
+	/**
+	 * Creates a new {@link Double} {@link Range} with the given lower and upper bound. Treats the given values as
+	 * including bounds. Use {@link #of(Boundary, Boundary)} to configure different bound behavior.
+	 * 
+	 * @param lowerBound
+	 * @param upperBound
+	 * @since 2.0
+	 */
+	public static Range<Double> from(double lowerBoundInclusive, double upperBoundInclusive) {
+		return of(Boundary.inclusive(lowerBoundInclusive), Boundary.inclusive(upperBoundInclusive));
+	}
+
+	/**
+	 * @return
+	 * @deprecated since 2.0, use {@link #getLowerBound()} and {@link Boundary#isInclusive()}.
+	 */
+	@Deprecated
+	public boolean isLowerInclusive() {
+		return lowerBound.isInclusive();
+	}
+
+	/**
+	 * @return
+	 * @deprecated since 2.0, use {@link #getUpperBound()} and {@link Boundary#isInclusive()}.
+	 */
+	@Deprecated
+	public boolean isUpperInclusive() {
+		return upperBound.isInclusive();
 	}
 
 	/**
@@ -87,11 +206,230 @@ public class Range<T extends Comparable<T>> {
 
 		Assert.notNull(value, "Reference value must not be null!");
 
-		boolean greaterThanLowerBound = lowerBound == null ? true
-				: lowerInclusive ? lowerBound.compareTo(value) <= 0 : lowerBound.compareTo(value) < 0;
-		boolean lessThanUpperBound = upperBound == null ? true
-				: upperInclusive ? upperBound.compareTo(value) >= 0 : upperBound.compareTo(value) > 0;
+		boolean greaterThanLowerBound = lowerBound.getValue() //
+				.map(it -> lowerBound.isInclusive() ? it.compareTo(value) <= 0 : it.compareTo(value) < 0) //
+				.orElse(true);
+
+		boolean lessThanUpperBound = upperBound.getValue() //
+				.map(it -> upperBound.isInclusive() ? it.compareTo(value) >= 0 : it.compareTo(value) > 0) //
+				.orElse(true);
 
 		return greaterThanLowerBound && lessThanUpperBound;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+
+		String lower = this.lowerBound.getValue().map(Object::toString).map(it -> {
+
+			if (this.lowerBound.isInclusive()) {
+				return "[".concat(it);
+			}
+			return "(".concat(it);
+		}).orElse("unbounded");
+
+		String upper = this.upperBound.getValue().map(Object::toString).map(it -> {
+
+			if (this.upperBound.isInclusive()) {
+				return it.concat("]");
+			}
+			return it.concat(")");
+		}).orElse("unbounded");
+
+		return String.format("%s-%s", lower, upper);
+	}
+
+	/**
+	 * Value object representing a boundary. A boundary can either be {@link #unbounded() unbounded},
+	 * {@link #inclusive(Comparable) including its value} or {@link #exclusive(Comparable) its value}.
+	 * 
+	 * @author Mark Paluch
+	 * @since 2.0
+	 * @soundtrack Mohamed Ragab - Excelsior Sessions (March 2017)
+	 */
+	@Value
+	public static class Boundary<T extends Comparable<T>> {
+
+		@SuppressWarnings({ "rawtypes",
+				"unchecked" }) private static final Range.Boundary<?> UNBOUNDED = new Boundary(Optional.empty(), true);
+
+		private final Optional<T> value;
+		private final boolean inclusive;
+
+		private Boundary(Optional<T> value, boolean inclusive) {
+
+			this.value = value;
+			this.inclusive = inclusive;
+		}
+
+		/**
+		 * Creates an unbounded {@link Boundary}.
+		 */
+		@SuppressWarnings("unchecked")
+		public static <T extends Comparable<T>> Boundary<T> unbounded() {
+			return (Boundary<T>) UNBOUNDED;
+		}
+
+		/**
+		 * Returns whether this boundary is bounded.
+		 * 
+		 * @return
+		 */
+		public boolean isBounded() {
+			return value.isPresent();
+		}
+
+		/**
+		 * Creates a boundary including {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static <T extends Comparable<T>> Boundary<T> inclusive(T value) {
+
+			Assert.notNull(value, "Value must not be null!");
+			return new Boundary<>(Optional.of(value), true);
+		}
+
+		/**
+		 * Creates a boundary including {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Integer> inclusive(int value) {
+			return inclusive((Integer) value);
+		}
+
+		/**
+		 * Creates a boundary including {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Long> inclusive(long value) {
+			return inclusive((Long) value);
+		}
+
+		/**
+		 * Creates a boundary including {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Float> inclusive(float value) {
+			return inclusive((Float) value);
+		}
+
+		/**
+		 * Creates a boundary including {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Double> inclusive(double value) {
+			return inclusive((Double) value);
+		}
+
+		/**
+		 * Creates a boundary excluding {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static <T extends Comparable<T>> Boundary<T> exclusive(T value) {
+
+			Assert.notNull(value, "Value must not be null!");
+			return new Boundary<>(Optional.of(value), false);
+		}
+
+		/**
+		 * Creates a boundary excluding {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Integer> exclusive(int value) {
+			return exclusive((Integer) value);
+		}
+
+		/**
+		 * Creates a boundary excluding {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Long> exclusive(long value) {
+			return exclusive((Long) value);
+		}
+
+		/**
+		 * Creates a boundary excluding {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Float> exclusive(float value) {
+			return exclusive((Float) value);
+		}
+
+		/**
+		 * Creates a boundary excluding {@code value}.
+		 * 
+		 * @param value must not be {@literal null}.
+		 * @return
+		 */
+		public static Boundary<Double> exclusive(double value) {
+			return exclusive((Double) value);
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return value.map(Object::toString).orElse("unbounded");
+		}
+	}
+
+	/**
+	 * Builder for {@link Range} allowing to specify the upper boundary.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.0
+	 * @soundtrack Aly and Fila - Future Sound Of Egypt 493
+	 */
+	public static class UpperRangeBuilder<T extends Comparable<T>> {
+
+		private final Boundary<T> lower;
+
+		UpperRangeBuilder(Boundary<T> lower) {
+			this.lower = lower;
+		}
+
+		/**
+		 * Create a {@link Range} for values less than or equals {@code max} value.
+		 * 
+		 * @param max must not be {@literal null}.
+		 * @return
+		 */
+		public Range<T> andLessThanOrEquals(T max) {
+			return new Range<>(lower, Boundary.inclusive(max));
+		}
+
+		/**
+		 * Create a {@link Range} for values less than {@code max} value.
+		 * 
+		 * @param max must not be {@literal null}.
+		 * @return
+		 */
+		public Range<T> andLessThan(T max) {
+			return new Range<>(lower, Boundary.exclusive(max));
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/domain/RangeUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/RangeUnitTests.java
@@ -18,7 +18,7 @@ package org.springframework.data.domain;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Test;
-import org.springframework.data.domain.Range.Boundary;
+import org.springframework.data.domain.Range.Bound;
 
 /**
  * Unit tests for {@link Range}.
@@ -102,26 +102,26 @@ public class RangeUnitTests {
 	@Test // DATACMNS-1050
 	public void createsInclusiveBoundaryCorrectly() {
 
-		Boundary<Integer> boundary = Boundary.inclusive(10);
+		Bound<Integer> bound = Bound.inclusive(10);
 
-		assertThat(boundary.isInclusive()).isTrue();
-		assertThat(boundary.getValue()).contains(10);
+		assertThat(bound.isInclusive()).isTrue();
+		assertThat(bound.getValue()).contains(10);
 	}
 
 	@Test // DATACMNS-1050
 	public void createsExclusiveBoundaryCorrectly() {
 
-		Boundary<Double> boundary = Boundary.exclusive(10d);
+		Bound<Double> bound = Bound.exclusive(10d);
 
-		assertThat(boundary.isInclusive()).isFalse();
-		assertThat(boundary.getValue()).contains(10d);
+		assertThat(bound.isInclusive()).isFalse();
+		assertThat(bound.getValue()).contains(10d);
 	}
 
 	@Test // DATACMNS-1050
 	public void createsRangeFromBoundariesCorrectly() {
 
-		Boundary<Long> lower = Boundary.inclusive(10L);
-		Boundary<Long> upper = Boundary.inclusive(20L);
+		Bound<Long> lower = Bound.inclusive(10L);
+		Bound<Long> upper = Bound.inclusive(20L);
 
 		Range<Long> range = Range.of(lower, upper);
 
@@ -134,7 +134,7 @@ public class RangeUnitTests {
 	@Test // DATACMNS-1050
 	public void shouldExclusiveBuildRangeLowerFirst() {
 
-		Range<Long> range = Range.greaterThan(10L).andLessThan(20L);
+		Range<Long> range = Range.from(Bound.exclusive(10L)).to(Bound.exclusive(20L));
 
 		assertThat(range.contains(9L)).isFalse();
 		assertThat(range.contains(10L)).isFalse();
@@ -148,7 +148,7 @@ public class RangeUnitTests {
 	@Test // DATACMNS-1050
 	public void shouldBuildRange() {
 
-		Range<Long> range = Range.greaterThanOrEquals(10L).andLessThanOrEquals(20L);
+		Range<Long> range = Range.from(Bound.inclusive(10L)).to(Bound.inclusive(20L));
 
 		assertThat(range.contains(9L)).isFalse();
 		assertThat(range.contains(10L)).isTrue();

--- a/src/test/java/org/springframework/data/geo/DistanceUnitTests.java
+++ b/src/test/java/org/springframework/data/geo/DistanceUnitTests.java
@@ -21,7 +21,7 @@ import static org.springframework.data.geo.Metrics.*;
 import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.springframework.data.domain.Range;
-import org.springframework.data.domain.Range.Boundary;
+import org.springframework.data.domain.Range.Bound;
 import org.springframework.util.SerializationUtils;
 
 /**
@@ -131,8 +131,8 @@ public class DistanceUnitTests {
 		Range<Distance> range = Distance.between(twoKilometers, tenKilometers);
 
 		assertThat(range).isNotNull();
-		assertThat(range.getLowerBound()).isEqualTo(Boundary.inclusive(twoKilometers));
-		assertThat(range.getUpperBound()).isEqualTo(Boundary.inclusive(tenKilometers));
+		assertThat(range.getLowerBound()).isEqualTo(Bound.inclusive(twoKilometers));
+		assertThat(range.getUpperBound()).isEqualTo(Bound.inclusive(tenKilometers));
 	}
 
 	@Test // DATACMNS-651
@@ -144,8 +144,8 @@ public class DistanceUnitTests {
 		Range<Distance> range = Distance.between(2, KILOMETERS, 10, KILOMETERS);
 
 		assertThat(range).isNotNull();
-		assertThat(range.getLowerBound()).isEqualTo(Boundary.inclusive(twoKilometers));
-		assertThat(range.getUpperBound()).isEqualTo(Boundary.inclusive(tenKilometers));
+		assertThat(range.getLowerBound()).isEqualTo(Bound.inclusive(twoKilometers));
+		assertThat(range.getUpperBound()).isEqualTo(Bound.inclusive(tenKilometers));
 	}
 
 	@Test // DATACMNS-651

--- a/src/test/java/org/springframework/data/geo/DistanceUnitTests.java
+++ b/src/test/java/org/springframework/data/geo/DistanceUnitTests.java
@@ -21,6 +21,7 @@ import static org.springframework.data.geo.Metrics.*;
 import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.springframework.data.domain.Range;
+import org.springframework.data.domain.Range.Boundary;
 import org.springframework.util.SerializationUtils;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.util.SerializationUtils;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class DistanceUnitTests {
 
@@ -129,8 +131,8 @@ public class DistanceUnitTests {
 		Range<Distance> range = Distance.between(twoKilometers, tenKilometers);
 
 		assertThat(range).isNotNull();
-		assertThat(range.getLowerBound()).isEqualTo(twoKilometers);
-		assertThat(range.getUpperBound()).isEqualTo(tenKilometers);
+		assertThat(range.getLowerBound()).isEqualTo(Boundary.inclusive(twoKilometers));
+		assertThat(range.getUpperBound()).isEqualTo(Boundary.inclusive(tenKilometers));
 	}
 
 	@Test // DATACMNS-651
@@ -142,8 +144,8 @@ public class DistanceUnitTests {
 		Range<Distance> range = Distance.between(2, KILOMETERS, 10, KILOMETERS);
 
 		assertThat(range).isNotNull();
-		assertThat(range.getLowerBound()).isEqualTo(twoKilometers);
-		assertThat(range.getUpperBound()).isEqualTo(tenKilometers);
+		assertThat(range.getLowerBound()).isEqualTo(Boundary.inclusive(twoKilometers));
+		assertThat(range.getUpperBound()).isEqualTo(Boundary.inclusive(tenKilometers));
 	}
 
 	@Test // DATACMNS-651


### PR DESCRIPTION
We now encapsulate a boundary in `Range` within a `Boundary` value object. `Boundary` consists of a value and whether the value is inclusive or exclusive. Boundaries without a value are unbounded.

We introduced factory methods for `Range` and `Boundary` creation using primitives and a builder to build a Range.

```java
Range<Long> range = Range.unbounded();

Range<Long> range = Range.greaterThanOrEquals(10L).andLessThanOrEquals(20L);

Range<Double> range = Range.from(10d, 20);

Boundary<Integer> lower = Boundary.inclusive(10);
Boundary<Integer> upper = Boundary.inclusive(20);

Range<Integer> range = Range.of(lower, upper);
```

---

Related ticket: [DATACMNS-1050](https://jira.spring.io/browse/DATACMNS-1050).