### PR TITLE
DATACMNS-1059 - Alter QuerydslPredicateExecutor.findOne to return Optional<T>.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1059-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/querydsl/QuerydslPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/querydsl/QuerydslPredicateExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.querydsl;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -24,26 +26,27 @@ import com.querydsl.core.types.Predicate;
 
 /**
  * Interface to allow execution of QueryDsl {@link Predicate} instances.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public interface QuerydslPredicateExecutor<T> {
 
 	/**
-	 * Returns a single entity matching the given {@link Predicate} or {@literal null} if none was found.
-	 * 
+	 * Returns a single entity matching the given {@link Predicate} or {@link Optional#empty()} if none was found.
+	 *
 	 * @param predicate can be {@literal null}.
-	 * @return a single entity matching the given {@link Predicate} or {@literal null} if none was found.
+	 * @return a single entity matching the given {@link Predicate} or {@link Optional#empty()} if none was found.
 	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if the predicate yields more than one
 	 *           result.
 	 */
-	T findOne(Predicate predicate);
+	Optional<T> findOne(Predicate predicate);
 
 	/**
 	 * Returns all entities matching the given {@link Predicate}. In case no match could be found an empty
 	 * {@link Iterable} is returned.
-	 * 
+	 *
 	 * @param predicate can be {@literal null}.
 	 * @return all entities matching the given {@link Predicate}.
 	 */
@@ -52,7 +55,7 @@ public interface QuerydslPredicateExecutor<T> {
 	/**
 	 * Returns all entities matching the given {@link Predicate} applying the given {@link Sort}. In case no match could
 	 * be found an empty {@link Iterable} is returned.
-	 * 
+	 *
 	 * @param predicate can be {@literal null}.
 	 * @param sort the {@link Sort} specification to sort the results by, must not be {@literal null}.
 	 * @return all entities matching the given {@link Predicate}.
@@ -63,16 +66,16 @@ public interface QuerydslPredicateExecutor<T> {
 	/**
 	 * Returns all entities matching the given {@link Predicate} applying the given {@link OrderSpecifier}s. In case no
 	 * match could be found an empty {@link Iterable} is returned.
-	 * 
+	 *
 	 * @param predicate can be {@literal null}.
-	 * @param orders the {@link OrderSpecifier}s to sort the results by
+	 * @param orders the {@link OrderSpecifier}s to sort the results by.
 	 * @return all entities matching the given {@link Predicate} applying the given {@link OrderSpecifier}s.
 	 */
 	Iterable<T> findAll(Predicate predicate, OrderSpecifier<?>... orders);
 
 	/**
 	 * Returns all entities ordered by the given {@link OrderSpecifier}s.
-	 * 
+	 *
 	 * @param orders the {@link OrderSpecifier}s to sort the results by.
 	 * @return all entities ordered by the given {@link OrderSpecifier}s.
 	 */
@@ -81,7 +84,7 @@ public interface QuerydslPredicateExecutor<T> {
 	/**
 	 * Returns a {@link Page} of entities matching the given {@link Predicate}. In case no match could be found, an empty
 	 * {@link Page} is returned.
-	 * 
+	 *
 	 * @param predicate can be {@literal null}.
 	 * @param pageable must not be {@literal null}.
 	 * @return a {@link Page} of entities matching the given {@link Predicate}.
@@ -90,7 +93,7 @@ public interface QuerydslPredicateExecutor<T> {
 
 	/**
 	 * Returns the number of instances matching the given {@link Predicate}.
-	 * 
+	 *
 	 * @param predicate the {@link Predicate} to count instances for, can be {@literal null}.
 	 * @return the number of instances matching the {@link Predicate}.
 	 */


### PR DESCRIPTION
We now return `Optional<T>` for `findOne(Predicate)` aligning the return type to the ones used in `CrudRepository`.