### PR TITLE
Typo @PageableDefaults - extra "s"

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -945,7 +945,7 @@ public String showUsers(Model model,
 
 you have to populate `foo_page` and `bar_page` etc.
 
-The default `Pageable` handed into the method is equivalent to a `new PageRequest(0, 20)` but can be customized using the `@PageableDefaults` annotation on the `Pageable` parameter.
+The default `Pageable` handed into the method is equivalent to a `new PageRequest(0, 20)` but can be customized using the `@PageableDefault` annotation on the `Pageable` parameter.
 
 [[core.web.pageables]]
 ==== Hypermedia support for Pageables

--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
@@ -91,7 +91,7 @@ public class PageableHandlerMethodArgumentResolver implements PageableArgumentRe
 
 	/**
 	 * Configures the {@link Pageable} to be used as fallback in case no {@link PageableDefault} or
-	 * {@link PageableDefaults} (the latter only supported in legacy mode) can be found at the method parameter to be
+	 * {@link PageableDefault} (the latter only supported in legacy mode) can be found at the method parameter to be
 	 * resolved.
 	 * <p>
 	 * If you set this to {@literal Optional#empty()}, be aware that you controller methods will get {@literal null}


### PR DESCRIPTION
Annotation `@PageableDefaults` does not exist. Exact spelling is `@PageableDefault`.


