### PR TITLE
DATACMNS-1026 ExtensionAwareEvaluationContextProvider now returns all overloaded methods as functions

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/EvaluationContextExtensionInformation.java
+++ b/src/main/java/org/springframework/data/repository/query/EvaluationContextExtensionInformation.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.data.repository.query.EvaluationContextExtensionInformation.ExtensionTypeInformation.PublicMethodAndFieldFilter;
-import org.springframework.data.repository.query.FunctionsMap.NameAndArgumentCount;
+import org.springframework.data.repository.query.Functions.NameAndArgumentCount;
 import org.springframework.data.repository.query.spi.EvaluationContextExtension;
 import org.springframework.data.repository.query.spi.Function;
 import org.springframework.data.util.MultiValueMapCollector;

--- a/src/main/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProvider.java
@@ -316,11 +316,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		 */
 		private Optional<MethodExecutor> getMethodExecutor(EvaluationContextExtensionAdapter adapter, String name,
 				List<TypeDescriptor> argumentTypes) {
-
-			FunctionsMap functions = adapter.getFunctions();
-
-			Optional<Function> function = functions.get(name, argumentTypes);
-			return function.map(FunctionMethodExecutor::new);
+			return adapter.getFunctions().get(name, argumentTypes).map(FunctionMethodExecutor::new);
 		}
 
 		/**
@@ -389,7 +385,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 
 		private final EvaluationContextExtension extension;
 
-		private final FunctionsMap functions = new FunctionsMap();
+		private final Functions functions = new Functions();
 		private final Map<String, Object> properties;
 
 		/**
@@ -435,7 +431,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		 * 
 		 * @return all exposed functions.
 		 */
