### PR TITLE
DATACMNS-1067 - Fix not to call @AfterDomainEventPublication method from Collection of entities.

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/EventPublishingRepositoryProxyPostProcessor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/EventPublishingRepositoryProxyPostProcessor.java
@@ -44,6 +44,7 @@ import org.springframework.util.ReflectionUtils;
  * 
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Yuki Yoshida
  * @since 1.13
  * @soundtrack Henrik Freischlader Trio - Master Plan (Openness)
  */
@@ -164,13 +165,14 @@ public class EventPublishingRepositoryProxyPostProcessor implements RepositoryPr
 			}
 
 			for (Object aggregateRoot : asCollection(object)) {
-				for (Object event : asCollection(ReflectionUtils.invokeMethod(publishingMethod, aggregateRoot))) {
+				Collection<Object> events = asCollection(ReflectionUtils.invokeMethod(publishingMethod, aggregateRoot));
+				for (Object event : events) {
 					publisher.publishEvent(event);
 				}
-			}
 
-			if (clearingMethod != null) {
-				ReflectionUtils.invokeMethod(clearingMethod, object);
+				if (clearingMethod != null && !events.isEmpty()) {
+					ReflectionUtils.invokeMethod(clearingMethod, aggregateRoot);
+				}
 			}
 		}
 


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

I've fixed below ticket, please review.
https://jira.spring.io/browse/DATACMNS-1067



