### PR TITLE
DATACMNS-102 - Allow Repositories to be composed of an arbitrary number of implementation classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
+	<version>2.0.0.DATACMNS-102-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
+import org.springframework.data.util.Streamable;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -64,7 +65,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfiguration#getBasePackages()
 	 */
-	public Iterable<String> getBasePackages() {
+	public Streamable<String> getBasePackages() {
 		return configurationSource.getBasePackages();
 	}
 
@@ -161,7 +162,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	 * @see org.springframework.data.repository.config.RepositoryConfiguration#getExcludeFilters()
 	 */
 	@Override
-	public Iterable<TypeFilter> getExcludeFilters() {
+	public Streamable<TypeFilter> getExcludeFilters() {
 		return configurationSource.getExcludeFilters();
 	}
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
 
 /**
  * Builder to create {@link BeanDefinitionBuilder} instance to eventually create Spring Data repository instances.
- * 
+ *
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Peter Rietzler
@@ -51,7 +51,7 @@ class RepositoryBeanDefinitionBuilder {
 	/**
 	 * Creates a new {@link RepositoryBeanDefinitionBuilder} from the given {@link BeanDefinitionRegistry},
 	 * {@link RepositoryConfigurationExtension} and {@link ResourceLoader}.
-	 * 
+	 *
 	 * @param registry must not be {@literal null}.
 	 * @param extension must not be {@literal null}.
 	 * @param resourceLoader must not be {@literal null}.
@@ -75,7 +75,7 @@ class RepositoryBeanDefinitionBuilder {
 	/**
 	 * Builds a new {@link BeanDefinitionBuilder} from the given {@link BeanDefinitionRegistry} and {@link ResourceLoader}
 	 * .
-	 * 
+	 *
 	 * @param configuration must not be {@literal null}.
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.repository.query.QueryLookupStrategy;
+import org.springframework.data.util.Streamable;
 
 /**
  * Configuration information for a single repository instance.
@@ -33,7 +34,7 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 *
 	 * @return
 	 */
-	Iterable<String> getBasePackages();
+	Streamable<String> getBasePackages();
 
 	/**
 	 * Returns the interface name of the repository.
@@ -117,5 +118,5 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 *
 	 * @return
 	 */
-	Iterable<TypeFilter> getExcludeFilters();
+	Streamable<TypeFilter> getExcludeFilters();
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -22,28 +22,28 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
 
 /**
  * Configuration information for a single repository instance.
- * 
+ *
  * @author Oliver Gierke
  */
 public interface RepositoryConfiguration<T extends RepositoryConfigurationSource> {
 
 	/**
 	 * Returns the base packages that the repository was scanned under.
-	 * 
+	 *
 	 * @return
 	 */
 	Iterable<String> getBasePackages();
 
 	/**
 	 * Returns the interface name of the repository.
-	 * 
+	 *
 	 * @return
 	 */
 	String getRepositoryInterface();
 
 	/**
 	 * Returns the key to resolve a {@link QueryLookupStrategy} from eventually.
-	 * 
+	 *
 	 * @see QueryLookupStrategy.Key
 	 * @return
 	 */
@@ -51,21 +51,21 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 
 	/**
 	 * Returns the location of the file containing Spring Data named queries.
-	 * 
+	 *
 	 * @return
 	 */
 	Optional<String> getNamedQueriesLocation();
 
 	/**
 	 * Returns the class name of the custom implementation.
-	 * 
+	 *
 	 * @return
 	 */
 	String getImplementationClassName();
 
 	/**
 	 * Returns the bean name of the custom implementation.
-	 * 
+	 *
 	 * @return
 	 */
 	String getImplementationBeanName();
@@ -73,7 +73,7 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	/**
 	 * Returns the name of the repository base class to be used or {@literal null} if the store specific defaults shall be
 	 * applied.
-	 * 
+	 *
 	 * @return
 	 * @since 1.11
 	 */
@@ -81,35 +81,35 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 
 	/**
 	 * Returns the name of the repository factory bean class to be used.
-	 * 
+	 *
 	 * @return
 	 */
 	String getRepositoryFactoryBeanClassName();
 
 	/**
 	 * Returns the source of the {@link RepositoryConfiguration}.
-	 * 
+	 *
 	 * @return
 	 */
 	Object getSource();
 
 	/**
 	 * Returns the {@link RepositoryConfigurationSource} that backs the {@link RepositoryConfiguration}.
-	 * 
+	 *
 	 * @return
 	 */
 	T getConfigurationSource();
 
 	/**
 	 * Returns whether to initialize the repository proxy lazily.
-	 * 
+	 *
 	 * @return
 	 */
 	boolean isLazyInit();
 
 	/**
 	 * Returns the {@link TypeFilter}s to be used to exclude packages from repository scanning.
-	 * 
+	 *
 	 * @return
 	 */
 	Iterable<TypeFilter> getExcludeFilters();

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
  * Configuration information for a single repository instance.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public interface RepositoryConfiguration<T extends RepositoryConfigurationSource> {
 
@@ -60,14 +61,18 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 * Returns the class name of the custom implementation.
 	 *
 	 * @return
+	 * @deprecated since 2.0. Use repository compositions by creating mixins.
 	 */
+	@Deprecated
 	String getImplementationClassName();
 
 	/**
 	 * Returns the bean name of the custom implementation.
 	 *
 	 * @return
+	 * @deprecated since 2.0. Use repository compositions by creating mixins.
 	 */
+	@Deprecated
 	String getImplementationBeanName();
 
 	/**

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
@@ -28,13 +28,13 @@ import org.springframework.util.StringUtils;
  * Fragment configuration consisting of an interface name and the implementation class name.
  *
  * @author Mark Paluch
+ * @author Oliver Gierke
  * @since 2.0
  */
 @Value
 public class RepositoryFragmentConfiguration {
 
-	String interfaceName;
-	String className;
+	String interfaceName, className;
 	Optional<AbstractBeanDefinition> beanDefinition;
 
 	/**
@@ -67,8 +67,8 @@ public class RepositoryFragmentConfiguration {
 		Assert.notNull(beanDefinition, "Bean definition must not be null!");
 
 		this.interfaceName = interfaceName;
-		this.beanDefinition = Optional.of(beanDefinition);
 		this.className = beanDefinition.getBeanClassName();
+		this.beanDefinition = Optional.of(beanDefinition);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
@@ -33,9 +33,9 @@ import org.springframework.util.StringUtils;
 @Value
 public class RepositoryFragmentConfiguration {
 
-	private final String interfaceName;
-	private final String className;
-	private final Optional<AbstractBeanDefinition> beanDefinition;
+	String interfaceName;
+	String className;
+	Optional<AbstractBeanDefinition> beanDefinition;
 
 	/**
 	 * Creates a {@link RepositoryFragmentConfiguration} given {@code interfaceName} and {@code className} of the

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import lombok.Value;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Fragment configuration consisting of an interface name and the implementation class name.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+@Value
+public class RepositoryFragmentConfiguration {
+
+	private final String interfaceName;
+	private final String className;
+	private final Optional<AbstractBeanDefinition> beanDefinition;
+
+	/**
+	 * Creates a {@link RepositoryFragmentConfiguration} given {@code interfaceName} and {@code className} of the
+	 * implementation.
+	 *
+	 * @param interfaceName must not be {@literal null} or empty.
+	 * @param className must not be {@literal null} or empty.
+	 */
+	public RepositoryFragmentConfiguration(String interfaceName, String className) {
+
+		Assert.hasText(interfaceName, "Interface name must not be null or empty!");
+		Assert.hasText(className, "Class name must not be null or empty!");
+
+		this.interfaceName = interfaceName;
+		this.className = className;
+		this.beanDefinition = Optional.empty();
+	}
+
+	/**
+	 * Creates a {@link RepositoryFragmentConfiguration} given {@code interfaceName} and {@link AbstractBeanDefinition} of
+	 * the implementation.
+	 *
+	 * @param interfaceName must not be {@literal null} or empty.
+	 * @param beanDefinition must not be {@literal null}.
+	 */
+	public RepositoryFragmentConfiguration(String interfaceName, AbstractBeanDefinition beanDefinition) {
+
+		Assert.hasText(interfaceName, "Interface name must not be null or empty!");
+		Assert.notNull(beanDefinition, "Bean definition must not be null!");
+
+		this.interfaceName = interfaceName;
+		this.beanDefinition = Optional.of(beanDefinition);
+		this.className = beanDefinition.getBeanClassName();
+	}
+
+	/**
+	 * @return name of the implementation bean.
+	 */
+	public String getImplementationBeanName() {
+		return StringUtils.uncapitalize(ClassUtils.getShortName(getClassName()));
+	}
+
+	/**
+	 * @return name of the implementation fragment bean.
+	 */
+	public String getFragmentBeanName() {
+		return getImplementationBeanName() + "Fragment";
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/MethodLookup.java
+++ b/src/main/java/org/springframework/data/repository/core/support/MethodLookup.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import lombok.NonNull;
+import lombok.Value;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.util.Assert;
+
+/**
+ * Strategy interface providing {@link MethodPredicate predicates} to resolve a method called on a composite to its
+ * implementation method.
+ * <p />
+ * {@link MethodPredicate Predicates} are ordered by filtering priority and applied individually. If a predicate does
+ * not yield any positive match, the next predicate is applied.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see RepositoryComposition
+ */
+@FunctionalInterface
+public interface MethodLookup {
+
+	/**
+	 * Return an ordered {@link List} of {@link MethodPredicate}. Each predicate is applied individually. If any
+	 * {@link MethodPredicate} matches, the tested candidate {@link Method} passes the filter.
+	 *
+	 * @return {@link List} of {@link MethodPredicate}.
+	 */
+	List<MethodPredicate> getLookups();
+
+	/**
+	 * Returns a composed {@link MethodLookup} that represents a concatenation of this predicate and another. When
+	 * evaluating the composed method lookup, if this lookup evaluates {@code true}, then the {@code other} method lookup
+	 * is not evaluated.
+	 *
+	 * @param other must not be {@literal null}.
+	 * @return the composed {@link MethodLookup}.
+	 */
+	default MethodLookup and(MethodLookup other) {
+
+		Assert.notNull(other, "Other method lookup must not be null!");
+
+		return () -> Stream.concat(getLookups().stream(), other.getLookups().stream()).collect(Collectors.toList());
+	}
+
+	/**
+	 * A method predicate to be applied on the {@link InvokedMethod} and {@link Method method candidate}.
+	 */
+	@FunctionalInterface
+	interface MethodPredicate extends BiPredicate<InvokedMethod, Method> {
+
+		@Override
+		boolean test(InvokedMethod invokedMethod, Method candidate);
+	}
+
+	/**
+	 * Value object representing an invoked {@link Method}.
+	 */
+	@Value(staticConstructor = "of")
+	class InvokedMethod {
+
+		private final @NonNull Method method;
+
+		public Class<?> getDeclaringClass() {
+			return method.getDeclaringClass();
+		}
+
+		public String getName() {
+			return method.getName();
+		}
+
+		public Class<?>[] getParameterTypes() {
+			return method.getParameterTypes();
+		}
+
+		public int getParameterCount() {
+			return method.getParameterCount();
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/MethodLookups.java
+++ b/src/main/java/org/springframework/data/repository/core/support/MethodLookups.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import static org.springframework.core.GenericTypeResolver.*;
+
+import lombok.Value;
+
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.MethodLookup.MethodPredicate;
+import org.springframework.data.repository.util.QueryExecutionConverters;
+import org.springframework.data.repository.util.ReactiveWrapperConverters;
+import org.springframework.util.Assert;
+
+/**
+ * Implementations of method lookup functions.
+ *
+ * @author Mark Paluch
+ */
+public abstract class MethodLookups {
+
+	private MethodLookups() {}
+
+	/**
+	 * Direct method lookup filtering on exact method name, parameter count and parameter types.
+	 *
+	 * @return direct method lookup.
+	 */
+	public static MethodLookup direct() {
+
+		MethodPredicate direct = (invoked, candidate) -> candidate.getName().equals(invoked.getName())
+				&& candidate.getParameterCount() == invoked.getParameterCount()
+				&& Arrays.equals(candidate.getParameterTypes(), invoked.getParameterTypes());
+
+		return () -> Collections.singletonList(direct);
+	}
+
+	/**
+	 * Repository type-aware method lookup composed of {@link #direct()} and {@link RepositoryAwareMethodLookup}.
+	 * <p/>
+	 * Repository-aware lookups resolve generic types from the repository declaration to verify assignability to Id/domain
+	 * types. This lookup also permits assignable method signatures but prefers {@link #direct()} matches.
+	 *
+	 * @param repositoryMetadata must not be {@literal null}.
+	 * @return the composed, repository-aware method lookup.
+	 * @see #direct()
+	 */
+	public static MethodLookup forRepositoryTypes(RepositoryMetadata repositoryMetadata) {
+		return direct().and(new RepositoryAwareMethodLookup(repositoryMetadata));
+	}
+
+	/**
+	 * Repository type-aware method lookup composed of {@link #direct()} and {@link ReactiveTypeInteropMethodLookup}.
+	 * <p/>
+	 * This method lookup considers adaptability of reactive types in method signatures. Repository methods accepting a
+	 * reactive type can be possibly called with a different reactive type if the reactive type can be adopted to the
+	 * target type. This lookup also permits assignable method signatures and resolves repository id/entity types but
+	 * prefers {@link #direct()} matches.
+	 *
+	 * @param repositoryMetadata must not be {@literal null}.
+	 * @return the composed, repository-aware method lookup.
+	 * @see #direct()
+	 * @see #forRepositoryTypes(RepositoryMetadata)
+	 */
+	public static MethodLookup forReactiveTypes(RepositoryMetadata repositoryMetadata) {
+		return direct().and(new ReactiveTypeInteropMethodLookup(repositoryMetadata));
+	}
+
+	/**
+	 * Default {@link MethodLookup} considering repository Id and entity types permitting calls to methods with assignable
+	 * arguments.
+	 *
+	 * @author Mark Paluch
+	 */
+	private static class RepositoryAwareMethodLookup implements MethodLookup {
+
+		private static final TypeVariable<Class<Repository>>[] PARAMETERS = Repository.class.getTypeParameters();
+		private static final String DOMAIN_TYPE_NAME = PARAMETERS[0].getName();
+		private static final String ID_TYPE_NAME = PARAMETERS[1].getName();
+
+		private final ResolvableType entityType;
+		private final ResolvableType idType;
+		private final Class<?> repositoryInterface;
+
+		public RepositoryAwareMethodLookup(RepositoryMetadata repositoryMetadata) {
+
+			this.entityType = ResolvableType.forClass(repositoryMetadata.getDomainType());
+			this.idType = ResolvableType.forClass(repositoryMetadata.getIdType());
+			this.repositoryInterface = repositoryMetadata.getRepositoryInterface();
+		}
+
+		@Override
+		public List<MethodPredicate> getLookups() {
+
+			MethodPredicate detailedComparison = (invoked, candidate) -> Optional.of(candidate)
+					.filter(baseClassMethod -> baseClassMethod.getName().equals(invoked.getName()))// Right name
+					.filter(baseClassMethod -> baseClassMethod.getParameterCount() == invoked.getParameterCount())
+					.filter(baseClassMethod -> parametersMatch(invoked.getMethod(), baseClassMethod))// All parameters match
+					.isPresent();
+
+			return Collections.singletonList(detailedComparison);
+		}
+
+		/**
+		 * Checks whether the given parameter type matches the generic type of the given parameter. Thus when {@literal PK}
+		 * is declared, the method ensures that given method parameter is the primary key type declared in the given
+		 * repository interface e.g.
+		 *
+		 * @param variable must not be {@literal null}.
+		 * @param parameterType must not be {@literal null}.
+		 * @return
+		 */
+		protected boolean matchesGenericType(TypeVariable<?> variable, ResolvableType parameterType) {
+
+			GenericDeclaration declaration = variable.getGenericDeclaration();
+
+			if (declaration instanceof Class) {
+
+				if (ID_TYPE_NAME.equals(variable.getName()) && parameterType.isAssignableFrom(idType)) {
+					return true;
+				}
+
+				Type boundType = variable.getBounds()[0];
+				String referenceName = boundType instanceof TypeVariable ? boundType.toString() : variable.toString();
+
+				return DOMAIN_TYPE_NAME.equals(referenceName) && parameterType.isAssignableFrom(entityType);
+			}
+
+			for (Type type : variable.getBounds()) {
+				if (ResolvableType.forType(type).isAssignableFrom(parameterType)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		 * Checks the given method's parameters to match the ones of the given base class method. Matches generic arguments
+		 * against the ones bound in the given repository interface.
+		 *
+		 * @param invokedMethod
+		 * @param candidate
+		 * @return
+		 */
+		private boolean parametersMatch(Method invokedMethod, Method candidate) {
+
+			Class<?>[] methodParameterTypes = invokedMethod.getParameterTypes();
+			Type[] genericTypes = candidate.getGenericParameterTypes();
+			Class<?>[] types = candidate.getParameterTypes();
+
+			for (int i = 0; i < genericTypes.length; i++) {
+
+				Type genericType = genericTypes[i];
+				Class<?> type = types[i];
+				MethodParameter parameter = new MethodParameter(invokedMethod, i);
+				Class<?> parameterType = resolveParameterType(parameter, repositoryInterface);
+
+				if (genericType instanceof TypeVariable<?>) {
+
+					if (!matchesGenericType((TypeVariable<?>) genericType, ResolvableType.forMethodParameter(parameter))) {
+						return false;
+					}
+
+					continue;
+				}
+
+				if (types[i].equals(parameterType)) {
+					continue;
+				}
+
+				if (!type.isAssignableFrom(parameterType) || !type.equals(methodParameterTypes[i])) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+
+	/**
+	 * Extension to {@link RepositoryAwareMethodLookup} considering reactive type adoption and entity types permitting
+	 * calls to methods with assignable arguments.
+	 *
+	 * @author Mark Paluch
+	 */
+	private static class ReactiveTypeInteropMethodLookup extends RepositoryAwareMethodLookup {
+
+		private final RepositoryMetadata repositoryMetadata;
+
+		public ReactiveTypeInteropMethodLookup(RepositoryMetadata repositoryMetadata) {
+			super(repositoryMetadata);
+			this.repositoryMetadata = repositoryMetadata;
+		}
+
+		@Override
+		public List<MethodPredicate> getLookups() {
+
+			MethodPredicate convertibleComparison = (invokedMethod, candidate) -> {
+
+				List<Supplier<Optional<Method>>> suppliers = new ArrayList<>();
+
+				if (usesParametersWithReactiveWrappers(invokedMethod.getMethod())) {
+					suppliers.add(() -> getMethodCandidate(invokedMethod, candidate, assignableWrapperMatch())); //
+					suppliers.add(() -> getMethodCandidate(invokedMethod, candidate, wrapperConversionMatch()));
+				}
+
+				return suppliers.stream().anyMatch(supplier -> supplier.get().isPresent());
+			};
+
+			MethodPredicate detailedComparison = (invokedMethod, candidate) -> getMethodCandidate(invokedMethod, candidate,
+					matchParameterOrComponentType(repositoryMetadata.getRepositoryInterface())).isPresent();
+
+			return Arrays.asList(convertibleComparison, detailedComparison);
+		}
+
+		/**
+		 * {@link Predicate} to check parameter assignability between a parameters in which the declared parameter may be
+		 * wrapped but supports unwrapping. Usually types like {@link Optional} or {@link java.util.stream.Stream}.
+		 *
+		 * @param repositoryInterface
+		 * @return
+		 * @see QueryExecutionConverters
+		 * @see #matchesGenericType
+		 */
+		private Predicate<ParameterOverrideCriteria> matchParameterOrComponentType(Class<?> repositoryInterface) {
+
+			return (parameterCriteria) -> {
+
+				Class<?> parameterType = resolveParameterType(parameterCriteria.getDeclared(), repositoryInterface);
+				Type genericType = parameterCriteria.getGenericBaseType();
+
+				if (genericType instanceof TypeVariable<?>) {
+
+					if (!matchesGenericType((TypeVariable<?>) genericType,
+							ResolvableType.forMethodParameter(parameterCriteria.getDeclared()))) {
+						return false;
+					}
+				}
+
+				return parameterCriteria.getBaseType().isAssignableFrom(parameterType)
+						&& parameterCriteria.isAssignableFromDeclared();
+			};
+		}
+
+		/**
+		 * Checks whether the type is a wrapper without unwrapping support. Reactive wrappers don't like to be unwrapped.
+		 *
+		 * @param parameterType must not be {@literal null}.
+		 * @return
+		 */
+		private static boolean isNonUnwrappingWrapper(Class<?> parameterType) {
+
+			Assert.notNull(parameterType, "Parameter type must not be null!");
+
+			return QueryExecutionConverters.supports(parameterType)
+					&& !QueryExecutionConverters.supportsUnwrapping(parameterType);
+		}
+
+		/**
+		 * Returns whether the given {@link Method} uses a reactive wrapper type as parameter.
+		 *
+		 * @param method must not be {@literal null}.
+		 * @return
+		 */
+		private static boolean usesParametersWithReactiveWrappers(Method method) {
+
+			Assert.notNull(method, "Method must not be null!");
+
+			return Arrays.stream(method.getParameterTypes())//
+					.anyMatch(ReactiveTypeInteropMethodLookup::isNonUnwrappingWrapper);
+		}
+
+		/**
+		 * Returns a candidate method from the base class for the given one or the method given in the first place if none
+		 * one the base class matches.
+		 *
+		 * @param method must not be {@literal null}.
+		 * @param baseClass must not be {@literal null}.
+		 * @param predicate must not be {@literal null}.
+		 * @return
+		 */
+		private static Optional<Method> getMethodCandidate(InvokedMethod invokedMethod, Method candidate,
+				Predicate<ParameterOverrideCriteria> predicate) {
+
+			return Optional.of(candidate)//
+					.filter(it -> invokedMethod.getName().equals(it.getName()))//
+					.filter(it -> invokedMethod.getParameterCount() == it.getParameterCount())//
+					.filter(it -> parametersMatch(it, invokedMethod.getMethod(), predicate));
+		}
+
+		/**
+		 * Checks the given method's parameters to match the ones of the given base class method. Matches generic arguments
+		 * against the ones bound in the given repository interface.
+		 *
+		 * @param baseClassMethod must not be {@literal null}.
+		 * @param declaredMethod must not be {@literal null}.
+		 * @param predicate must not be {@literal null}.
+		 * @return
+		 */
+		private static boolean parametersMatch(Method baseClassMethod, Method declaredMethod,
+				Predicate<ParameterOverrideCriteria> predicate) {
+
+			return methodParameters(baseClassMethod, declaredMethod).allMatch(predicate);
+		}
+
+		/**
+		 * {@link Predicate} to check whether a method parameter is a {@link #isNonUnwrappingWrapper(Class)} and can be
+		 * converted into a different wrapper. Usually {@link rx.Observable} to {@link org.reactivestreams.Publisher}
+		 * conversion.
+		 *
+		 * @return
+		 */
+		private static Predicate<ParameterOverrideCriteria> wrapperConversionMatch() {
+
+			return (parameterCriteria) -> isNonUnwrappingWrapper(parameterCriteria.getBaseType()) //
+					&& isNonUnwrappingWrapper(parameterCriteria.getDeclaredType()) //
+					&& ReactiveWrapperConverters.canConvert(parameterCriteria.getDeclaredType(), parameterCriteria.getBaseType());
+		}
+
+		/**
+		 * {@link Predicate} to check parameter assignability between a {@link #isNonUnwrappingWrapper(Class)} parameter and
+		 * a declared parameter. Usually {@link reactor.core.publisher.Flux} vs. {@link org.reactivestreams.Publisher}
+		 * conversion.
+		 *
+		 * @return
+		 */
+		private static Predicate<ParameterOverrideCriteria> assignableWrapperMatch() {
+
+			return (parameterCriteria) -> isNonUnwrappingWrapper(parameterCriteria.getBaseType()) //
+					&& isNonUnwrappingWrapper(parameterCriteria.getDeclaredType()) //
+					&& parameterCriteria.getBaseType().isAssignableFrom(parameterCriteria.getDeclaredType());
+		}
+
+		private static Stream<ParameterOverrideCriteria> methodParameters(Method first, Method second) {
+
+			Assert.isTrue(first.getParameterCount() == second.getParameterCount(), "Method parameter count must be equal!");
+
+			return IntStream.range(0, first.getParameterCount()) //
+					.mapToObj(index -> ParameterOverrideCriteria.of(new MethodParameter(first, index),
+							new MethodParameter(second, index)));
+		}
+
+		/**
+		 * Criterion to represent {@link MethodParameter}s from a base method and its declared (overridden) method. Method
+		 * parameters indexes are correlated so {@link ParameterOverrideCriteria} applies only to methods with same
+		 * parameter count.
+		 */
+		@Value(staticConstructor = "of")
+		static class ParameterOverrideCriteria {
+
+			private final MethodParameter base;
+			private final MethodParameter declared;
+
+			/**
+			 * @return base method parameter type.
+			 */
+			public Class<?> getBaseType() {
+				return base.getParameterType();
+			}
+
+			/**
+			 * @return generic base method parameter type.
+			 */
+			public Type getGenericBaseType() {
+				return base.getGenericParameterType();
+			}
+
+			/**
+			 * @return declared method parameter type.
+			 */
+			public Class<?> getDeclaredType() {
+				return declared.getParameterType();
+			}
+
+			public boolean isAssignableFromDeclared() {
+				return getBaseType().isAssignableFrom(getDeclaredType());
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/repository/core/support/MethodLookups.java
+++ b/src/main/java/org/springframework/data/repository/core/support/MethodLookups.java
@@ -46,10 +46,10 @@ import org.springframework.util.Assert;
  * Implementations of method lookup functions.
  *
  * @author Mark Paluch
+ * @author Oliver Gierke
+ * @since 2.0
  */
-public abstract class MethodLookups {
-
-	private MethodLookups() {}
+interface MethodLookups {
 
 	/**
 	 * Direct method lookup filtering on exact method name, parameter count and parameter types.
@@ -102,23 +102,34 @@ public abstract class MethodLookups {
 	 *
 	 * @author Mark Paluch
 	 */
-	private static class RepositoryAwareMethodLookup implements MethodLookup {
+	static class RepositoryAwareMethodLookup implements MethodLookup {
 
-		private static final TypeVariable<Class<Repository>>[] PARAMETERS = Repository.class.getTypeParameters();
+		@SuppressWarnings("rawtypes") private static final TypeVariable<Class<Repository>>[] PARAMETERS = Repository.class
+				.getTypeParameters();
 		private static final String DOMAIN_TYPE_NAME = PARAMETERS[0].getName();
 		private static final String ID_TYPE_NAME = PARAMETERS[1].getName();
 
-		private final ResolvableType entityType;
-		private final ResolvableType idType;
+		private final ResolvableType entityType, idType;
 		private final Class<?> repositoryInterface;
 
+		/**
+		 * Creates a new {@link RepositoryAwareMethodLookup} for the given {@link RepositoryMetadata}.
+		 * 
+		 * @param repositoryMetadata must not be {@literal null}.
+		 */
 		public RepositoryAwareMethodLookup(RepositoryMetadata repositoryMetadata) {
+
+			Assert.notNull(repositoryMetadata, "Repository metadata must not be null!");
 
 			this.entityType = ResolvableType.forClass(repositoryMetadata.getDomainType());
 			this.idType = ResolvableType.forClass(repositoryMetadata.getIdType());
 			this.repositoryInterface = repositoryMetadata.getRepositoryInterface();
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.MethodLookup#getLookups()
+		 */
 		@Override
 		public List<MethodPredicate> getLookups() {
 
@@ -214,15 +225,20 @@ public abstract class MethodLookups {
 	 *
 	 * @author Mark Paluch
 	 */
-	private static class ReactiveTypeInteropMethodLookup extends RepositoryAwareMethodLookup {
+	static class ReactiveTypeInteropMethodLookup extends RepositoryAwareMethodLookup {
 
 		private final RepositoryMetadata repositoryMetadata;
 
 		public ReactiveTypeInteropMethodLookup(RepositoryMetadata repositoryMetadata) {
+
 			super(repositoryMetadata);
 			this.repositoryMetadata = repositoryMetadata;
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.MethodLookups.RepositoryAwareMethodLookup#getLookups()
+		 */
 		@Override
 		public List<MethodPredicate> getLookups() {
 
@@ -408,5 +424,4 @@ public abstract class MethodLookups {
 			}
 		}
 	}
-
 }

--- a/src/main/java/org/springframework/data/repository/core/support/ReactiveRepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/ReactiveRepositoryInformation.java
@@ -15,33 +15,9 @@
  */
 package org.springframework.data.repository.core.support;
 
-import static org.springframework.core.GenericTypeResolver.*;
-import static org.springframework.util.ReflectionUtils.*;
-
-import lombok.Value;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import org.springframework.core.MethodParameter;
-import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
-import org.springframework.data.repository.util.QueryExecutionConverters;
-import org.springframework.data.repository.util.ReactiveWrapperConverters;
-import org.springframework.data.util.Optionals;
-import org.springframework.data.util.Streamable;
-import org.springframework.util.Assert;
 
 /**
  * This {@link RepositoryInformation} uses a {@link ConversionService} to check whether method arguments can be
@@ -50,7 +26,9 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Oliver Gierke
  * @since 2.0
+ * @deprecated as of 2.0, can be deleted...
  */
+@Deprecated
 public class ReactiveRepositoryInformation extends DefaultRepositoryInformation {
 
 	/**
@@ -59,209 +37,10 @@ public class ReactiveRepositoryInformation extends DefaultRepositoryInformation 
 	 *
 	 * @param metadata must not be {@literal null}.
 	 * @param repositoryBaseClass must not be {@literal null}.
-	 * @param customImplementationClass can be {@literal null}.
+	 * @param composition can be {@literal null}.
 	 */
 	public ReactiveRepositoryInformation(RepositoryMetadata metadata, Class<?> repositoryBaseClass,
-			Optional<Class<?>> customImplementationClass) {
-		super(metadata, repositoryBaseClass, customImplementationClass);
-	}
-
-	/**
-	 * Returns the given target class' method if the given method (declared in the repository interface) was also declared
-	 * at the target class. Returns the given method if the given base class does not declare the method given. Takes
-	 * generics into account.
-	 *
-	 * @param method must not be {@literal null}.
-	 * @param baseClass must not be {@literal null}.
-	 * @return
-	 */
-	@Override
-	Method getTargetClassMethod(Method method, Optional<Class<?>> baseClass) {
-
-		Supplier<Optional<Method>> directMatch = () -> baseClass
-				.map(it -> findMethod(it, method.getName(), method.getParameterTypes()));
-
-		Supplier<Optional<Method>> detailedComparison = () -> baseClass.flatMap(it -> {
-
-			List<Supplier<Optional<Method>>> suppliers = new ArrayList<>();
-
-			if (usesParametersWithReactiveWrappers(method)) {
-				suppliers.add(() -> getMethodCandidate(method, it, assignableWrapperMatch())); //
-				suppliers.add(() -> getMethodCandidate(method, it, wrapperConversionMatch()));
-			}
-
-			suppliers.add(() -> getMethodCandidate(method, it, matchParameterOrComponentType(getRepositoryInterface())));
-
-			return Optionals.firstNonEmpty(Streamable.of(suppliers));
-		});
-
-		return Optionals.firstNonEmpty(directMatch, detailedComparison).orElse(method);
-	}
-
-	/**
-	 * {@link Predicate} to check parameter assignability between a parameters in which the declared parameter may be
-	 * wrapped but supports unwrapping. Usually types like {@link java.util.Optional} or {@link java.util.stream.Stream}.
-	 *
-	 * @param repositoryInterface
-	 * @return
-	 * @see QueryExecutionConverters
-	 * @see #matchesGenericType
-	 */
-	private Predicate<ParameterOverrideCriteria> matchParameterOrComponentType(Class<?> repositoryInterface) {
-
-		return (parameterCriteria) -> {
-
-			Class<?> parameterType = resolveParameterType(parameterCriteria.getDeclared(), repositoryInterface);
-			Type genericType = parameterCriteria.getGenericBaseType();
-
-			if (genericType instanceof TypeVariable<?>) {
-
-				if (!matchesGenericType((TypeVariable<?>) genericType,
-						ResolvableType.forMethodParameter(parameterCriteria.getDeclared()))) {
-					return false;
-				}
-			}
-
-			return parameterCriteria.getBaseType().isAssignableFrom(parameterType)
-					&& parameterCriteria.isAssignableFromDeclared();
-		};
-	}
-
-	/**
-	 * Checks whether the type is a wrapper without unwrapping support. Reactive wrappers don't like to be unwrapped.
-	 *
-	 * @param parameterType must not be {@literal null}.
-	 * @return
-	 */
-	private static boolean isNonUnwrappingWrapper(Class<?> parameterType) {
-
-		Assert.notNull(parameterType, "Parameter type must not be null!");
-
-		return QueryExecutionConverters.supports(parameterType)
-				&& !QueryExecutionConverters.supportsUnwrapping(parameterType);
-	}
-
-	/**
-	 * Returns whether the given {@link Method} uses a reactive wrapper type as parameter.
-	 *
-	 * @param method must not be {@literal null}.
-	 * @return
-	 */
-	private static boolean usesParametersWithReactiveWrappers(Method method) {
-
-		Assert.notNull(method, "Method must not be null!");
-
-		return Arrays.stream(method.getParameterTypes())//
-				.anyMatch(ReactiveRepositoryInformation::isNonUnwrappingWrapper);
-	}
-
-	/**
-	 * Returns a candidate method from the base class for the given one or the method given in the first place if none one
-	 * the base class matches.
-	 *
-	 * @param method must not be {@literal null}.
-	 * @param baseClass must not be {@literal null}.
-	 * @param predicate must not be {@literal null}.
-	 * @return
-	 */
-	private static Optional<Method> getMethodCandidate(Method method, Class<?> baseClass,
-			Predicate<ParameterOverrideCriteria> predicate) {
-
-		return Arrays.stream(baseClass.getMethods())//
-				.filter(it -> method.getName().equals(it.getName()))//
-				.filter(it -> method.getParameterCount() == it.getParameterCount())//
-				.filter(it -> parametersMatch(it, method, predicate))//
-				.findFirst();
-	}
-
-	/**
-	 * Checks the given method's parameters to match the ones of the given base class method. Matches generic arguments
-	 * against the ones bound in the given repository interface.
-	 *
-	 * @param baseClassMethod must not be {@literal null}.
-	 * @param declaredMethod must not be {@literal null}.
-	 * @param predicate must not be {@literal null}.
-	 * @return
-	 */
-	private static boolean parametersMatch(Method baseClassMethod, Method declaredMethod,
-			Predicate<ParameterOverrideCriteria> predicate) {
-
-		return methodParameters(baseClassMethod, declaredMethod).allMatch(predicate);
-	}
-
-	/**
-	 * {@link Predicate} to check whether a method parameter is a {@link #isNonUnwrappingWrapper(Class)} and can be
-	 * converted into a different wrapper. Usually {@link rx.Observable} to {@link org.reactivestreams.Publisher}
-	 * conversion.
-	 *
-	 * @return
-	 */
-	private static Predicate<ParameterOverrideCriteria> wrapperConversionMatch() {
-
-		return (parameterCriteria) -> isNonUnwrappingWrapper(parameterCriteria.getBaseType()) //
-				&& isNonUnwrappingWrapper(parameterCriteria.getDeclaredType()) //
-				&& ReactiveWrapperConverters.canConvert(parameterCriteria.getDeclaredType(), parameterCriteria.getBaseType());
-	}
-
-	/**
-	 * {@link Predicate} to check parameter assignability between a {@link #isNonUnwrappingWrapper(Class)} parameter and a
-	 * declared parameter. Usually {@link reactor.core.publisher.Flux} vs. {@link org.reactivestreams.Publisher}
-	 * conversion.
-	 *
-	 * @return
-	 */
-	private static Predicate<ParameterOverrideCriteria> assignableWrapperMatch() {
-
-		return (parameterCriteria) -> isNonUnwrappingWrapper(parameterCriteria.getBaseType()) //
-				&& isNonUnwrappingWrapper(parameterCriteria.getDeclaredType()) //
-				&& parameterCriteria.getBaseType().isAssignableFrom(parameterCriteria.getDeclaredType());
-	}
-
-	private static Stream<ParameterOverrideCriteria> methodParameters(Method first, Method second) {
-
-		Assert.isTrue(first.getParameterCount() == second.getParameterCount(), "Method parameter count must be equal!");
-
-		return IntStream.range(0, first.getParameterCount()) //
-				.mapToObj(index -> ParameterOverrideCriteria.of(new MethodParameter(first, index),
-						new MethodParameter(second, index)));
-
-	}
-
-	/**
-	 * Criterion to represent {@link MethodParameter}s from a base method and its declared (overriden) method.
-	 * <p>
-	 * Method parameters indexes are correlated so {@link ParameterOverrideCriteria} applies only to methods with same
-	 * parameter count.
-	 */
-	@Value(staticConstructor = "of")
-	private static class ParameterOverrideCriteria {
-
-		private final MethodParameter base;
-		private final MethodParameter declared;
-
-		/**
-		 * @return base method parameter type.
-		 */
-		public Class<?> getBaseType() {
-			return base.getParameterType();
-		}
-
-		/**
-		 * @return generic base method parameter type.
-		 */
-		public Type getGenericBaseType() {
-			return base.getGenericParameterType();
-		}
-
-		/**
-		 * @return declared method parameter type.
-		 */
-		public Class<?> getDeclaredType() {
-			return declared.getParameterType();
-		}
-
-		public boolean isAssignableFromDeclared() {
-			return getBaseType().isAssignableFrom(getDeclaredType());
-		}
+			RepositoryComposition composition) {
+		super(metadata, repositoryBaseClass, composition.withMethodLookup(MethodLookups.forReactiveTypes(metadata)));
 	}
 }

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.MethodLookup.InvokedMethod;
+import org.springframework.data.repository.core.support.MethodLookup.MethodPredicate;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Collection of {@link RepositoryFragment fragments} that form a repository implementation.
+ * <p/>
+ * Fragments contribute method signatures to forming a composite component that routes method execution into the
+ * according {@link RepositoryFragment}. Fragments are ordered and the order of fragments controls routing if a method
+ * is implemented by more than one fragment.
+ * <p />
+ * A {@link RepositoryComposition} allows configuration of {@link #withMethodLookup(BiFunction)} method lookup and
+ * {@link #withArgumentConverter(BiFunction)} runtime argument conversion.
+ * <p />
+ * Composition objects are immutable and thread-safe.
+ *
+ * @author Mark Paluch
+ * @soundtrack Masterboy - Anybody (Fj Gauder Mix)
+ * @since 2.0
+ * @see RepositoryFragment
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = "fragments")
+public class RepositoryComposition {
+
+	private static final BiFunction<Method, Object[], Object[]> PASSTHRU_ARG_CONVERTER = (methodParameter, o) -> o;
+
+	private static final RepositoryComposition EMPTY = new RepositoryComposition(RepositoryFragments.empty(),
+			MethodLookups.direct(), PASSTHRU_ARG_CONVERTER);
+
+	private final Map<Method, Optional<Method>> methodCache = new ConcurrentReferenceHashMap<>();
+	private final RepositoryFragments fragments;
+	private final MethodLookup methodLookup;
+	private final BiFunction<Method, Object[], Object[]> argumentConverter;
+
+	/**
+	 * Create an empty {@link RepositoryComposition}.
+	 *
+	 * @return an empty {@link RepositoryComposition}.
+	 */
+	public static RepositoryComposition empty() {
+		return EMPTY;
+	}
+
+	/**
+	 * Create a {@link RepositoryComposition} for just a single {@code implementation} with {@link MethodLookups#direct())
+	 * method lokup.
+	 *
+	 * @param implementation must not be {@literal null}.
+	 * @return the {@link RepositoryComposition} for a single {@code implementation}.
+	 */
+	public static RepositoryComposition just(Object implementation) {
+		return new RepositoryComposition(RepositoryFragments.just(implementation), MethodLookups.direct(),
+				PASSTHRU_ARG_CONVERTER);
+	}
+
+	/**
+	 * Create a {@link RepositoryComposition} from {@link RepositoryFragment fragments} with
+	 * {@link MethodLookups#direct()) method lokup.
+	 *
+	 * @param fragments must not be {@literal null}.
+	 * @return the {@link RepositoryComposition} from {@link RepositoryFragment fragments}.
+	 */
+	public static RepositoryComposition of(RepositoryFragment<?>... fragments) {
+		return of(Arrays.asList(fragments));
+	}
+
+	/**
+	 * Create a {@link RepositoryComposition} from {@link RepositoryFragment fragments} with
+	 * {@link MethodLookups#direct()) method lokup.
+	 *
+	 * @param fragments must not be {@literal null}.
+	 * @return the {@link RepositoryComposition} from {@link RepositoryFragment fragments}.
+	 */
+	public static RepositoryComposition of(List<RepositoryFragment<?>> fragments) {
+		return new RepositoryComposition(RepositoryFragments.of(fragments), MethodLookups.direct(), PASSTHRU_ARG_CONVERTER);
+	}
+
+	/**
+	 * Create a {@link RepositoryComposition} from {@link RepositoryFragments} and {@link RepositoryMetadata} with
+	 * {@link MethodLookups#direct()) method lokup.
+	 *
+	 * @param fragments must not be {@literal null}.
+	 * @return the {@link RepositoryComposition} from {@link RepositoryFragments fragments}.
+	 */
+	public static RepositoryComposition of(RepositoryFragments fragments) {
+		return new RepositoryComposition(fragments, MethodLookups.direct(), PASSTHRU_ARG_CONVERTER);
+	}
+
+	/**
+	 * Create a new {@link RepositoryComposition} retaining current configuration and prepend {@link RepositoryFragment}
+	 * to the new composition. The resulting composition contains the prepended {@link RepositoryFragment} as first
+	 * element.
+	 *
+	 * @param fragment must not be {@literal null}.
+	 * @return the new {@link RepositoryComposition}.
+	 */
+	public RepositoryComposition prepend(RepositoryFragment<?> fragment) {
+		return new RepositoryComposition(fragments.prepend(fragment), methodLookup, argumentConverter);
+	}
+
+	/**
+	 * Create a new {@link RepositoryComposition} retaining current configuration and prepend {@link RepositoryFragment}
+	 * to the new composition. The resulting composition contains the prepended {@link RepositoryFragment} as first
+	 * element.
+	 *
+	 * @param fragments must not be {@literal null}.
+	 * @return the new {@link RepositoryComposition}.
+	 */
+	public RepositoryComposition prepend(RepositoryFragments fragments) {
+		return new RepositoryComposition(fragments.prepend(fragments), methodLookup, argumentConverter);
+	}
+
+	/**
+	 * Create a new {@link RepositoryComposition} retaining current configuration and append {@link RepositoryFragment} to
+	 * the new composition. The resulting composition contains the appended {@link RepositoryFragment} as last element.
+	 *
+	 * @param fragment must not be {@literal null}.
+	 * @return the new {@link RepositoryComposition}.
+	 */
+	public RepositoryComposition append(RepositoryFragment<?> fragment) {
+		return new RepositoryComposition(fragments.append(fragment), methodLookup, argumentConverter);
+	}
+
+	/**
+	 * Create a new {@link RepositoryComposition} retaining current configuration and append {@link RepositoryFragments}
+	 * to the new composition. The resulting composition contains the appended {@link RepositoryFragments} as last
+	 * element.
+	 *
+	 * @param repositoryFragments must not be {@literal null}.
+	 * @return the new {@link RepositoryComposition}.
+	 */
+	public RepositoryComposition append(RepositoryFragments repositoryFragments) {
+		return new RepositoryComposition(fragments.append(repositoryFragments), methodLookup, argumentConverter);
+	}
+
+	/**
+	 * Create a new {@link RepositoryComposition} retaining current configuration and set {@code argumentConverter}.
+	 *
+	 * @param argumentConverter must not be {@literal null}.
+	 * @return the new {@link RepositoryComposition}.
+	 */
+	public RepositoryComposition withArgumentConverter(BiFunction<Method, Object[], Object[]> argumentConverter) {
+		return new RepositoryComposition(fragments, methodLookup, argumentConverter);
+	}
+
+	/**
+	 * Create a new {@link RepositoryComposition} retaining current configuration and set {@code methodLookup}.
+	 *
+	 * @param methodLookup must not be {@literal null}.
+	 * @return the new {@link RepositoryComposition}.
+	 */
+	public RepositoryComposition withMethodLookup(MethodLookup methodLookup) {
+		return new RepositoryComposition(fragments, methodLookup, argumentConverter);
+	}
+
+	public MethodLookup getMethodLookup() {
+		return methodLookup;
+	}
+
+	public RepositoryFragments getFragments() {
+		return fragments;
+	}
+
+	public BiFunction<Method, Object[], Object[]> getArgumentConverter() {
+		return argumentConverter;
+	}
+
+	/**
+	 * Return {@literal true} if this {@link RepositoryComposition} contains no {@link RepositoryFragment fragments}.
+	 *
+	 * @return {@literal true} if this {@link RepositoryComposition} contains no {@link RepositoryFragment fragments}.
+	 */
+	public boolean isEmpty() {
+		return fragments.isEmpty();
+	}
+
+	/**
+	 * Invoke a method on the repository by routing the invocation to the appropriate {@link RepositoryFragment}.
+	 *
+	 * @param method
+	 * @param args
+	 * @return
+	 * @throws Throwable
+	 */
+	public Object invoke(Method method, Object... args) throws Throwable {
+
+		Method methodToCall = findMethod(method) //
+				.orElseThrow(() -> new IllegalArgumentException(String.format("No fragment found for method %s", method)));
+
+		ReflectionUtils.makeAccessible(methodToCall);
+
+		return fragments.invoke(methodToCall, argumentConverter.apply(methodToCall, args));
+	}
+
+	/**
+	 * Find the implementation method for the given {@link Method} invoked on the composite interface.
+	 *
+	 * @param method must not be {@literal null}.
+	 * @return
+	 */
+	public Optional<Method> findMethod(Method method) {
+
+		return methodCache.computeIfAbsent(method,
+				key -> RepositoryFragments.findMethod(InvokedMethod.of(key), methodLookup, fragments::methods));
+	}
+
+	/**
+	 * Validates that all {@link RepositoryFragment fragments} have an implementation.
+	 */
+	public void validateImplementation() {
+
+		fragments.stream()
+				.forEach(it -> it.getImplementation() //
+						.orElseThrow(() -> new IllegalStateException(String.format("Fragment %s has no implementation.",
+								ClassUtils.getQualifiedName(it.getSignatureContributor())))));
+	}
+
+	/**
+	 * Value object representing an ordered list of {@link RepositoryFragment fragments}.
+	 *
+	 * @author Mark Paluch
+	 */
+	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+	@EqualsAndHashCode
+	public static class RepositoryFragments {
+
+		public static final RepositoryFragments EMPTY = new RepositoryFragments(Collections.emptyList());
+
+		private final Map<Method, RepositoryFragment> fragmentCache = new ConcurrentReferenceHashMap<>();
+		private final List<RepositoryFragment<?>> fragments;
+
+		/**
+		 * Create empty {@link RepositoryFragments}.
+		 *
+		 * @return empty {@link RepositoryFragments}.
+		 */
+		public static RepositoryFragments empty() {
+			return EMPTY;
+		}
+
+		/**
+		 * Create {@link RepositoryFragments} from just implementation objects.
+		 *
+		 * @param implementations must not be {@literal null}.
+		 * @return the {@link RepositoryFragments} for {@code implementations}.
+		 */
+		public static RepositoryFragments just(Object... implementations) {
+
+			Assert.notNull(implementations, "Implementations must not be null!");
+			Assert.noNullElements(implementations, "Implementations must not contain null elements!");
+
+			return new RepositoryFragments(
+					Arrays.stream(implementations).map(RepositoryFragment::implemented).collect(Collectors.toList()));
+		}
+
+		/**
+		 * Create {@link RepositoryFragments} from of {@link RepositoryFragments fragments}.
+		 *
+		 * @param fragments must not be {@literal null}.
+		 * @return the {@link RepositoryFragments} for {@code implementations}.
+		 */
+		public static RepositoryFragments of(RepositoryFragment<?>... fragments) {
+
+			Assert.notNull(fragments, "RepositoryFragments must not be null!");
+			Assert.noNullElements(fragments, "RepositoryFragments must not contain null elements!");
+
+			return new RepositoryFragments(Arrays.asList(fragments));
+		}
+
+		private static RepositoryFragments of(List<RepositoryFragment<?>> fragments) {
+			return new RepositoryFragments(new ArrayList<>(fragments));
+		}
+
+		/**
+		 * Create new {@link RepositoryFragments} from the current content prepending {@link RepositoryFragment}.
+		 *
+		 * @param fragment must not be {@literal null}
+		 * @return the new {@link RepositoryFragments} containing all existing fragments and the given
+		 *         {@link RepositoryFragment} as first element.
+		 */
+		public RepositoryFragments prepend(RepositoryFragment<?> fragment) {
+
+			Assert.notNull(fragment, "RepositoryFragment must not be null!");
+
+			return concat(Stream.of(fragment), stream());
+		}
+
+		/**
+		 * Create new {@link RepositoryFragments} from the current content prepending {@link RepositoryFragments}.
+		 *
+		 * @param fragments must not be {@literal null}
+		 * @return the new {@link RepositoryFragments} containing all existing fragments and the given
+		 *         {@link RepositoryFragments} as first elements.
+		 */
+		public RepositoryFragments prepend(RepositoryFragments fragments) {
+
+			Assert.notNull(fragments, "RepositoryFragments must not be null!");
+
+			return concat(fragments.stream(), stream());
+		}
+
+		/**
+		 * Create new {@link RepositoryFragments} from the current content appending {@link RepositoryFragment}.
+		 *
+		 * @param fragment must not be {@literal null}
+		 * @return the new {@link RepositoryFragments} containing all existing fragments and the given
+		 *         {@link RepositoryFragment} as last element.
+		 */
+		public RepositoryFragments append(RepositoryFragment<?> fragment) {
+
+			Assert.notNull(fragment, "RepositoryFragment must not be null!");
+
+			return concat(stream(), Stream.of(fragment));
+		}
+
+		/**
+		 * Create new {@link RepositoryFragments} from the current content appending {@link RepositoryFragments}.
+		 *
+		 * @param fragments must not be {@literal null}
+		 * @return the new {@link RepositoryFragments} containing all existing fragments and the given
+		 *         {@link RepositoryFragments} as last elements.
+		 */
+		public RepositoryFragments append(RepositoryFragments fragments) {
+
+			Assert.notNull(fragments, "RepositoryFragments must not be null!");
+
+			return concat(stream(), fragments.stream());
+		}
+
+		private static RepositoryFragments concat(Stream<RepositoryFragment<?>> left, Stream<RepositoryFragment<?>> right) {
+			return of(Stream.concat(left, right).collect(Collectors.toList()));
+		}
+
+		/**
+		 * Return {@literal true} if this {@link RepositoryFragments} contains no {@link RepositoryFragment fragments}.
+		 *
+		 * @return {@literal true} if this {@link RepositoryFragments} contains no {@link RepositoryFragment fragments}.
+		 */
+		public boolean isEmpty() {
+			return fragments.isEmpty();
+		}
+
+		/**
+		 * @return {@link Stream} of {@link RepositoryFragment fragments}.
+		 */
+		public Stream<RepositoryFragment<?>> stream() {
+			return fragments.stream();
+		}
+
+		/**
+		 * @return {@link Stream} of {@link Method methods}.
+		 */
+		public Stream<Method> methods() {
+			return stream().flatMap(RepositoryFragment::methods);
+		}
+
+		static Optional<Method> findMethod(InvokedMethod invokedMethod, MethodLookup lookup,
+				Supplier<Stream<Method>> methodStreamSupplier) {
+
+			for (MethodPredicate methodPredicate : lookup.getLookups()) {
+
+				Optional<Method> resolvedMethod = methodStreamSupplier.get()
+						.filter(it -> methodPredicate.test(invokedMethod, it)) //
+						.findFirst();
+
+				if (resolvedMethod.isPresent()) {
+					return resolvedMethod;
+				}
+			}
+
+			return Optional.empty();
+		}
+
+		/**
+		 * Invoke {@link Method} by resolving the
+		 *
+		 * @param method
+		 * @param args
+		 * @return
+		 * @throws Throwable
+		 */
+		public Object invoke(Method method, Object[] args) throws Throwable {
+
+			RepositoryFragment<?> fragment = fragmentCache.computeIfAbsent(method, key -> {
+
+				return stream().filter(it -> it.hasMethod(key)) //
+						.filter(it -> it.getImplementation().isPresent()) //
+						.findFirst()
+						.orElseThrow(() -> new IllegalArgumentException(String.format("No fragment found for method %s", key)));
+			});
+
+			Object target = fragment.getImplementation().orElseThrow(
+					() -> new IllegalArgumentException(String.format("No implementation found for method %s", method)));
+
+			return method.invoke(target, args);
+		}
+
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
@@ -17,6 +17,7 @@ package org.springframework.data.repository.core.support;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Method;
@@ -66,14 +67,13 @@ import org.springframework.util.ReflectionUtils;
 public class RepositoryComposition {
 
 	private static final BiFunction<Method, Object[], Object[]> PASSTHRU_ARG_CONVERTER = (methodParameter, o) -> o;
-
 	private static final RepositoryComposition EMPTY = new RepositoryComposition(RepositoryFragments.empty(),
 			MethodLookups.direct(), PASSTHRU_ARG_CONVERTER);
 
 	private final Map<Method, Optional<Method>> methodCache = new ConcurrentReferenceHashMap<>();
-	private final RepositoryFragments fragments;
-	private final MethodLookup methodLookup;
-	private final BiFunction<Method, Object[], Object[]> argumentConverter;
+	private final @Getter RepositoryFragments fragments;
+	private final @Getter MethodLookup methodLookup;
+	private final @Getter BiFunction<Method, Object[], Object[]> argumentConverter;
 
 	/**
 	 * Create an empty {@link RepositoryComposition}.
@@ -86,7 +86,7 @@ public class RepositoryComposition {
 
 	/**
 	 * Create a {@link RepositoryComposition} for just a single {@code implementation} with {@link MethodLookups#direct())
-	 * method lokup.
+	 * method lookup.
 	 *
 	 * @param implementation must not be {@literal null}.
 	 * @return the {@link RepositoryComposition} for a single {@code implementation}.
@@ -98,7 +98,7 @@ public class RepositoryComposition {
 
 	/**
 	 * Create a {@link RepositoryComposition} from {@link RepositoryFragment fragments} with
-	 * {@link MethodLookups#direct()) method lokup.
+	 * {@link MethodLookups#direct()) method lookup.
 	 *
 	 * @param fragments must not be {@literal null}.
 	 * @return the {@link RepositoryComposition} from {@link RepositoryFragment fragments}.
@@ -109,7 +109,7 @@ public class RepositoryComposition {
 
 	/**
 	 * Create a {@link RepositoryComposition} from {@link RepositoryFragment fragments} with
-	 * {@link MethodLookups#direct()) method lokup.
+	 * {@link MethodLookups#direct()) method lookup.
 	 *
 	 * @param fragments must not be {@literal null}.
 	 * @return the {@link RepositoryComposition} from {@link RepositoryFragment fragments}.
@@ -121,7 +121,7 @@ public class RepositoryComposition {
 
 	/**
 	 * Create a {@link RepositoryComposition} from {@link RepositoryFragments} and {@link RepositoryMetadata} with
-	 * {@link MethodLookups#direct()) method lokup.
+	 * {@link MethodLookups#direct()) method lookup.
 	 *
 	 * @param fragments must not be {@literal null}.
 	 * @return the {@link RepositoryComposition} from {@link RepositoryFragments fragments}.
@@ -195,18 +195,6 @@ public class RepositoryComposition {
 	 */
 	public RepositoryComposition withMethodLookup(MethodLookup methodLookup) {
 		return new RepositoryComposition(fragments, methodLookup, argumentConverter);
-	}
-
-	public MethodLookup getMethodLookup() {
-		return methodLookup;
-	}
-
-	public RepositoryFragments getFragments() {
-		return fragments;
-	}
-
-	public BiFunction<Method, Object[], Object[]> getArgumentConverter() {
-		return argumentConverter;
 	}
 
 	/**
@@ -393,6 +381,10 @@ public class RepositoryComposition {
 			return fragments.isEmpty();
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Iterable#iterator()
+		 */
 		@Override
 		public Iterator<RepositoryFragment<?>> iterator() {
 			return fragments.iterator();
@@ -401,6 +393,7 @@ public class RepositoryComposition {
 		/**
 		 * @return {@link Stream} of {@link RepositoryFragment fragments}.
 		 */
+		@Override
 		public Stream<RepositoryFragment<?>> stream() {
 			return fragments.stream();
 		}
@@ -410,23 +403,6 @@ public class RepositoryComposition {
 		 */
 		public Stream<Method> methods() {
 			return stream().flatMap(RepositoryFragment::methods);
-		}
-
-		static Optional<Method> findMethod(InvokedMethod invokedMethod, MethodLookup lookup,
-				Supplier<Stream<Method>> methodStreamSupplier) {
-
-			for (MethodPredicate methodPredicate : lookup.getLookups()) {
-
-				Optional<Method> resolvedMethod = methodStreamSupplier.get()
-						.filter(it -> methodPredicate.test(invokedMethod, it)) //
-						.findFirst();
-
-				if (resolvedMethod.isPresent()) {
-					return resolvedMethod;
-				}
-			}
-
-			return Optional.empty();
 		}
 
 		/**
@@ -453,7 +429,25 @@ public class RepositoryComposition {
 			return method.invoke(target, args);
 		}
 
-		/* (non-Javadoc)
+		private static Optional<Method> findMethod(InvokedMethod invokedMethod, MethodLookup lookup,
+				Supplier<Stream<Method>> methodStreamSupplier) {
+
+			for (MethodPredicate methodPredicate : lookup.getLookups()) {
+
+				Optional<Method> resolvedMethod = methodStreamSupplier.get()
+						.filter(it -> methodPredicate.test(invokedMethod, it)) //
+						.findFirst();
+
+				if (resolvedMethod.isPresent()) {
+					return resolvedMethod;
+				}
+			}
+
+			return Optional.empty();
+		}
+
+		/*
+		 * (non-Javadoc)
 		 * @see java.lang.Object#toString()
 		 */
 		@Override

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
@@ -131,30 +131,6 @@ public class RepositoryComposition {
 	}
 
 	/**
-	 * Create a new {@link RepositoryComposition} retaining current configuration and prepend {@link RepositoryFragment}
-	 * to the new composition. The resulting composition contains the prepended {@link RepositoryFragment} as first
-	 * element.
-	 *
-	 * @param fragment must not be {@literal null}.
-	 * @return the new {@link RepositoryComposition}.
-	 */
-	public RepositoryComposition prepend(RepositoryFragment<?> fragment) {
-		return new RepositoryComposition(fragments.prepend(fragment), methodLookup, argumentConverter);
-	}
-
-	/**
-	 * Create a new {@link RepositoryComposition} retaining current configuration and prepend {@link RepositoryFragment}
-	 * to the new composition. The resulting composition contains the prepended {@link RepositoryFragment} as first
-	 * element.
-	 *
-	 * @param fragments must not be {@literal null}.
-	 * @return the new {@link RepositoryComposition}.
-	 */
-	public RepositoryComposition prepend(RepositoryFragments fragments) {
-		return new RepositoryComposition(this.fragments.prepend(fragments), methodLookup, argumentConverter);
-	}
-
-	/**
 	 * Create a new {@link RepositoryComposition} retaining current configuration and append {@link RepositoryFragment} to
 	 * the new composition. The resulting composition contains the appended {@link RepositoryFragment} as last element.
 	 *
@@ -256,7 +232,7 @@ public class RepositoryComposition {
 	@EqualsAndHashCode
 	public static class RepositoryFragments implements Streamable<RepositoryFragment<?>> {
 
-		public static final RepositoryFragments EMPTY = new RepositoryFragments(Collections.emptyList());
+		static final RepositoryFragments EMPTY = new RepositoryFragments(Collections.emptyList());
 
 		private final Map<Method, RepositoryFragment<?>> fragmentCache = new ConcurrentReferenceHashMap<>();
 		private final List<RepositoryFragment<?>> fragments;
@@ -310,34 +286,6 @@ public class RepositoryComposition {
 			Assert.notNull(fragments, "RepositoryFragments must not be null!");
 
 			return new RepositoryFragments(new ArrayList<>(fragments));
-		}
-
-		/**
-		 * Create new {@link RepositoryFragments} from the current content prepending {@link RepositoryFragment}.
-		 *
-		 * @param fragment must not be {@literal null}
-		 * @return the new {@link RepositoryFragments} containing all existing fragments and the given
-		 *         {@link RepositoryFragment} as first element.
-		 */
-		public RepositoryFragments prepend(RepositoryFragment<?> fragment) {
-
-			Assert.notNull(fragment, "RepositoryFragment must not be null!");
-
-			return concat(Stream.of(fragment), stream());
-		}
-
-		/**
-		 * Create new {@link RepositoryFragments} from the current content prepending {@link RepositoryFragments}.
-		 *
-		 * @param fragments must not be {@literal null}
-		 * @return the new {@link RepositoryFragments} containing all existing fragments and the given
-		 *         {@link RepositoryFragments} as first elements.
-		 */
-		public RepositoryFragments prepend(RepositoryFragments fragments) {
-
-			Assert.notNull(fragments, "RepositoryFragments must not be null!");
-
-			return concat(fragments.stream(), stream());
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryCompositionFactoryBean.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryCompositionFactoryBean.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * Factory bean for creation of {@link RepositoryComposition}. This {@link FactoryBean} uses named
+ * {@link #RepositoryCompositionFactoryBean(List) bean references} to look up {@link RepositoryFragment} beans and
+ * construct a {@link RepositoryComposition}.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class RepositoryCompositionFactoryBean<T>
+		implements FactoryBean<RepositoryComposition>, BeanFactoryAware, InitializingBean {
+
+	private final List<String> fragmentBeanNames;
+
+	private BeanFactory beanFactory;
+	private RepositoryComposition repositoryComposition = RepositoryComposition.empty();
+
+	/**
+	 * Creates a new {@link RepositoryCompositionFactoryBean} given {@code fragmentBeanNames}.
+	 *
+	 * @param fragmentBeanNames must not be {@literal null}.
+	 */
+	public RepositoryCompositionFactoryBean(List<String> fragmentBeanNames) {
+
+		Assert.notNull(fragmentBeanNames, "Fragment bean names must not be null!");
+		this.fragmentBeanNames = fragmentBeanNames;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void afterPropertiesSet() {
+
+		List<RepositoryFragment<?>> collect = (List) fragmentBeanNames.stream()
+				.map(it -> beanFactory.getBean(it, RepositoryFragment.class)).collect(Collectors.toList());
+		this.repositoryComposition = RepositoryComposition.of(collect);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#getObject()
+	 */
+	@Override
+	public RepositoryComposition getObject() throws Exception {
+		return this.repositoryComposition;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.FactoryBean#getObjectType()
+	 */
+	@Override
+	public Class<?> getObjectType() {
+		return RepositoryComposition.class;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
+	 */
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
@@ -264,10 +264,18 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		}
 
 		repositoryBaseClass.ifPresent(this.factory::setRepositoryBaseClass);
-		repositoryComposition.ifPresent(this.factory::setRepositoryComposition);
+
+		RepositoryComposition repositoryComposition = customImplementation.map(RepositoryComposition::just) //
+				.orElse(RepositoryComposition.empty()); //
+
+		repositoryComposition = this.repositoryComposition.map(RepositoryComposition::getFragments) //
+				.map(repositoryComposition::append) //
+				.orElse(repositoryComposition);
+
+		this.factory.setRepositoryComposition(repositoryComposition);
 
 		this.repositoryMetadata = this.factory.getRepositoryMetadata(repositoryInterface);
-		this.repository = Lazy.of(() -> this.factory.getRepository(repositoryInterface, customImplementation));
+		this.repository = Lazy.of(() -> this.factory.getRepository(repositoryInterface));
 
 		if (!lazyInit) {
 			this.repository.get();

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
@@ -44,7 +44,7 @@ import org.springframework.util.Assert;
 /**
  * Adapter for Springs {@link FactoryBean} interface to allow easy setup of repository factories via Spring
  * configuration.
- * 
+ *
  * @param <T> the type of the repository
  * @author Oliver Gierke
  * @author Thomas Darimont
@@ -73,7 +73,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Creates a new {@link RepositoryFactoryBeanSupport} for the given repository interface.
-	 * 
+	 *
 	 * @param repositoryInterface must not be {@literal null}.
 	 */
 	protected RepositoryFactoryBeanSupport(Class<? extends T> repositoryInterface) {
@@ -84,7 +84,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Configures the repository base class to be used.
-	 * 
+	 *
 	 * @param repositoryBaseClass the repositoryBaseClass to set, can be {@literal null}.
 	 * @since 1.11
 	 */
@@ -94,7 +94,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Set the {@link QueryLookupStrategy.Key} to be used.
-	 * 
+	 *
 	 * @param queryLookupStrategyKey
 	 */
 	public void setQueryLookupStrategyKey(Key queryLookupStrategyKey) {
@@ -103,7 +103,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Setter to inject a custom repository implementation.
-	 * 
+	 *
 	 * @param customImplementation
 	 */
 	public void setCustomImplementation(Object customImplementation) {
@@ -112,7 +112,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Setter to inject a {@link NamedQueries} instance.
-	 * 
+	 *
 	 * @param namedQueries the namedQueries to set
 	 */
 	public void setNamedQueries(NamedQueries namedQueries) {
@@ -122,7 +122,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	/**
 	 * Configures the {@link MappingContext} to be used to lookup {@link PersistentEntity} instances for
 	 * {@link #getPersistentEntity()}.
-	 * 
+	 *
 	 * @param mappingContext
 	 */
 	protected void setMappingContext(MappingContext<?, ?> mappingContext) {
@@ -131,7 +131,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Sets the {@link EvaluationContextProvider} to be used to evaluate SpEL expressions in manually defined queries.
-	 * 
+	 *
 	 * @param evaluationContextProvider can be {@literal null}, defaults to
 	 *          {@link DefaultEvaluationContextProvider#INSTANCE}.
 	 */
@@ -142,14 +142,14 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Configures whether to initialize the repository proxy lazily. This defaults to {@literal false}.
-	 * 
+	 *
 	 * @param lazy whether to initialize the repository proxy lazily. This defaults to {@literal false}.
 	 */
 	public void setLazyInit(boolean lazy) {
 		this.lazyInit = lazy;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.BeanClassLoaderAware#setBeanClassLoader(java.lang.ClassLoader)
 	 */
@@ -158,7 +158,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		this.classLoader = classLoader;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
 	 */
@@ -167,7 +167,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		this.beanFactory = beanFactory;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.context.ApplicationEventPublisherAware#setApplicationEventPublisher(org.springframework.context.ApplicationEventPublisher)
 	 */
@@ -185,7 +185,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		return (EntityInformation<S, ID>) factory.getEntityInformation(repositoryMetadata.getDomainType());
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.core.support.RepositoryFactoryInformation#getRepositoryInformation()
 	 */
@@ -193,7 +193,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		return this.factory.getRepositoryInformation(repositoryMetadata, customImplementation.map(Object::getClass));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.core.support.RepositoryFactoryInformation#getPersistentEntity()
 	 */
@@ -263,7 +263,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 	/**
 	 * Create the actual {@link RepositoryFactorySupport} instance.
-	 * 
+	 *
 	 * @return
 	 */
 	protected abstract RepositoryFactorySupport createRepositoryFactory();

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
@@ -272,7 +272,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 
 		RepositoryFragments repositoryFragmentsToUse = this.repositoryFragments //
 				.orElseGet(RepositoryFragments::empty) //
-				.prepend(customImplementationFragment);
+				.append(customImplementationFragment);
 
 		this.repositoryMetadata = this.factory.getRepositoryMetadata(repositoryInterface);
 		this.repository = Lazy.of(() -> this.factory.getRepository(repositoryInterface, repositoryFragmentsToUse));

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -67,7 +67,7 @@ import org.springframework.util.Assert;
  * Factory bean to create instances of a given repository interface. Creates a proxy implementing the configured
  * repository interface and apply an advice handing the control to the {@code QueryExecuterMethodInterceptor}. Query
  * detection strategy can be configured by setting {@link QueryLookupStrategy.Key}.
- * 
+ *
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -102,7 +102,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Sets the strategy of how to lookup a query to execute finders.
-	 * 
+	 *
 	 * @param key
 	 */
 	public void setQueryLookupStrategyKey(Key key) {
@@ -111,14 +111,14 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Configures a {@link NamedQueries} instance to be handed to the {@link QueryLookupStrategy} for query creation.
-	 * 
+	 *
 	 * @param namedQueries the namedQueries to set
 	 */
 	public void setNamedQueries(NamedQueries namedQueries) {
 		this.namedQueries = namedQueries == null ? PropertiesBasedNamedQueries.EMPTY : namedQueries;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.BeanClassLoaderAware#setBeanClassLoader(java.lang.ClassLoader)
 	 */
@@ -127,7 +127,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		this.classLoader = classLoader == null ? org.springframework.util.ClassUtils.getDefaultClassLoader() : classLoader;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
 	 */
@@ -138,7 +138,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Sets the {@link EvaluationContextProvider} to be used to evaluate SpEL expressions in manually defined queries.
-	 * 
+	 *
 	 * @param evaluationContextProvider can be {@literal null}, defaults to
 	 *          {@link DefaultEvaluationContextProvider#INSTANCE}.
 	 */
@@ -150,7 +150,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * Configures the repository base class to use when creating the repository proxy. If not set, the factory will use
 	 * the type returned by {@link #getRepositoryBaseClass(RepositoryMetadata)} by default.
-	 * 
+	 *
 	 * @param repositoryBaseClass the repository base class to back the repository proxy, can be {@literal null}.
 	 * @since 1.11
 	 */
@@ -161,7 +161,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * Adds a {@link QueryCreationListener} to the factory to plug in functionality triggered right after creation of
 	 * {@link RepositoryQuery} instances.
-	 * 
+	 *
 	 * @param listener
 	 */
 	public void addQueryCreationListener(QueryCreationListener<?> listener) {
@@ -174,7 +174,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	 * Adds {@link RepositoryProxyPostProcessor}s to the factory to allow manipulation of the {@link ProxyFactory} before
 	 * the proxy gets created. Note that the {@link QueryExecutorMethodInterceptor} will be added to the proxy
 	 * <em>after</em> the {@link RepositoryProxyPostProcessor}s are considered.
-	 * 
+	 *
 	 * @param processor
 	 */
 	public void addRepositoryProxyPostProcessor(RepositoryProxyPostProcessor processor) {
@@ -185,7 +185,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Returns a repository instance for the given interface.
-	 * 
+	 *
 	 * @param <T>
 	 * @param repositoryInterface
 	 * @return
@@ -197,7 +197,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * Returns a repository instance for the given interface backed by an instance providing implementation logic for
 	 * custom logic.
-	 * 
+	 *
 	 * @param <T>
 	 * @param repositoryInterface
 	 * @param customImplementation
@@ -210,7 +210,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * Returns a repository instance for the given interface backed by an instance providing implementation logic for
 	 * custom logic.
-	 * 
+	 *
 	 * @param <T>
 	 * @param repositoryInterface
 	 * @param customImplementation
@@ -229,7 +229,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		// Create proxy
 		ProxyFactory result = new ProxyFactory();
 		result.setTarget(target);
-		result.setInterfaces(new Class[] { repositoryInterface, Repository.class, TransactionalProxy.class });
+		result.setInterfaces(repositoryInterface, Repository.class, TransactionalProxy.class);
 
 		result.addAdvice(SurroundingTransactionDetectorMethodInterceptor.INSTANCE);
 		result.addAdvisor(ExposeInvocationInterceptor.ADVISOR);
@@ -248,7 +248,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Returns the {@link RepositoryMetadata} for the given repository interface.
-	 * 
+	 *
 	 * @param repositoryInterface will never be {@literal null}.
 	 * @return
 	 */
@@ -258,7 +258,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Returns the {@link RepositoryInformation} for the given repository interface.
-	 * 
+	 *
 	 * @param metadata
 	 * @param customImplementationClass
 	 * @return
@@ -284,7 +284,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Returns the {@link EntityInformation} for the given domain class.
-	 * 
+	 *
 	 * @param <T> the entity type
 	 * @param <ID> the id type
 	 * @param domainClass
@@ -294,7 +294,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Create a repository instance as backing for the query proxy.
-	 * 
+	 *
 	 * @param metadata
 	 * @return
 	 */
@@ -303,7 +303,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * Returns the base class backing the actual repository instance. Make sure
 	 * {@link #getTargetRepository(RepositoryMetadata)} returns an instance of this class.
-	 * 
+	 *
 	 * @param metadata
 	 * @return
 	 */
@@ -311,7 +311,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Returns the {@link QueryLookupStrategy} for the given {@link Key} and {@link EvaluationContextProvider}.
-	 * 
+	 *
 	 * @param key can be {@literal null}.
 	 * @param evaluationContextProvider will never be {@literal null}.
 	 * @return the {@link QueryLookupStrategy} to use or {@literal null} if no queries should be looked up.
@@ -324,7 +324,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Validates the given repository interface as well as the given custom implementation.
-	 * 
+	 *
 	 * @param repositoryInformation
 	 * @param customImplementation
 	 */
@@ -351,7 +351,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * Creates a repository of the repository base class defined in the given {@link RepositoryInformation} using
 	 * reflection.
-	 * 
+	 *
 	 * @param information
 	 * @param constructorArguments
 	 * @return
@@ -373,7 +373,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	 * This {@code MethodInterceptor} intercepts calls to methods of the custom implementation and delegates the to it if
 	 * configured. Furthermore it resolves method calls to finders and triggers execution of them. You can rely on having
 	 * a custom repository implementation instance set if this returns true.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	public class QueryExecutorMethodInterceptor implements MethodInterceptor {
@@ -457,7 +457,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 		/**
 		 * Returns whether we know of a query to execute for the given {@link Method};
-		 * 
+		 *
 		 * @param method
 		 * @return
 		 */
@@ -501,7 +501,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 		/**
 		 * Executes the given method on the given target. Correctly unwraps exceptions not caused by the reflection magic.
-		 * 
+		 *
 		 * @param target
 		 * @param method
 		 * @param parameters
@@ -522,7 +522,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		/**
 		 * Returns whether the given {@link MethodInvocation} is considered to be targeted as an invocation of a custom
 		 * method.
-		 * 
+		 *
 		 * @param method
 		 * @return
 		 */
@@ -593,7 +593,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	/**
 	 * {@link QueryCreationListener} collecting the {@link QueryMethod}s created for all query methods of the repository
 	 * interface.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	@Getter
@@ -614,7 +614,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Simple value object to build up keys to cache {@link RepositoryInformation} instances.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	@EqualsAndHashCode
@@ -626,7 +626,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		/**
 		 * Creates a new {@link RepositoryInformationCacheKey} for the given {@link RepositoryMetadata} and cuytom
 		 * implementation type.
-		 * 
+		 *
 		 * @param repositoryInterfaceName must not be {@literal null}.
 		 * @param customImplementationClassName
 		 */

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -17,6 +17,7 @@ package org.springframework.data.repository.core.support;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Constructor;
@@ -24,10 +25,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -49,6 +50,7 @@ import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
 import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
 import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.QueryLookupStrategy;
@@ -62,6 +64,8 @@ import org.springframework.data.util.Pair;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.transaction.interceptor.TransactionalProxy;
 import org.springframework.util.Assert;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
 
 /**
  * Factory bean to create instances of a given repository interface. Creates a proxy implementing the configured
@@ -74,6 +78,37 @@ import org.springframework.util.Assert;
  */
 public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, BeanFactoryAware {
 
+	private static final BiFunction<Method, Object[], Object[]> REACTIVE_ARGS_CONVERTER = (method, o) -> {
+
+		if (ReactiveWrappers.isAvailable()) {
+
+			Class<?>[] parameterTypes = method.getParameterTypes();
+
+			Object[] converted = new Object[o.length];
+			for (int i = 0; i < parameterTypes.length; i++) {
+
+				Class<?> parameterType = parameterTypes[i];
+				Object value = o[i];
+
+				if (value == null) {
+					continue;
+				}
+
+				if (!parameterType.isAssignableFrom(value.getClass())
+						&& ReactiveWrapperConverters.canConvert(value.getClass(), parameterType)) {
+
+					converted[i] = ReactiveWrapperConverters.toWrapper(value, parameterType);
+				} else {
+					converted[i] = value;
+				}
+			}
+
+			return converted;
+		}
+
+		return o;
+	};
+
 	private final Map<RepositoryInformationCacheKey, RepositoryInformation> repositoryInformationCache;
 	private final List<RepositoryProxyPostProcessor> postProcessors;
 
@@ -84,15 +119,17 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	private ClassLoader classLoader;
 	private EvaluationContextProvider evaluationContextProvider;
 	private BeanFactory beanFactory;
+	private Optional<RepositoryComposition> composition;
 
 	private QueryCollectingQueryCreationListener collectingListener = new QueryCollectingQueryCreationListener();
 
 	public RepositoryFactorySupport() {
 
-		this.repositoryInformationCache = new HashMap<>();
+		this.repositoryInformationCache = new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK);
 		this.postProcessors = new ArrayList<>();
 
 		this.repositoryBaseClass = Optional.empty();
+		this.composition = Optional.empty();
 		this.namedQueries = PropertiesBasedNamedQueries.EMPTY;
 		this.classLoader = org.springframework.util.ClassUtils.getDefaultClassLoader();
 		this.evaluationContextProvider = DefaultEvaluationContextProvider.INSTANCE;
@@ -183,46 +220,88 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		this.postProcessors.add(processor);
 	}
 
+	public void setRepositoryComposition(RepositoryComposition composition) {
+
+		Assert.notNull(composition, "RepositoryComposition must not be null!");
+		this.composition = Optional.of(composition);
+	}
+
+	protected RepositoryComposition getRepositoryCompositition(RepositoryMetadata metadata) {
+
+		RepositoryComposition composition = this.composition.orElseGet(RepositoryComposition::empty);
+
+		if (metadata.isReactiveRepository()) {
+			return composition.withMethodLookup(MethodLookups.forReactiveTypes(metadata))
+					.withArgumentConverter(REACTIVE_ARGS_CONVERTER);
+		}
+
+		return composition.withMethodLookup(MethodLookups.forRepositoryTypes(metadata));
+	}
+
 	/**
 	 * Returns a repository instance for the given interface.
 	 *
-	 * @param <T>
-	 * @param repositoryInterface
+
+	 * @param repositoryInterfacemust not be {@literal null}.
 	 * @return
 	 */
 	public <T> T getRepository(Class<T> repositoryInterface) {
-		return getRepository(repositoryInterface, Optional.empty());
+		return getRepository(repositoryInterface, Optional.empty(), Optional.empty());
 	}
 
 	/**
 	 * Returns a repository instance for the given interface backed by an instance providing implementation logic for
 	 * custom logic.
 	 *
-	 * @param <T>
-	 * @param repositoryInterface
-	 * @param customImplementation
+
+	 * @param repositoryInterfacemust not be {@literal null}.
+	 * @param fragments must not be {@literal null}.
 	 * @return
+	 * @since 2.0
 	 */
-	public <T> T getRepository(Class<T> repositoryInterface, Object customImplementation) {
-		return getRepository(repositoryInterface, Optional.of(customImplementation));
+	public <T> T getRepository(Class<T> repositoryInterface, RepositoryFragments fragments) {
+		return getRepository(repositoryInterface, Optional.empty(), Optional.of(fragments));
 	}
 
 	/**
 	 * Returns a repository instance for the given interface backed by an instance providing implementation logic for
 	 * custom logic.
 	 *
-	 * @param <T>
-	 * @param repositoryInterface
-	 * @param customImplementation
+	 * @param repositoryInterface must not be {@literal null}.
+	 * @param customImplementation must not be {@literal null}.
+	 * @return
+	 * @deprecated since 2.0. Use {@link RepositoryFragments} with {@link #getRepository(Class, RepositoryFragments)} to
+	 *             compose repositories backed by custom implementations.
+	 */
+	@Deprecated
+	public <T> T getRepository(Class<T> repositoryInterface, Object customImplementation) {
+		return getRepository(repositoryInterface, Optional.of(customImplementation), Optional.empty());
+	}
+
+	/**
+	 * Returns a repository instance for the given interface backed by an instance providing implementation logic for
+	 * custom logic.
+	 *
+
+	 * @param repositoryInterfacemust not be {@literal null}.
+	 * @param customImplementationmust not be {@literal null}.
 	 * @return
 	 */
 	@SuppressWarnings({ "unchecked" })
-	protected <T> T getRepository(Class<T> repositoryInterface, Optional<Object> customImplementation) {
+	protected <T> T getRepository(Class<T> repositoryInterface, Optional<Object> customImplementation,
+			Optional<RepositoryFragments> fragments) {
 
 		RepositoryMetadata metadata = getRepositoryMetadata(repositoryInterface);
-		RepositoryInformation information = getRepositoryInformation(metadata, customImplementation.map(Object::getClass));
+		RepositoryComposition composition = fragments.map(it -> getRepositoryCompositition(metadata).prepend(it))
+				.orElseGet(() -> getRepositoryCompositition(metadata));
 
-		validate(information, customImplementation);
+		composition = customImplementation.map(RepositoryFragment::implemented) //
+				.map(composition::append) //
+				.orElse(composition);
+
+		RepositoryInformation information = getRepositoryInformation(metadata, composition);
+
+		validate(information, composition);
 
 		Object target = getTargetRepository(information);
 
@@ -239,9 +318,8 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		result.addAdvice(new DefaultMethodInvokingMethodInterceptor());
 		result.addAdvice(new QueryExecutorMethodInterceptor(information));
 
-		result.addAdvice(information.isReactiveRepository()
-				? new ConvertingImplementationMethodExecutionInterceptor(information, customImplementation, target)
-				: new ImplementationMethodExecutionInterceptor(information, customImplementation, target));
+		RepositoryComposition compositionToUse = composition.append(RepositoryFragment.implemented(target));
+		result.addAdvice(new ImplementationMethodExecutionInterceptor(compositionToUse));
 
 		return (T) result.getProxy(classLoader);
 	}
@@ -260,21 +338,19 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	 * Returns the {@link RepositoryInformation} for the given repository interface.
 	 *
 	 * @param metadata
-	 * @param customImplementationClass
+	 * @param composition
 	 * @return
 	 */
 	protected RepositoryInformation getRepositoryInformation(RepositoryMetadata metadata,
-			Optional<Class<?>> customImplementationClass) {
+			RepositoryComposition composition) {
 
-		RepositoryInformationCacheKey cacheKey = new RepositoryInformationCacheKey(metadata, customImplementationClass);
+		RepositoryInformationCacheKey cacheKey = new RepositoryInformationCacheKey(metadata, composition);
 
 		return repositoryInformationCache.computeIfAbsent(cacheKey, key -> {
 
 			Class<?> baseClass = repositoryBaseClass.orElse(getRepositoryBaseClass(metadata));
 
-			return metadata.isReactiveRepository()
-					? new ReactiveRepositoryInformation(metadata, baseClass, customImplementationClass)
-					: new DefaultRepositoryInformation(metadata, baseClass, customImplementationClass);
+			return new DefaultRepositoryInformation(metadata, baseClass, composition);
 		});
 	}
 
@@ -302,7 +378,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 	/**
 	 * Returns the base class backing the actual repository instance. Make sure
-	 * {@link #getTargetRepository(RepositoryMetadata)} returns an instance of this class.
+	 * {@link #getTargetRepository(RepositoryInformation)} returns an instance of this class.
 	 *
 	 * @param metadata
 	 * @return
@@ -326,20 +402,21 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	 * Validates the given repository interface as well as the given custom implementation.
 	 *
 	 * @param repositoryInformation
-	 * @param customImplementation
+	 * @param composition
 	 */
-	private void validate(RepositoryInformation repositoryInformation, Optional<Object> customImplementation) {
+	private void validate(RepositoryInformation repositoryInformation, RepositoryComposition composition) {
 
-		customImplementation.orElseGet(() -> {
+		if (repositoryInformation.hasCustomMethod()) {
 
-			if (!repositoryInformation.hasCustomMethod()) {
-				return null;
+			if (composition.isEmpty()) {
+
+				throw new IllegalArgumentException(
+						String.format("You have custom methods in %s but not provided a custom implementation!",
+								repositoryInformation.getRepositoryInterface()));
 			}
 
-			throw new IllegalArgumentException(
-					String.format("You have custom methods in %s but not provided a custom implementation!",
-							repositoryInformation.getRepositoryInterface()));
-		});
+			composition.validateImplementation();
+		}
 
 		validate(repositoryInformation);
 	}
@@ -356,11 +433,23 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	 * @param constructorArguments
 	 * @return
 	 */
-	@SuppressWarnings("unchecked")
 	protected final <R> R getTargetRepositoryViaReflection(RepositoryInformation information,
 			Object... constructorArguments) {
 
 		Class<?> baseClass = information.getRepositoryBaseClass();
+		return getTargetRepositoryViaReflection(baseClass, constructorArguments);
+	}
+
+	/**
+	 * Creates a repository of the repository base class defined in the given {@link RepositoryInformation} using
+	 * reflection.
+	 *
+	 * @param baseClass
+	 * @param constructorArguments
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	protected final <R> R getTargetRepositoryViaReflection(Class<?> baseClass, Object... constructorArguments) {
 		Optional<Constructor<?>> constructor = ReflectionUtils.findConstructor(baseClass, constructorArguments);
 
 		return constructor.map(it -> (R) BeanUtils.instantiateClass(it, constructorArguments))
@@ -467,16 +556,14 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	}
 
 	/**
-	 * Method interceptor that calls methods on either the base implementation or the custom repository implementation.
+	 * Method interceptor that calls methods on the {@link RepositoryComposition}.
 	 *
 	 * @author Mark Paluch
 	 */
 	@RequiredArgsConstructor
 	public class ImplementationMethodExecutionInterceptor implements MethodInterceptor {
 
-		private final RepositoryInformation repositoryInformation;
-		private final Optional<Object> customImplementation;
-		private final Object target;
+		private final @NonNull RepositoryComposition composition;
 
 		/* (non-Javadoc)
 		 * @see org.aopalliance.intercept.MethodInterceptor#invoke(org.aopalliance.intercept.MethodInvocation)
@@ -487,106 +574,13 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 			Method method = invocation.getMethod();
 			Object[] arguments = invocation.getArguments();
 
-			if (isCustomMethodInvocation(invocation)) {
-
-				Method actualMethod = repositoryInformation.getTargetClassMethod(method);
-				return executeMethodOn(customImplementation.get(), actualMethod, arguments);
-			}
-
-			// Lookup actual method as it might be redeclared in the interface
-			// and we have to use the repository instance nevertheless
-			Method actualMethod = repositoryInformation.getTargetClassMethod(method);
-			return executeMethodOn(target, actualMethod, arguments);
-		}
-
-		/**
-		 * Executes the given method on the given target. Correctly unwraps exceptions not caused by the reflection magic.
-		 *
-		 * @param target
-		 * @param method
-		 * @param parameters
-		 * @return
-		 * @throws Throwable
-		 */
-		protected Object executeMethodOn(Object target, Method method, Object[] parameters) throws Throwable {
-
 			try {
-				return method.invoke(target, parameters);
+				return composition.invoke(method, arguments);
 			} catch (Exception e) {
 				ClassUtils.unwrapReflectionException(e);
 			}
 
 			throw new IllegalStateException("Should not occur!");
-		}
-
-		/**
-		 * Returns whether the given {@link MethodInvocation} is considered to be targeted as an invocation of a custom
-		 * method.
-		 *
-		 * @param method
-		 * @return
-		 */
-		private boolean isCustomMethodInvocation(MethodInvocation invocation) {
-			return customImplementation.map(it -> repositoryInformation.isCustomMethod(invocation.getMethod())).orElse(false);
-		}
-	}
-
-	/**
-	 * Method interceptor that converts parameters before invoking a method.
-	 *
-	 * @author Mark Paluch
-	 */
-	public class ConvertingImplementationMethodExecutionInterceptor extends ImplementationMethodExecutionInterceptor {
-
-		/**
-		 * @param repositoryInformation
-		 * @param customImplementation
-		 * @param target
-		 */
-		public ConvertingImplementationMethodExecutionInterceptor(RepositoryInformation repositoryInformation,
-				Optional<Object> customImplementation, Object target) {
-
-			super(repositoryInformation, customImplementation, target);
-		}
-
-		/* (non-Javadoc)
-		 * @see org.springframework.data.repository.core.support.RepositoryFactorySupport.ImplementationMethodExecutionInterceptor#executeMethodOn(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
-		 */
-		@Override
-		protected Object executeMethodOn(Object target, Method method, Object[] parameters) throws Throwable {
-			return super.executeMethodOn(target, method, convertParameters(method.getParameterTypes(), parameters));
-		}
-
-		/**
-		 * @param parameterTypes
-		 * @param parameters
-		 * @return
-		 */
-		private Object[] convertParameters(Class<?>[] parameterTypes, Object[] parameters) {
-
-			if (parameters.length == 0) {
-				return parameters;
-			}
-
-			Object[] result = new Object[parameters.length];
-
-			for (int i = 0; i < parameters.length; i++) {
-
-				if (parameters[i] == null) {
-					continue;
-				}
-
-				if (!parameterTypes[i].isAssignableFrom(parameters[i].getClass()) && ReactiveWrappers.isAvailable()
-						&& ReactiveWrapperConverters.canConvert(parameters[i].getClass(), parameterTypes[i])) {
-
-					result[i] = ReactiveWrapperConverters.toWrapper(parameters[i], parameterTypes[i]);
-				} else {
-					result[i] = parameters[i];
-				}
-
-			}
-
-			return result;
 		}
 	}
 
@@ -616,24 +610,24 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	 * Simple value object to build up keys to cache {@link RepositoryInformation} instances.
 	 *
 	 * @author Oliver Gierke
+	 * @author Mark Paluch
 	 */
 	@EqualsAndHashCode
 	private static class RepositoryInformationCacheKey {
 
 		private final String repositoryInterfaceName;
-		private final String customImplementationClassName;
+		private final long compositionHash;
 
 		/**
-		 * Creates a new {@link RepositoryInformationCacheKey} for the given {@link RepositoryMetadata} and cuytom
-		 * implementation type.
+		 * Creates a new {@link RepositoryInformationCacheKey} for the given {@link RepositoryMetadata} and composition.
 		 *
 		 * @param repositoryInterfaceName must not be {@literal null}.
-		 * @param customImplementationClassName
+		 * @param composition
 		 */
-		public RepositoryInformationCacheKey(RepositoryMetadata metadata, Optional<Class<?>> customImplementationType) {
+		public RepositoryInformationCacheKey(RepositoryMetadata metadata, RepositoryComposition composition) {
 
 			this.repositoryInterfaceName = metadata.getRepositoryInterface().getName();
-			this.customImplementationClassName = customImplementationType.map(Class::getName).orElse(null);
+			this.compositionHash = composition.hashCode();
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFragment.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFragment.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Value object representing a repository fragment. A fragment can be purely structural or implemented.
+ * <p/>
+ * Structural fragments are not backed by an implementation and are primarily used to discover the structure of a
+ * repository composition and to perform validations.
+ * <p/>
+ * Implemented repository fragments consist of a signature contributor and the implementing object. A signature
+ * contributor may be an interface or just the implementing object providing the available signatures for a repository.
+ * <p/>
+ * Fragment objects are immutable and thread-safe.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public abstract class RepositoryFragment<T> {
+
+	/**
+	 * Create an implemented {@link RepositoryFragment} backed by the {@code implementation} object.
+	 *
+	 * @param implementation must not be {@literal null}.
+	 * @return
+	 */
+	public static <T> RepositoryFragment<T> implemented(T implementation) {
+		return new ImplementedRepositoryFragment<T>(Optional.empty(), implementation);
+	}
+
+	/**
+	 * Create an implemented {@link RepositoryFragment} from a {@code interfaceClass} backed by the {@code implementation}
+	 * object.
+	 *
+	 * @param implementation must not be {@literal null}.
+	 * @return
+	 */
+	public static <T> RepositoryFragment<T> implemented(Class<T> interfaceClass, T implementation) {
+		return new ImplementedRepositoryFragment<>(Optional.of(interfaceClass), implementation);
+	}
+
+	/**
+	 * Create a structural {@link RepositoryFragment} given {@code interfaceOrImplementation}.
+	 *
+	 * @param interfaceOrImplementation must not be {@literal null}.
+	 * @return
+	 */
+	public static <T> RepositoryFragment<T> structural(Class<T> interfaceOrImplementation) {
+		return new StructuralRepositoryFragment<>(interfaceOrImplementation);
+	}
+
+	/**
+	 * Attempt to find the {@link Method} by name and exact parameters. Returns {@literal true} if the method was found or
+	 * {@literal false} otherwise.
+	 *
+	 * @param method must not be {@literal null}.
+	 * @return {@literal true} if the method was found or {@literal false} otherwise
+	 */
+	public boolean hasMethod(Method method) {
+
+		Assert.notNull(method, "Method must not be null!");
+		return ReflectionUtils.findMethod(getSignatureContributor(), method.getName(), method.getParameterTypes()) != null;
+	}
+
+	/**
+	 * @return the class/interface providing signatures for this {@link RepositoryFragment}.
+	 */
+	protected abstract Class<?> getSignatureContributor();
+
+	/**
+	 * @return the optional implementation. Only available for implemented fragments. Structural fragments return always
+	 *         {@link Optional#empty()}.
+	 */
+	public Optional<T> getImplementation() {
+		return Optional.empty();
+	}
+
+	/**
+	 * Implement a structural {@link RepositoryFragment} given its {@code implementation} object. Returns an implemented
+	 * {@link RepositoryFragment}.
+	 *
+	 * @param implementation must not be {@literal null}.
+	 * @return a new implemented {@link RepositoryFragment} for {@code implementation}.
+	 */
+	public abstract RepositoryFragment<T> withImplementation(T implementation);
+
+	/**
+	 * @return a {@link Stream} of methods exposed by this {@link RepositoryFragment}.
+	 */
+	public Stream<Method> methods() {
+		return Arrays.stream(getSignatureContributor().getMethods());
+	}
+
+	@RequiredArgsConstructor
+	@EqualsAndHashCode(callSuper = false)
+	static class StructuralRepositoryFragment<T> extends RepositoryFragment<T> {
+
+		private final @NonNull Class<T> interfaceOrImplementation;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.RepositoryFragment#getSignatureContributor()
+		 */
+		@Override
+		public Class<?> getSignatureContributor() {
+			return interfaceOrImplementation;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.RepositoryFragment#withImplementation(java.lang.Object)
+		 */
+		@Override
+		public RepositoryFragment<T> withImplementation(T implementation) {
+			return new ImplementedRepositoryFragment<>(Optional.of(interfaceOrImplementation), implementation);
+		}
+	}
+
+	@RequiredArgsConstructor
+	@EqualsAndHashCode(callSuper = false)
+	static class ImplementedRepositoryFragment<T> extends RepositoryFragment<T> {
+
+		private final @NonNull Optional<Class<T>> interfaceClass;
+		private final @NonNull T implementation;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.RepositoryFragment#getSignatureContributor()
+		 */
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		public Class<?> getSignatureContributor() {
+			return interfaceClass.orElse((Class) implementation.getClass());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.RepositoryFragment#getImplementation()
+		 */
+		@Override
+		public Optional<T> getImplementation() {
+			return Optional.of(implementation);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.core.support.RepositoryFragment#withImplementation(java.lang.Object)
+		 */
+		@Override
+		public RepositoryFragment<T> withImplementation(T implementation) {
+			return new ImplementedRepositoryFragment<>(interfaceClass, implementation);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFragment.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFragment.java
@@ -25,21 +25,27 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 
 /**
- * Value object representing a repository fragment. A fragment can be purely structural or implemented.
+ * Value object representing a repository fragment.
+ * <p />
+ * Repository fragments are individual parts that contribute method signatures. They are used to form a
+ * {@link RepositoryComposition}. Fragments can be purely structural or backed with an implementation.
  * <p/>
- * Structural fragments are not backed by an implementation and are primarily used to discover the structure of a
- * repository composition and to perform validations.
+ * {@link #structural(Class) Structural} fragments are not backed by an implementation and are primarily used to
+ * discover the structure of a repository composition and to perform validations.
  * <p/>
- * Implemented repository fragments consist of a signature contributor and the implementing object. A signature
- * contributor may be an interface or just the implementing object providing the available signatures for a repository.
+ * {@link #implemented(Object) Implemented} repository fragments consist of a signature contributor and the implementing
+ * object. A signature contributor may be {@link #implemented(Class, Object) an interface} or
+ * {@link #implemented(Object) just the implementing object} providing the available signatures for a repository.
  * <p/>
- * Fragment objects are immutable and thread-safe.
+ * Fragments are immutable.
  *
  * @author Mark Paluch
  * @since 2.0
+ * @see RepositoryComposition
  */
 public abstract class RepositoryFragment<T> {
 
@@ -50,7 +56,7 @@ public abstract class RepositoryFragment<T> {
 	 * @return
 	 */
 	public static <T> RepositoryFragment<T> implemented(T implementation) {
-		return new ImplementedRepositoryFragment<T>(Optional.empty(), implementation);
+		return new ImplementedRepositoryFragment<>(Optional.empty(), implementation);
 	}
 
 	/**
@@ -122,8 +128,7 @@ public abstract class RepositoryFragment<T> {
 
 		private final @NonNull Class<T> interfaceOrImplementation;
 
-		/*
-		 * (non-Javadoc)
+		/* (non-Javadoc)
 		 * @see org.springframework.data.repository.core.support.RepositoryFragment#getSignatureContributor()
 		 */
 		@Override
@@ -131,13 +136,21 @@ public abstract class RepositoryFragment<T> {
 			return interfaceOrImplementation;
 		}
 
-		/*
-		 * (non-Javadoc)
+		/* (non-Javadoc)
 		 * @see org.springframework.data.repository.core.support.RepositoryFragment#withImplementation(java.lang.Object)
 		 */
 		@Override
 		public RepositoryFragment<T> withImplementation(T implementation) {
 			return new ImplementedRepositoryFragment<>(Optional.of(interfaceOrImplementation), implementation);
+		}
+
+		/* (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+
+			return String.format("StructuralRepositoryFragment %s", ClassUtils.getShortName(interfaceOrImplementation));
 		}
 	}
 
@@ -148,8 +161,7 @@ public abstract class RepositoryFragment<T> {
 		private final @NonNull Optional<Class<T>> interfaceClass;
 		private final @NonNull T implementation;
 
-		/*
-		 * (non-Javadoc)
+		/* (non-Javadoc)
 		 * @see org.springframework.data.repository.core.support.RepositoryFragment#getSignatureContributor()
 		 */
 		@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -157,8 +169,7 @@ public abstract class RepositoryFragment<T> {
 			return interfaceClass.orElse((Class) implementation.getClass());
 		}
 
-		/*
-		 * (non-Javadoc)
+		/* (non-Javadoc)
 		 * @see org.springframework.data.repository.core.support.RepositoryFragment#getImplementation()
 		 */
 		@Override
@@ -166,13 +177,23 @@ public abstract class RepositoryFragment<T> {
 			return Optional.of(implementation);
 		}
 
-		/*
-		 * (non-Javadoc)
+		/* (non-Javadoc)
 		 * @see org.springframework.data.repository.core.support.RepositoryFragment#withImplementation(java.lang.Object)
 		 */
 		@Override
 		public RepositoryFragment<T> withImplementation(T implementation) {
 			return new ImplementedRepositoryFragment<>(interfaceClass, implementation);
+		}
+
+		/* (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+
+			return String.format("ImplementedRepositoryFragment %s%s",
+					interfaceClass.map(ClassUtils::getShortName).map(it -> it + ":").orElse(""),
+					ClassUtils.getShortName(implementation.getClass()));
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFragmentsFactoryBean.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFragmentsFactoryBean.java
@@ -53,20 +53,32 @@ public class RepositoryFragmentsFactoryBean<T>
 		this.fragmentBeanNames = fragmentBeanNames;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
+	 */
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */
 	@Override
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void afterPropertiesSet() {
 
-		List<RepositoryFragment<?>> fragments = (List) fragmentBeanNames.stream()
-				.map(it -> beanFactory.getBean(it, RepositoryFragment.class)).collect(Collectors.toList());
+		List<RepositoryFragment<?>> fragments = (List) fragmentBeanNames.stream() //
+				.map(it -> beanFactory.getBean(it, RepositoryFragment.class)) //
+				.collect(Collectors.toList());
 
 		this.repositoryFragments = RepositoryFragments.from(fragments);
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.beans.factory.FactoryBean#getObject()
 	 */
 	@Override
@@ -80,13 +92,5 @@ public class RepositoryFragmentsFactoryBean<T>
 	@Override
 	public Class<?> getObjectType() {
 		return RepositoryComposition.class;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
-	 */
-	@Override
-	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		this.beanFactory = beanFactory;
 	}
 }

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFragmentsFactoryBean.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFragmentsFactoryBean.java
@@ -23,30 +23,31 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
 import org.springframework.util.Assert;
 
 /**
- * Factory bean for creation of {@link RepositoryComposition}. This {@link FactoryBean} uses named
- * {@link #RepositoryCompositionFactoryBean(List) bean references} to look up {@link RepositoryFragment} beans and
- * construct a {@link RepositoryComposition}.
+ * Factory bean for creation of {@link RepositoryFragments}. This {@link FactoryBean} uses named
+ * {@link #RepositoryFragmentsFactoryBean(List) bean references} to look up {@link RepositoryFragment} beans and
+ * construct {@link RepositoryFragments}.
  *
  * @author Mark Paluch
  * @since 2.0
  */
-public class RepositoryCompositionFactoryBean<T>
-		implements FactoryBean<RepositoryComposition>, BeanFactoryAware, InitializingBean {
+public class RepositoryFragmentsFactoryBean<T>
+		implements FactoryBean<RepositoryFragments>, BeanFactoryAware, InitializingBean {
 
 	private final List<String> fragmentBeanNames;
 
 	private BeanFactory beanFactory;
-	private RepositoryComposition repositoryComposition = RepositoryComposition.empty();
+	private RepositoryFragments repositoryFragments = RepositoryFragments.empty();
 
 	/**
-	 * Creates a new {@link RepositoryCompositionFactoryBean} given {@code fragmentBeanNames}.
+	 * Creates a new {@link RepositoryFragmentsFactoryBean} given {@code fragmentBeanNames}.
 	 *
 	 * @param fragmentBeanNames must not be {@literal null}.
 	 */
-	public RepositoryCompositionFactoryBean(List<String> fragmentBeanNames) {
+	public RepositoryFragmentsFactoryBean(List<String> fragmentBeanNames) {
 
 		Assert.notNull(fragmentBeanNames, "Fragment bean names must not be null!");
 		this.fragmentBeanNames = fragmentBeanNames;
@@ -59,17 +60,18 @@ public class RepositoryCompositionFactoryBean<T>
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void afterPropertiesSet() {
 
-		List<RepositoryFragment<?>> collect = (List) fragmentBeanNames.stream()
+		List<RepositoryFragment<?>> fragments = (List) fragmentBeanNames.stream()
 				.map(it -> beanFactory.getBean(it, RepositoryFragment.class)).collect(Collectors.toList());
-		this.repositoryComposition = RepositoryComposition.of(collect);
+
+		this.repositoryFragments = RepositoryFragments.from(fragments);
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.beans.factory.FactoryBean#getObject()
 	 */
 	@Override
-	public RepositoryComposition getObject() throws Exception {
-		return this.repositoryComposition;
+	public RepositoryFragments getObject() throws Exception {
+		return this.repositoryFragments;
 	}
 
 	/* (non-Javadoc)

--- a/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.util.Streamable;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class AnnotationRepositoryConfigurationSourceUnitTests {
 
@@ -62,14 +63,13 @@ public class AnnotationRepositoryConfigurationSourceUnitTests {
 				.contains(AnnotationRepositoryConfigurationSourceUnitTests.class.getPackage().getName());
 	}
 
-	@Test // DATACMNS-47
+	@Test // DATACMNS-47, DATACMNS-102
 	public void evaluatesExcludeFiltersCorrectly() {
 
 		Streamable<BeanDefinition> candidates = source.getCandidates(new DefaultResourceLoader());
-		assertThat(candidates).hasSize(1);
 
-		BeanDefinition candidate = candidates.iterator().next();
-		assertThat(candidate.getBeanClassName()).isEqualTo(MyRepository.class.getName());
+		assertThat(candidates).hasSize(2).extracting("beanClassName").containsOnly(MyRepository.class.getName(),
+				ComposedRepository.class.getName());
 	}
 
 	@Test // DATACMNS-47

--- a/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
@@ -35,7 +35,7 @@ import org.springframework.data.util.Streamable;
 
 /**
  * Unit tests for {@link AnnotationRepositoryConfigurationSource}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  */

--- a/src/test/java/org/springframework/data/repository/config/ComposedRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/ComposedRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSourceUnitTests.Person;
+
+/**
+ * @author Mark Paluch
+ */
+public interface ComposedRepository extends Repository<Person, Long>, Mixin {}

--- a/src/test/java/org/springframework/data/repository/config/Mixin.java
+++ b/src/test/java/org/springframework/data/repository/config/Mixin.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+/**
+ * @author Mark Paluch
+ */
+public interface Mixin {
+
+	String getOne();
+}

--- a/src/test/java/org/springframework/data/repository/config/MixinImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/MixinImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+/**
+ * @author Mark Paluch
+ */
+public class MixinImpl implements Mixin {
+
+	@Override
+	public String getOne() {
+		return "one";
+	}
+}

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportIntegrationTests.java
@@ -29,9 +29,10 @@ import org.springframework.data.repository.config.RepositoryBeanDefinitionRegist
 
 /**
  * Integration tests for {@link RepositoryBeanDefinitionRegistrarSupport}.
- * 
+ *
  * @author Oliver Gierke
  * @author Peter Rietzler
+ * @author Mark Paluch
  */
 public class RepositoryBeanDefinitionRegistrarSupportIntegrationTests {
 
@@ -84,5 +85,10 @@ public class RepositoryBeanDefinitionRegistrarSupportIntegrationTests {
 	@Test // DATACMNS-544
 	public void registersExtensionAsBeanDefinition() {
 		assertThat(context.getBean(DummyConfigurationExtension.class)).isNotNull();
+	}
+
+	@Test // DATACMNS-102
+	public void composedRepositoriesShouldBeAssembledCorrectly() {
+		assertThat(context.getBean(ComposedRepository.class).getOne()).isEqualTo("one");
 	}
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportUnitTests.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.data.repository.config;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.lang.annotation.Annotation;
@@ -37,6 +38,7 @@ import org.springframework.data.repository.core.support.DummyRepositoryFactoryBe
  * Integration test for {@link RepositoryBeanDefinitionRegistrarSupport}.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
@@ -63,6 +65,9 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 		registrar.registerBeanDefinitions(metadata, registry);
 
 		assertBeanDefinitionRegisteredFor("myRepository");
+		assertBeanDefinitionRegisteredFor("composedRepository");
+		assertBeanDefinitionRegisteredFor("mixinImpl");
+		assertBeanDefinitionRegisteredFor("mixinImplFragment");
 		assertNoBeanDefinitionRegisteredFor("profileRepository");
 	}
 
@@ -100,7 +105,7 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 			setResourceLoader(new DefaultResourceLoader());
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getAnnotation()
 		 */
@@ -109,7 +114,7 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 			return EnableRepositories.class;
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getExtension()
 		 */

--- a/src/test/java/org/springframework/data/repository/core/support/DefaultCrudMethodsUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DefaultCrudMethodsUnitTests.java
@@ -35,7 +35,7 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 
 /**
  * Unit tests dor {@link DefaultCrudMethods}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  */

--- a/src/test/java/org/springframework/data/repository/core/support/DefaultCrudMethodsUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DefaultCrudMethodsUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.repository.core.RepositoryMetadata;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class DefaultCrudMethodsUnitTests {
 
@@ -143,7 +144,7 @@ public class DefaultCrudMethodsUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(repositoryInterface);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, PagingAndSortingRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		return new DefaultCrudMethods(information);
 	}

--- a/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
@@ -47,7 +47,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
 
 /**
  * Unit tests for {@link DefaultRepositoryInformation}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch

--- a/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,8 @@ public class DefaultRepositoryInformationUnitTests {
 
 		Method method = FooRepository.class.getMethod("findById", Integer.class);
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
-		DefaultRepositoryInformation information = new DefaultRepositoryInformation(metadata, REPOSITORY, Optional.empty());
+		DefaultRepositoryInformation information = new DefaultRepositoryInformation(metadata, REPOSITORY,
+				RepositoryComposition.empty().withMethodLookup(MethodLookups.forRepositoryTypes(metadata)));
 
 		Method reference = information.getTargetClassMethod(method);
 		assertThat(reference.getDeclaringClass()).isEqualTo(REPOSITORY);
@@ -78,7 +79,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
 		DefaultRepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty().withMethodLookup(MethodLookups.forRepositoryTypes(metadata)));
 
 		assertThat(information.getTargetClassMethod(method)).isEqualTo(method);
 	}
@@ -88,7 +89,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.of(customImplementation.getClass()));
+				RepositoryComposition.just(customImplementation));
 
 		Method source = FooRepositoryCustom.class.getMethod("save", User.class);
 		Method expected = customImplementation.getClass().getMethod("save", User.class);
@@ -101,7 +102,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(ConcreteRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		assertThat(information.hasCustomMethod()).isFalse();
 	}
@@ -111,7 +112,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		DefaultRepositoryMetadata metadata = new DefaultRepositoryMetadata(CustomRepository.class);
 		DefaultRepositoryInformation information = new DefaultRepositoryInformation(metadata,
-				PagingAndSortingRepository.class, Optional.empty());
+				PagingAndSortingRepository.class, RepositoryComposition.empty());
 
 		Method method = CustomRepository.class.getMethod("findAll", Pageable.class);
 		assertThat(information.isBaseClassMethod(method)).isTrue();
@@ -127,7 +128,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(CustomRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, PagingAndSortingRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		assertThat(information.getQueryMethods()).isEmpty();
 	}
@@ -137,7 +138,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(ConcreteRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		Method saveMethod = BaseRepository.class.getMethod("save", Object.class);
 		Method deleteMethod = BaseRepository.class.getMethod("delete", Object.class);
@@ -152,7 +153,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(ConcreteRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		Method intermediateMethod = BaseRepository.class.getMethod("genericMethodToOverride", String.class);
 		Method concreteMethod = ConcreteRepository.class.getMethod("genericMethodToOverride", String.class);
@@ -168,7 +169,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(ConcreteRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		Method queryMethod = getMethodFrom(ConcreteRepository.class, "findBySomethingDifferent");
 
@@ -181,7 +182,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(ConcreteRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		Method method = BaseRepository.class.getMethod("findById", Object.class);
 
@@ -193,7 +194,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(BossRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		Method method = BossRepository.class.getMethod("saveAll", Iterable.class);
 		Method reference = CrudRepository.class.getMethod("saveAll", Iterable.class);
@@ -206,7 +207,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(CustomDefaultRepositoryMethodsRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		assertThat(information.getQueryMethods()).allMatch(method -> !method.isBridge());
 	}
@@ -216,7 +217,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.of(customImplementation.getClass()));
+				RepositoryComposition.just(customImplementation));
 
 		Method source = FooRepositoryCustom.class.getMethod("exists", Object.class);
 		Method expected = customImplementation.getClass().getMethod("exists", Object.class);
@@ -230,7 +231,7 @@ public class DefaultRepositoryInformationUnitTests {
 		GenericsSaveRepositoryImpl customImplementation = new GenericsSaveRepositoryImpl();
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(GenericsSaveRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, RepositoryFactorySupport.class,
-				Optional.of(customImplementation.getClass()));
+				RepositoryComposition.just(customImplementation).withMethodLookup(MethodLookups.forRepositoryTypes(metadata)));
 
 		Method customBaseRepositoryMethod = GenericsSaveRepository.class.getMethod("save", Object.class);
 		assertThat(information.isCustomMethod(customBaseRepositoryMethod)).isTrue();
@@ -241,7 +242,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.of(customImplementation.getClass()));
+				RepositoryComposition.just(customImplementation));
 
 		Method method = FooRepository.class.getMethod("staticMethod");
 
@@ -253,7 +254,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(FooRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, CrudRepository.class,
-				Optional.of(customImplementation.getClass()));
+				RepositoryComposition.just(customImplementation));
 
 		Method method = FooRepository.class.getMethod("defaultMethod");
 
@@ -265,7 +266,7 @@ public class DefaultRepositoryInformationUnitTests {
 
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(DummyRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, DummyRepositoryImpl.class,
-				Optional.empty());
+				RepositoryComposition.empty());
 
 		Method method = DummyRepository.class.getMethod("saveAll", Iterable.class);
 
@@ -279,7 +280,7 @@ public class DefaultRepositoryInformationUnitTests {
 		SimpleSaveRepositoryImpl customImplementation = new SimpleSaveRepositoryImpl();
 		RepositoryMetadata metadata = new DefaultRepositoryMetadata(SimpleSaveRepository.class);
 		RepositoryInformation information = new DefaultRepositoryInformation(metadata, RepositoryFactorySupport.class,
-				Optional.of(customImplementation.getClass()));
+				RepositoryComposition.just(customImplementation).withMethodLookup(MethodLookups.forRepositoryTypes(metadata)));
 
 		Method customBaseRepositoryMethod = SimpleSaveRepository.class.getMethod("save", Object.class);
 		assertThat(information.isCustomMethod(customBaseRepositoryMethod)).isTrue();

--- a/src/test/java/org/springframework/data/repository/core/support/ReactiveWrapperRepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/ReactiveWrapperRepositoryFactorySupportUnitTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.repository.core.support;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.reactivex.Completable;
@@ -37,7 +37,7 @@ import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 
 /**
  * Unit tests for {@link RepositoryFactorySupport} using reactive wrapper types.
- * 
+ *
  * @author Mark Paluch
  * @author Christoph Strobl
  */

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import lombok.Data;
+
+import java.lang.reflect.Method;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Unit tests for {@link RepositoryComposition}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RepositoryCompositionUnitTests {
+
+	@Mock QueryByExampleExecutor<Person> queryByExampleExecutor;
+
+	@Mock PersonRepository backingRepo;
+
+	RepositoryComposition repositoryComposition;
+
+	@Before
+	public void before() {
+
+		RepositoryInformation repositoryInformation = new DefaultRepositoryInformation(
+				new DefaultRepositoryMetadata(PersonRepository.class), backingRepo.getClass(), RepositoryComposition.empty());
+
+		RepositoryFragment<QueryByExampleExecutor> mixin = RepositoryFragment.implemented(QueryByExampleExecutor.class,
+				queryByExampleExecutor);
+
+		RepositoryFragment<PersonRepository> base = RepositoryFragment.implemented(backingRepo);
+
+		repositoryComposition = RepositoryComposition.of(RepositoryFragments.of(mixin, base))
+				.withMethodLookup(MethodLookups.forRepositoryTypes(repositoryInformation));
+	}
+
+	@Test // DATACMNS-102
+	public void shouldReportIfEmpty() {
+
+		assertThat(RepositoryComposition.empty().isEmpty()).isTrue();
+		assertThat(repositoryComposition.isEmpty()).isFalse();
+	}
+
+	@Test // DATACMNS-102
+	public void shouldCallSaveOnBackingRepo() throws Throwable {
+
+		Method save = ReflectionUtils.findMethod(PersonRepository.class, "save", Person.class);
+
+		Method method = repositoryComposition.findMethod(save).get();
+
+		Person person = new Person();
+		repositoryComposition.invoke(method, person);
+
+		verify(backingRepo).save(person);
+	}
+
+	@Test // DATACMNS-102
+	public void shouldCallObjectSaveOnBackingRepo() throws Throwable {
+
+		Method save = ReflectionUtils.findMethod(PersonRepository.class, "save", Object.class);
+
+		Method method = repositoryComposition.findMethod(save).get();
+
+		Person person = new Person();
+		repositoryComposition.invoke(method, person);
+
+		verify(backingRepo).save((Object) person);
+	}
+
+	@Test // DATACMNS-102
+	public void shouldCallFindOneOnMixin() throws Throwable {
+
+		Method findOne = ReflectionUtils.findMethod(PersonRepository.class, "findOne", Example.class);
+
+		Method method = repositoryComposition.findMethod(findOne).get();
+
+		Person person = new Person();
+		Example<Person> example = Example.of(person);
+
+		repositoryComposition.invoke(method, example);
+
+		verify(queryByExampleExecutor).findOne(example);
+	}
+
+	@Test // DATACMNS-102
+	public void shouldCallMethodsInOrder() throws Throwable {
+
+		RepositoryInformation repositoryInformation = new DefaultRepositoryInformation(
+				new DefaultRepositoryMetadata(OrderedRepository.class), OrderedRepository.class, RepositoryComposition.empty());
+
+		RepositoryFragment<?> foo = RepositoryFragment.implemented(FooMixinImpl.INSTANCE);
+		RepositoryFragment<?> bar = RepositoryFragment.implemented(BarMixinImpl.INSTANCE);
+
+		RepositoryComposition fooBar = RepositoryComposition.of(RepositoryFragments.of(foo, bar))
+				.withMethodLookup(MethodLookups.forRepositoryTypes(repositoryInformation));
+
+		RepositoryComposition barFoo = RepositoryComposition.of(RepositoryFragments.of(bar, foo))
+				.withMethodLookup(MethodLookups.forRepositoryTypes(repositoryInformation));
+
+		Method getString = ReflectionUtils.findMethod(OrderedRepository.class, "getString");
+
+		assertThat(fooBar.invoke(fooBar.findMethod(getString).get())).isEqualTo("foo");
+
+		assertThat(barFoo.invoke(barFoo.findMethod(getString).get())).isEqualTo("bar");
+	}
+
+	@Test // DATACMNS-102
+	public void shouldValidateStructuralFragments() {
+
+		RepositoryComposition mixed = RepositoryComposition.of(RepositoryFragment.structural(QueryByExampleExecutor.class),
+				RepositoryFragment.implemented(backingRepo));
+
+		assertThatExceptionOfType(IllegalStateException.class) //
+				.isThrownBy(mixed::validateImplementation) //
+				.withMessageContaining(
+						"Fragment org.springframework.data.repository.query.QueryByExampleExecutor has no implementation.");
+	}
+
+	@Test // DATACMNS-102
+	public void shouldValidateImplementationFragments() {
+
+		RepositoryComposition mixed = RepositoryComposition.of(RepositoryFragment.implemented(backingRepo));
+
+		mixed.validateImplementation();
+	}
+
+	interface PersonRepository extends Repository<Person, String>, QueryByExampleExecutor<Person> {
+
+		Person save(Person entity);
+
+		Person save(Object entity);
+
+		Person findOne(Person entity);
+	}
+
+	@Data
+	static class Person {
+
+		@Id String id;
+	}
+
+	@Data
+	static class Contact {
+
+		@Id String id;
+	}
+
+	interface OrderedRepository extends Repository<Person, String>, FooMixin, BarMixin {
+
+	}
+
+	interface FooMixin {
+
+		String getString();
+	}
+
+	enum FooMixinImpl implements FooMixin {
+		INSTANCE;
+
+		@Override
+		public String getString() {
+			return "foo";
+		}
+	}
+
+	interface BarMixin {
+
+		String getString();
+	}
+
+	enum BarMixinImpl implements BarMixin {
+		INSTANCE;
+
+		@Override
+		public String getString() {
+			return "bar";
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
@@ -157,19 +157,6 @@ public class RepositoryCompositionUnitTests {
 
 	@Test // DATACMNS-102
 	@SuppressWarnings("rawtypes")
-	public void shouldPrependCorrectly() {
-
-		RepositoryFragment<PersonRepository> initial = RepositoryFragment.implemented(backingRepo);
-		RepositoryFragment<QueryByExampleExecutor> structural = RepositoryFragment.structural(QueryByExampleExecutor.class);
-
-		assertThat(RepositoryComposition.of(initial).prepend(structural).getFragments()).containsSequence(structural,
-				initial);
-		assertThat(RepositoryComposition.of(initial).prepend(RepositoryFragments.of(structural)).getFragments())
-				.containsSequence(structural, initial);
-	}
-
-	@Test // DATACMNS-102
-	@SuppressWarnings("rawtypes")
 	public void shouldAppendCorrectly() {
 
 		RepositoryFragment<PersonRepository> initial = RepositoryFragment.implemented(backingRepo);

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
@@ -39,17 +39,18 @@ import org.springframework.util.ReflectionUtils;
  * Unit tests for {@link RepositoryComposition}.
  *
  * @author Mark Paluch
+ * @author Oliver Gierke
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RepositoryCompositionUnitTests {
 
 	@Mock QueryByExampleExecutor<Person> queryByExampleExecutor;
-
 	@Mock PersonRepository backingRepo;
 
 	RepositoryComposition repositoryComposition;
 
 	@Before
+	@SuppressWarnings("rawtypes")
 	public void before() {
 
 		RepositoryInformation repositoryInformation = new DefaultRepositoryInformation(
@@ -155,6 +156,7 @@ public class RepositoryCompositionUnitTests {
 	}
 
 	@Test // DATACMNS-102
+	@SuppressWarnings("rawtypes")
 	public void shouldPrependCorrectly() {
 
 		RepositoryFragment<PersonRepository> initial = RepositoryFragment.implemented(backingRepo);
@@ -167,6 +169,7 @@ public class RepositoryCompositionUnitTests {
 	}
 
 	@Test // DATACMNS-102
+	@SuppressWarnings("rawtypes")
 	public void shouldAppendCorrectly() {
 
 		RepositoryFragment<PersonRepository> initial = RepositoryFragment.implemented(backingRepo);

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
@@ -154,6 +154,30 @@ public class RepositoryCompositionUnitTests {
 		mixed.validateImplementation();
 	}
 
+	@Test // DATACMNS-102
+	public void shouldPrependCorrectly() {
+
+		RepositoryFragment<PersonRepository> initial = RepositoryFragment.implemented(backingRepo);
+		RepositoryFragment<QueryByExampleExecutor> structural = RepositoryFragment.structural(QueryByExampleExecutor.class);
+
+		assertThat(RepositoryComposition.of(initial).prepend(structural).getFragments()).containsSequence(structural,
+				initial);
+		assertThat(RepositoryComposition.of(initial).prepend(RepositoryFragments.of(structural)).getFragments())
+				.containsSequence(structural, initial);
+	}
+
+	@Test // DATACMNS-102
+	public void shouldAppendCorrectly() {
+
+		RepositoryFragment<PersonRepository> initial = RepositoryFragment.implemented(backingRepo);
+		RepositoryFragment<QueryByExampleExecutor> structural = RepositoryFragment.structural(QueryByExampleExecutor.class);
+
+		assertThat(RepositoryComposition.of(initial).append(structural).getFragments()).containsSequence(initial,
+				structural);
+		assertThat(RepositoryComposition.of(initial).append(RepositoryFragments.of(structural)).getFragments())
+				.containsSequence(initial, structural);
+	}
+
 	interface PersonRepository extends Repository<Person, String>, QueryByExampleExecutor<Person> {
 
 		Person save(Person entity);

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.sample.User;
 import org.springframework.data.util.Version;
@@ -119,6 +120,17 @@ public class RepositoryFactorySupportUnitTests {
 	public void invokesCustomMethodIfItRedeclaresACRUDOne() {
 
 		ObjectRepository repository = factory.getRepository(ObjectRepository.class, customImplementation);
+		repository.findById(1);
+
+		verify(customImplementation, times(1)).findById(1);
+		verify(backingRepo, times(0)).findById(1);
+	}
+
+	@Test // DATACMNS-102
+	public void invokesCustomMethodCompositionMethodIfItRedeclaresACRUDOne() {
+
+		ObjectRepository repository = factory.getRepository(ObjectRepository.class,
+				RepositoryFragments.just(customImplementation));
 		repository.findById(1);
 
 		verify(customImplementation, times(1)).findById(1);

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -63,7 +63,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * Unit tests for {@link RepositoryFactorySupport}.
- * 
+ *
  * @author Oliver Gierke
  * @author Mark Paluch
  */


### PR DESCRIPTION
We now use `RepositoryComposition` as backing implementation for repository method calls to implementations. `RepositoryComposition` are subject to `MethodLookup` and argument converter customization to select the target method that should be invoked. A composition consists of one or more fragments that contribute their API backed by an implementation.

During configuration, we scan for repository fragments. Fragment implementation candidates derive from the repository interface declaration, specifically the declared interfaces and their order. We scan the class path during fragment scan for each interface and add discovered fragments to the repository composition. The name of the implementation is derived from the simple name of the interface and the implementation suffix. Qualified fragments are top-level interface declarations that are not annotated with `@NoRepositoryBean`. Inherited interfaces are not considered as fragment candidates.

```java
interface ComposedRepository extends Repository<Person, Long>, 
                                                    WriteRepository<Person>, 
                                                    ReadRepository<Person>, 
                                                    QueryByExampleExecutor<Person> {}

// fragment candidate
interface WriteRepository<T> extends BaseRepository {}
// fragment implementation
class WriteRepositoryImpl<T> extends BaseRepositoryImpl implements WriteRepository<T> {}

// transient dependency of ComposedRepository, not a fragment candidate
interface BaseRepository {}
// ignored
class BaseRepositoryImpl implements BaseRepository {}

// fragment candidate
interface ReadRepository<T> extends BaseRepository {}
// fragment implementation
class ReadRepositoryImpl<T> implements ReadRepository<T> {}

// excluded fragment (can be added by RepositoryFactorySupport)
@NoRepositoryBean
interface QueryByExampleExecutor<Person> {}

```
We create a `RepositoryComposition` from the discovered fragments in the order of interface declaration in the repository interface and supply the composition to the actual repository creation.

---

Related ticket: [DATACMNS-102](https://jira.spring.io/browse/DATACMNS-102).