-		FunctionsMap getFunctions() {
+		Functions getFunctions() {
 			return this.functions;
 		}
 

--- a/src/main/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProvider.java
@@ -80,7 +80,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	/**
 	 * Creates a new {@link ExtensionAwareEvaluationContextProvider} for the given {@link EvaluationContextExtension}s.
 	 * 
-	 * @param adapters must not be {@literal null}.
+	 * @param extensions must not be {@literal null}.
 	 */
 	public ExtensionAwareEvaluationContextProvider(List<? extends EvaluationContextExtension> extensions) {
 
@@ -210,7 +210,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		/**
 		 * Creates a new {@link ExtensionAwarePropertyAccessor} for the given {@link EvaluationContextExtension}s.
 		 * 
-		 * @param adapters must not be {@literal null}.
+		 * @param extensions must not be {@literal null}.
 		 */
 		public ExtensionAwarePropertyAccessor(List<? extends EvaluationContextExtension> extensions) {
 
@@ -307,12 +307,12 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		}
 
 		/**
-		 * Returns a {@link MethodExecutor}
+		 * Returns a {@link MethodExecutor} wrapping a function from the adapter passed in as an argument.
 		 * 
-		 * @param adapter
-		 * @param name
-		 * @param argumentTypes
-		 * @return
+		 * @param adapter the source of functions to consider.
+		 * @param name the name of the function
+		 * @param argumentTypes the types of the arguments that the function must accept.
+		 * @return a matching {@link MethodExecutor}
 		 */
 		private Optional<MethodExecutor> getMethodExecutor(EvaluationContextExtensionAdapter adapter, String name,
 				List<TypeDescriptor> argumentTypes) {
@@ -329,7 +329,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		 * 
 		 * @param extension must not be {@literal null}.
 		 * @param name must not be {@literal null} or empty.
-		 * @return
+		 * @return a {@link TypedValue} matching the given parameters.
 		 */
 		private TypedValue lookupPropertyFrom(EvaluationContextExtensionAdapter extension, String name) {
 
@@ -424,25 +424,25 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		/**
 		 * Returns the extension identifier.
 		 * 
-		 * @return
+		 * @return the id of the extension
 		 */
-		public String getExtensionId() {
+		String getExtensionId() {
 			return extension.getExtensionId();
 		}
 
 		/**
 		 * Returns all functions exposed.
 		 * 
-		 * @return
+		 * @return all exposed functions.
 		 */
-		public FunctionsMap getFunctions() {
+		FunctionsMap getFunctions() {
 			return this.functions;
 		}
 
 		/**
 		 * Returns all properties exposed. Note, the value of a property can be a {@link Function} in turn
 		 * 
-		 * @return
+		 * @return a map from property name to property value.
 		 */
 		public Map<String, Object> getProperties() {
 			return this.properties;

--- a/src/main/java/org/springframework/data/repository/query/Functions.java
+++ b/src/main/java/org/springframework/data/repository/query/Functions.java
@@ -101,11 +101,23 @@ class Functions {
 		}
 
 		Optional<Function> exactMatch = candidates.stream().filter(f -> f.supportsExact(argumentTypes)).findFirst();
-		if (exactMatch.isPresent()) {
-			return exactMatch;
+		if (!exactMatch.isPresent()) {
+			throw new IllegalStateException(createErrorMessage(candidates, argumentTypes));
 		}
 
-		throw new IllegalStateException("There are multiple matching methods.");
+		return exactMatch;
+	}
+
+	private static String createErrorMessage(List<Function> candidates, List<TypeDescriptor> argumentTypes) {
+
+		String argumentTypeString = String.join( //
+				",", //
+				argumentTypes.stream().map(TypeDescriptor::getName).collect(Collectors.toList()));
+
+		String messageTemplate = "There are multiple matching methods of name '%s' for parameter types (%s), but no "
+				+ "exact match. Make sure to provide only one matching overload or one with exactly those types.";
+
+		return String.format(messageTemplate, candidates.get(0).getName(), argumentTypeString);
 	}
 
 	@Value

--- a/src/main/java/org/springframework/data/repository/query/FunctionsMap.java
+++ b/src/main/java/org/springframework/data/repository/query/FunctionsMap.java
@@ -32,7 +32,7 @@ import org.springframework.util.MultiValueMap;
 import lombok.Data;
 
 /**
- * {@link MultiValueMap} like datastructure to keep lists of
+ * {@link MultiValueMap} like data structure to keep lists of
  * {@link org.springframework.data.repository.query.spi.Function}s indexed by name and argument list length, where the
  * value lists are actually unique with respect to the signature.
  *

--- a/src/main/java/org/springframework/data/repository/query/FunctionsMap.java
+++ b/src/main/java/org/springframework/data/repository/query/FunctionsMap.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.data.repository.query.spi.Function;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.MultiValueMap;
+
+import lombok.Data;
+
+/**
+ * {@link MultiValueMap} like datastructure to keep lists of
+ * {@link org.springframework.data.repository.query.spi.Function}s indexed by name and argument list length, where the
+ * value lists are actually unique with respect to the signature.
+ *
+ * @author Jens Schauder
+ * @since 2.0
+ */
+class FunctionsMap {
+
+	private final MultiValueMap<NameAndArgumentCount, Function> functions = CollectionUtils.toMultiValueMap(new HashMap<>());
+
+	void addAll(Map<String, Function> newFunctions) {
+
+		newFunctions.forEach((n, f) -> {
+			NameAndArgumentCount k = new NameAndArgumentCount(n, f.getParameterCount());
+			List<Function> currentElements = get(k);
+			if (!contains(currentElements, f)) {
+				functions.add(k, f);
+			}
+		});
+	}
+
+	void addAll(MultiValueMap<NameAndArgumentCount, Function> newFunctions) {
+
+		newFunctions.forEach((k, list) -> {
+			List<Function> currentElements = get(k);
+			list.forEach(f -> {
+				if (!contains(currentElements, f)) {
+					functions.add(k, f);
+				}
+			});
+		});
+	}
+
+	List<Function> get(NameAndArgumentCount key) {
+		return functions.getOrDefault(key, Collections.emptyList());
+	}
+
+	/**
+	 * Gets the function that best matches the parameters given.
+	 *
+	 * The {@code name} must match, and the {@code argumentTypes} must be compatible with parameter list of the function.
+	 * In order to resolve ambiguity it checks for a method with exactly matching parameter list.
+	 *
+	 * @param name the name of the method
+	 * @param argumentTypes types of arguments that the method must be able to accept
+	 * @return a {@code Function} if a unique on gets found. {@code Optional.empty} if none matches.
+	 *    Throws {@link IllegalStateException} if multiple functions match the parameters.
+	 */
+	Optional<Function> get(String name, List<TypeDescriptor> argumentTypes) {
+
+		Stream<Function> candidates = get(new NameAndArgumentCount(name, argumentTypes.size()))
+				.stream() //
+				.filter(f -> f.supports(argumentTypes));
+		return bestMatch(candidates.collect(Collectors.toList()), argumentTypes);
+	}
+
+	private static boolean contains(List<Function> elements, Function f) {
+		return elements.stream().anyMatch(f::isSignatureEqual);
+	}
+
+	private static Optional<Function> bestMatch(List<Function> candidates, List<TypeDescriptor> argumentTypes) {
+
+		if (candidates.isEmpty()) {
+			return Optional.empty();
+		}
+		if (candidates.size() == 1) {
+			return Optional.of(candidates.get(0));
+		}
+
+		Optional<Function> exactMatch = candidates.stream().filter(f -> f.supportsExact(argumentTypes)).findFirst();
+		if (exactMatch.isPresent()) {
+			return exactMatch;
+		} else {
+			throw new IllegalStateException("There are multiple matching methods.");
+		}
+	}
+
+	@Data
+	static class NameAndArgumentCount {
+		private final String name;
+		private final int count;
+
+		static NameAndArgumentCount of(Method m) {
+			return new NameAndArgumentCount(m.getName(), m.getParameterCount());
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/spi/Function.java
+++ b/src/main/java/org/springframework/data/repository/query/spi/Function.java
@@ -151,7 +151,7 @@ public class Function {
 	}
 
 	/**
-	 * Checks wither this {@code Function} has the same signature as another {@code Function}.
+	 * Checks wether this {@code Function} has the same signature as another {@code Function}.
 	 *
 	 * @param other the {@code Function} to compare {@code this} with.
 	 *

--- a/src/main/java/org/springframework/data/repository/query/spi/Function.java
+++ b/src/main/java/org/springframework/data/repository/query/spi/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.data.repository.query.spi;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.core.convert.TypeDescriptor;
@@ -29,6 +30,7 @@ import org.springframework.util.TypeUtils;
  * 
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Jens Schauder
  * @since 1.9
  */
 public class Function {
@@ -114,5 +116,50 @@ public class Function {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Returns the number of parameters required by the underlying method.
+	 *
+	 * @return
+	 */
+	public int getParameterCount() {
+		return method.getParameterCount();
+	}
+
+	/**
+	 * Checks if the encapsulated method has exactly the argument types as those passed as an argument.
+	 *
+	 * @param argumentTypes a list of {@link TypeDescriptor}s to compare with the argument types of the method
+	 * @return {@code true} if the types are equal, {@code false} otherwise.
+	 */
+	public boolean supportsExact(List<TypeDescriptor> argumentTypes) {
+
+		if (method.getParameterCount() != argumentTypes.size()) {
+			return false;
+		}
+
+		Class<?>[] parameterTypes = method.getParameterTypes();
+
+		for (int i = 0; i < parameterTypes.length; i++) {
+			if (parameterTypes[i] != argumentTypes.get(i).getType()) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks wither this {@code Function} has the same signature as another {@code Function}.
+	 *
+	 * @param other the {@code Function} to compare {@code this} with.
+	 *
+	 * @return {@code true} iff name and argument list are the same.
+	 */
+	public boolean isSignatureEqual(Function other) {
+
+		return getName().equals(other.getName()) //
+				&& Arrays.equals(method.getParameterTypes(), other.method.getParameterTypes());
 	}
 }

--- a/src/main/java/org/springframework/data/util/MultiValueMapCollector.java
+++ b/src/main/java/org/springframework/data/util/MultiValueMapCollector.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.util;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Set;
@@ -33,21 +36,11 @@ import org.springframework.util.MultiValueMap;
  * @author Jens Schauder
  * @since 2.0
  */
+@RequiredArgsConstructor
 public class MultiValueMapCollector<T, K, V> implements Collector<T, MultiValueMap<K, V>, MultiValueMap<K, V>> {
 
-	private final Function<T, K> keyFunction;
-	private final Function<T, V> valueFunction;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param keyFunction {@link Function} to create a key from an element of the {@link java.util.stream.Stream}
-	 * @param valueFunction {@link Function} to create a value from an element of the {@link java.util.stream.Stream}
-	 */
-	public MultiValueMapCollector(Function<T, K> keyFunction, Function<T, V> valueFunction) {
-		this.keyFunction = keyFunction;
-		this.valueFunction = valueFunction;
-	}
+	@NonNull private final Function<T, K> keyFunction;
+	@NonNull private final Function<T, V> valueFunction;
 
 	/*
 	 * (non-Javadoc)
@@ -58,7 +51,6 @@ public class MultiValueMapCollector<T, K, V> implements Collector<T, MultiValueM
 		return () -> CollectionUtils.toMultiValueMap(new HashMap<>());
 	}
 
-
 	/*
 	 * (non-Javadoc)
 	 * @see java.util.stream.Collector#accumulator()
@@ -68,7 +60,6 @@ public class MultiValueMapCollector<T, K, V> implements Collector<T, MultiValueM
 		return (map, t) -> map.add(keyFunction.apply(t), valueFunction.apply(t));
 	}
 
-
 	/*
 	 * (non-Javadoc)
 	 * @see java.util.stream.Collector#combiner()
@@ -76,15 +67,15 @@ public class MultiValueMapCollector<T, K, V> implements Collector<T, MultiValueM
 	@Override
 	public BinaryOperator<MultiValueMap<K, V>> combiner() {
 
-		return (map1,map2) -> {
+		return (map1, map2) -> {
 
 			for (K key : map2.keySet()) {
 				map1.addAll(key, map2.get(key));
 			}
+
 			return map1;
 		};
 	}
-
 
 	/*
 	 * (non-Javadoc)
@@ -92,9 +83,8 @@ public class MultiValueMapCollector<T, K, V> implements Collector<T, MultiValueM
 	 */
 	@Override
 	public Function<MultiValueMap<K, V>, MultiValueMap<K, V>> finisher() {
-		return it -> it;
+		return Function.identity();
 	}
-
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/util/MultiValueMapCollector.java
+++ b/src/main/java/org/springframework/data/util/MultiValueMapCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.util;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * A {@link Collector} for building a {@link MultiValueMap} from a {@link java.util.stream.Stream}.
+ *
+ * @author Jens Schauder
+ * @since 2.0
+ */
+public class MultiValueMapCollector<T, K, V> implements Collector<T, MultiValueMap<K, V>, MultiValueMap<K, V>> {
+
+	private final Function<T, K> keyFunction;
+	private final Function<T, V> valueFunction;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param keyFunction {@link Function} to create a key from an element of the {@link java.util.stream.Stream}
+	 * @param valueFunction {@link Function} to create a value from an element of the {@link java.util.stream.Stream}
+	 */
+	public MultiValueMapCollector(Function<T, K> keyFunction, Function<T, V> valueFunction) {
+		this.keyFunction = keyFunction;
+		this.valueFunction = valueFunction;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.stream.Collector#supplier()
+	 */
+	@Override
+	public Supplier<MultiValueMap<K, V>> supplier() {
+		return () -> CollectionUtils.toMultiValueMap(new HashMap<>());
+	}
+
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.stream.Collector#accumulator()
+	 */
+	@Override
+	public BiConsumer<MultiValueMap<K, V>, T> accumulator() {
+		return (map, t) -> map.add(keyFunction.apply(t), valueFunction.apply(t));
+	}
+
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.stream.Collector#combiner()
+	 */
+	@Override
+	public BinaryOperator<MultiValueMap<K, V>> combiner() {
+
+		return (map1,map2) -> {
+
+			for (K key : map2.keySet()) {
+				map1.addAll(key, map2.get(key));
+			}
+			return map1;
+		};
+	}
+
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.stream.Collector#finisher()
+	 */
+	@Override
+	public Function<MultiValueMap<K, V>, MultiValueMap<K, V>> finisher() {
+		return it -> it;
+	}
+
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.stream.Collector#characteristics()
+	 */
+	@Override
+	public Set<Characteristics> characteristics() {
+		return EnumSet.of(Characteristics.IDENTITY_FINISH, Characteristics.UNORDERED);
+	}
+}

--- a/src/main/java/org/springframework/data/util/StreamUtils.java
+++ b/src/main/java/org/springframework/data/util/StreamUtils.java
@@ -23,11 +23,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
 
 /**
  * Spring Data specific Java {@link Stream} utility methods and classes.
@@ -76,5 +78,16 @@ public interface StreamUtils {
 	 */
 	public static <T> Collector<T, ?, Set<T>> toUnmodifiableSet() {
 		return collectingAndThen(toSet(), Collections::unmodifiableSet);
+	}
+
+	/**
+	 * Returns a {@link Collector} to create a {@link MultiValueMap}.
+	 *
+	 * @param keyFunction {@link Function} to create a key from an element of the {@link java.util.stream.Stream}
+	 * @param valueFunction {@link Function} to create a value from an element of the {@link java.util.stream.Stream}
+	 */
+	public static <T, K, V> Collector<T, MultiValueMap<K, V>, MultiValueMap<K, V>> toMultiMap(Function<T, K> keyFunction,
+			Function<T, V> valueFunction) {
+		return new MultiValueMapCollector<T, K, V>(keyFunction, valueFunction);
 	}
 }

--- a/src/test/java/org/springframework/data/mapping/model/ConvertingPropertyAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ConvertingPropertyAccessorUnitTests.java
@@ -59,7 +59,8 @@ public class ConvertingPropertyAccessorUnitTests {
 		Entity entity = new Entity();
 		entity.id = 1L;
 
-		assertThat(getIdProperty()).hasValueSatisfying(it -> assertThat(getAccessor(entity, CONVERSION_SERVICE).getProperty(it, String.class)).hasValue("1"));
+		assertThat(getIdProperty()).hasValueSatisfying(
+				it -> assertThat(getAccessor(entity, CONVERSION_SERVICE).getProperty(it, String.class)).hasValue("1"));
 	}
 
 	@Test // DATACMNS-596

--- a/src/test/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProviderUnitTests.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -225,13 +224,7 @@ public class ExtensionAwareEvaluationContextProviderUnitTests {
 	@Test // DATACMNS-1026
 	public void overloadedMethodsGetResolved() throws Exception {
 
-		provider = new ExtensionAwareEvaluationContextProvider(
-				Collections.singletonList(new DummyExtension("_first", "first") {
-					@Override
-					public Object getRootObject() {
-						return new RootWithOverloads();
-					}
-				}));
+		provider = createContextProviderWithOverloads();
 
 		// from the root object
 		assertThat(evaluateExpression("method()")).isEqualTo("zero");
@@ -247,13 +240,7 @@ public class ExtensionAwareEvaluationContextProviderUnitTests {
 	@Test // DATACMNS-1026
 	public void methodFromRootObjectOverwritesMethodFromExtension() throws Exception {
 
-		provider = new ExtensionAwareEvaluationContextProvider(
-				Collections.singletonList(new DummyExtension("_first", "first") {
-					@Override
-					public Object getRootObject() {
-						return new RootWithOverloads();
-					}
-				}));
+		provider = createContextProviderWithOverloads();
 
 		assertThat(evaluateExpression("ambiguous()")).isEqualTo("from-root");
 	}
@@ -261,13 +248,7 @@ public class ExtensionAwareEvaluationContextProviderUnitTests {
 	@Test // DATACMNS-1026
 	public void aliasedMethodOverwritesMethodFromRootObject() throws Exception {
 
-		provider = new ExtensionAwareEvaluationContextProvider(
-				Collections.singletonList(new DummyExtension("_first", "first") {
-					@Override
-					public Object getRootObject() {
-						return new RootWithOverloads();
-					}
-				}));
+		provider = createContextProviderWithOverloads();
 
 		assertThat(evaluateExpression("aliasedMethod()")).isEqualTo("methodResult");
 	}
@@ -275,33 +256,29 @@ public class ExtensionAwareEvaluationContextProviderUnitTests {
 	@Test // DATACMNS-1026
 	public void exactMatchIsPreferred() throws Exception {
 
-		provider = new ExtensionAwareEvaluationContextProvider(
-				Collections.singletonList(new DummyExtension("_first", "first") {
-					@Override
-					public Object getRootObject() {
-						return new RootWithOverloads();
-					}
-				}));
+		provider = createContextProviderWithOverloads();
 
 		assertThat(evaluateExpression("ambiguousOverloaded('aString')")).isEqualTo("string");
 	}
 
-
 	@Test(expected = IllegalStateException.class) // DATACMNS-1026
 	public void throwsExceptionWhenStillAmbiguous() throws Exception {
 
-		provider = new ExtensionAwareEvaluationContextProvider(
-				Collections.singletonList(new DummyExtension("_first", "first") {
+		provider = createContextProviderWithOverloads();
+
+		evaluateExpression("ambiguousOverloaded(23)");
+	}
+
+	private ExtensionAwareEvaluationContextProvider createContextProviderWithOverloads() {
+
+		return new ExtensionAwareEvaluationContextProvider(Collections.singletonList( //
+				new DummyExtension("_first", "first") {
 					@Override
 					public Object getRootObject() {
 						return new RootWithOverloads();
 					}
 				}));
-
-		evaluateExpression("ambiguousOverloaded(23)");
 	}
-
-
 
 	@RequiredArgsConstructor
 	public static class DummyExtension extends EvaluationContextExtensionSupport {

--- a/src/test/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProviderUnitTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.domain.PageRequest;
@@ -261,12 +262,15 @@ public class ExtensionAwareEvaluationContextProviderUnitTests {
 		assertThat(evaluateExpression("ambiguousOverloaded('aString')")).isEqualTo("string");
 	}
 
-	@Test(expected = IllegalStateException.class) // DATACMNS-1026
+	@Test // DATACMNS-1026
 	public void throwsExceptionWhenStillAmbiguous() throws Exception {
 
 		provider = createContextProviderWithOverloads();
 
-		evaluateExpression("ambiguousOverloaded(23)");
+		assertThatExceptionOfType(IllegalStateException.class) //
+				.isThrownBy(() -> evaluateExpression("ambiguousOverloaded(23)")) //
+				.withMessageContaining("ambiguousOverloaded") //
+				.withMessageContaining("(java.lang.Integer)");
 	}
 
 	private ExtensionAwareEvaluationContextProvider createContextProviderWithOverloads() {


### PR DESCRIPTION

All overloaded methods are now available in SPeL expressions.

The key of the Map used for collecting methods is now the name and the length of the argument list.

It is also actually a MultiValueMap to allow multiple overloaded methods.

Among methods with identical argument list from different sources in the same extension (extension, root object, aliases) the last one in the order in parens wins.

If there is more than one method for an application the following rules are applied:

If there is one method with exact matching types in the argument list it is used. Otherwise, an exception is thrown.