### PR TITLE
DATACMNS-991 Update DefaultMethodInvokingMethodInterceptor to Java 9 compatible method handle invocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-
+  <version>2.0.0.DATACMNS-991-SNAPSHOT</version>
 	<name>Spring Data Core</name>
 
 	<parent>


### PR DESCRIPTION
The two code paths are there and they make access violations go away in the example projects.

I don't see how we can get useful tests into this at this stage. There might be some testing possible, once DATACMNS-1033 is finished, but there is still a lot of work to do for that. 