### PR TITLE
DATACMNS-1074 - Cache MethodHandles of default methods after lookup.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
+	<version>2.0.0.DATACMNS-1074-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
We now cache method handles after lookup to reuse them and prevent subsequent lookups.

MethodHandle lookup is expensive, in particular, the lookup uses exceptions as control flow [1] during speculative lookup [2].

[1] http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/5b86f66575b7/src/share/classes/java/lang/invoke/MemberName.java#l978
[2] http://mail.openjdk.java.net/pipermail/core-libs-dev/2016-August/042770.html