### PR TITLE
DATACMNS-1063 - Accept Publisher in findById(…) and existsById(…)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
+	<version>2.0.0.DATACMNS-1063-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
@@ -73,11 +73,11 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	/**
 	 * Retrieves an entity by its id supplied by a {@link Mono}.
 	 *
-	 * @param id must not be {@literal null}.
+	 * @param id must not be {@literal null}. Uses the first emitted element to perform the find-query.
 	 * @return the entity with the given id or {@link Mono#empty()} if none found.
 	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
 	 */
-	Mono<T> findById(Mono<ID> id);
+	Mono<T> findById(Publisher<ID> id);
 
 	/**
 	 * Returns whether an entity with the given id exists.
@@ -89,13 +89,14 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	Mono<Boolean> existsById(ID id);
 
 	/**
-	 * Returns whether an entity with the given id, supplied by a {@link Mono}, exists.
+	 * Returns whether an entity with the given id, supplied by a {@link Mono}, exists. Uses the first emitted element to
+	 * perform the exists-query.
 	 *
 	 * @param id must not be {@literal null}.
 	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise
 	 * @throws IllegalArgumentException if {@code id} is {@literal null}
 	 */
-	Mono<Boolean> existsById(Mono<ID> id);
+	Mono<Boolean> existsById(Publisher<ID> id);
 
 	/**
 	 * Returns all instances of the type.

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
@@ -27,6 +27,7 @@ import org.springframework.data.repository.Repository;
  * and uses Project Reactor types which are built on top of Reactive Streams.
  *
  * @author Mark Paluch
+ * @author Christph Strobl
  * @since 2.0
  * @see Mono
  * @see Flux
@@ -39,7 +40,8 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 * entity instance completely.
 	 *
 	 * @param entity must not be {@literal null}.
-	 * @return the saved entity.
+	 * @return {@link Mono} emitting the saved entity.
+	 * @throws IllegalArgumentException in case the given {@code entity} is {@literal null}.
 	 */
 	<S extends T> Mono<S> save(S entity);
 
@@ -47,8 +49,8 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 * Saves all given entities.
 	 *
 	 * @param entities must not be {@literal null}.
-	 * @return the saved entities.
-	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
+	 * @return {@link Flux} emitting the saved entities.
+	 * @throws IllegalArgumentException in case the given {@link Iterable} {@code entities} is {@literal null}.
 	 */
 	<S extends T> Flux<S> saveAll(Iterable<S> entities);
 
@@ -56,8 +58,8 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 * Saves all given entities.
 	 *
 	 * @param entityStream must not be {@literal null}.
-	 * @return the saved entities.
-	 * @throws IllegalArgumentException in case the given {@code Publisher} is {@literal null}.
+	 * @return {@link Flux} emitting the saved entities.
+	 * @throws IllegalArgumentException in case the given {@code Publisher} {@code entityStream} is {@literal null}.
 	 */
 	<S extends T> Flux<S> saveAll(Publisher<S> entityStream);
 
@@ -65,66 +67,68 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 * Retrieves an entity by its id.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return the entity with the given id or {@link Mono#empty()} if none found.
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
+	 * @return {@link Mono} emitting the entity with the given id or {@link Mono#empty()} if none found.
+	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
 	 */
 	Mono<T> findById(ID id);
 
 	/**
-	 * Retrieves an entity by its id supplied by a {@link Mono}.
+	 * Retrieves an entity by its id supplied by a {@link Publisher}.
 	 *
 	 * @param id must not be {@literal null}. Uses the first emitted element to perform the find-query.
-	 * @return the entity with the given id or {@link Mono#empty()} if none found.
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
+	 * @return {@link Mono} emitting the entity with the given id or {@link Mono#empty()} if none found.
+	 * @throws IllegalArgumentException in case the given {@link Publisher} {@code id} is {@literal null}.
 	 */
 	Mono<T> findById(Publisher<ID> id);
 
 	/**
-	 * Returns whether an entity with the given id exists.
+	 * Returns whether an entity with the id exists.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}.
+	 * @return {@link Mono} emitting {@literal true} if an entity with the given id exists, {@literal false} otherwise.
+	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
 	 */
 	Mono<Boolean> existsById(ID id);
 
 	/**
-	 * Returns whether an entity with the given id, supplied by a {@link Mono}, exists. Uses the first emitted element to
-	 * perform the exists-query.
+	 * Returns whether an entity with the given id, supplied by a {@link Publisher}, exists. Uses the first emitted
+	 * element to perform the exists-query.
 	 *
 	 * @param id must not be {@literal null}.
-	 * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise
-	 * @throws IllegalArgumentException if {@code id} is {@literal null}
+	 * @return {@link Mono} emitting {@literal true} if an entity with the given id exists, {@literal false} otherwise
+	 * @throws IllegalArgumentException in case the given {@link Publisher} {@code id} is {@literal null}.
 	 */
 	Mono<Boolean> existsById(Publisher<ID> id);
 
 	/**
 	 * Returns all instances of the type.
 	 *
-	 * @return all entities.
+	 * @return {@link Flux} emitting all entities.
 	 */
 	Flux<T> findAll();
 
 	/**
-	 * Returns all instances of the type with the given IDs.
+	 * Returns all instances with the given IDs.
 	 *
 	 * @param ids must not be {@literal null}.
-	 * @return the found entities.
+	 * @return {@link Flux} emitting the found entities.
+	 * @throws IllegalArgumentException in case the given {@link Iterable} {@code ids} is {@literal null}.
 	 */
 	Flux<T> findAllById(Iterable<ID> ids);
 
 	/**
-	 * Returns all instances of the type with the given IDs.
+	 * Returns all instances of the type with the given IDs supplied by a {@link Publisher}.
 	 *
 	 * @param idStream must not be {@literal null}.
-	 * @return the found entities.
+	 * @return {@link Flux} emitting the found entities.
+	 * @throws IllegalArgumentException in case the given {@link Publisher} {@code idStream} is {@literal null}.
 	 */
 	Flux<T> findAllById(Publisher<ID> idStream);
 
 	/**
 	 * Returns the number of entities available.
 	 *
-	 * @return the number of entities.
+	 * @return {@link Mono} emitting the number of entities.
 	 */
 	Mono<Long> count();
 
@@ -132,14 +136,25 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 * Deletes the entity with the given id.
 	 *
 	 * @param id must not be {@literal null}.
+	 * @return {@link Mono} signaling when operation has completed.
 	 * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
 	 */
 	Mono<Void> deleteById(ID id);
 
 	/**
+	 * Deletes the entity with the given id supplied by a {@link Publisher}.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return {@link Mono} signaling when operation has completed.
+	 * @throws IllegalArgumentException in case the given {@link Publisher} {@code id} is {@literal null}.
+	 */
+	Mono<Void> deleteById(Publisher<ID> id);
+
+	/**
 	 * Deletes a given entity.
 	 *
 	 * @param entity must not be {@literal null}.
+	 * @return {@link Mono} signaling when operation has completed.
 	 * @throws IllegalArgumentException in case the given entity is {@literal null}.
 	 */
 	Mono<Void> delete(T entity);
@@ -148,20 +163,24 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 * Deletes the given entities.
 	 *
 	 * @param entities must not be {@literal null}.
-	 * @throws IllegalArgumentException in case the given {@link Iterable} is {@literal null}.
+	 * @return {@link Mono} signaling when operation has completed.
+	 * @throws IllegalArgumentException in case the given {@link Iterable} {@code entities} is {@literal null}.
 	 */
 	Mono<Void> deleteAll(Iterable<? extends T> entities);
 
 	/**
-	 * Deletes the given entities.
+	 * Deletes the given entities supplied by a {@link Publisher}.
 	 *
 	 * @param entityStream must not be {@literal null}.
-	 * @throws IllegalArgumentException in case the given {@link Publisher} is {@literal null}.
+	 * @return {@link Mono} signaling when operation has completed.
+	 * @throws IllegalArgumentException in case the given {@link Publisher} {@code entityStream} is {@literal null}.
 	 */
 	Mono<Void> deleteAll(Publisher<? extends T> entityStream);
 
 	/**
 	 * Deletes all entities managed by the repository.
+	 *
+	 * @return {@link Mono} signaling when operation has completed.
 	 */
 	Mono<Void> deleteAll();
 }

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveSortingRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveSortingRepository.java
@@ -26,6 +26,7 @@ import org.springframework.data.repository.NoRepositoryBean;
  * abstraction.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  * @see Sort
  * @see Mono
@@ -39,6 +40,7 @@ public interface ReactiveSortingRepository<T, ID> extends ReactiveCrudRepository
 	 *
 	 * @param sort must not be {@literal null}.
 	 * @return all entities sorted by the given options.
+	 * @throws IllegalArgumentException in case the given {@link Sort} is {@literal null}.
 	 */
 	Flux<T> findAll(Sort sort);
 }

--- a/src/test/java/org/springframework/data/repository/core/support/ReactiveWrapperRepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/ReactiveWrapperRepositoryFactorySupportUnitTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import rx.Single;
 
@@ -37,7 +38,7 @@ import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 
 /**
  * Unit tests for {@link RepositoryFactorySupport} using reactive wrapper types.
- * 
+ *
  * @author Mark Paluch
  * @author Christoph Strobl
  */
@@ -77,7 +78,7 @@ public class ReactiveWrapperRepositoryFactorySupportUnitTests {
 		verify(backingRepo, times(2)).existsById(id);
 	}
 
-	@Test // DATACMNS-836
+	@Test // DATACMNS-836, DATACMNS-1063
 	@SuppressWarnings("unchecked")
 	public void callsRxJava1MethodOnBaseImplementationWithTypeConversion() {
 
@@ -86,7 +87,7 @@ public class ReactiveWrapperRepositoryFactorySupportUnitTests {
 		RxJava1ConvertingRepository repository = factory.getRepository(RxJava1ConvertingRepository.class);
 		repository.existsById(ids);
 
-		verify(backingRepo, times(1)).existsById(any(Mono.class));
+		verify(backingRepo, times(1)).existsById(any(Publisher.class));
 	}
 
 	@Test // DATACMNS-988


### PR DESCRIPTION
We now accept `Publisher<T>` instead of `Mono<T>` in `findById(…)` and `existsById(…)`. Users of a ReactiveStreams-based framework are no longer required to perform Publisher to Mono-adoption themselves but can pass a `Publisher` directly. Both methods use the first emitted value to issue their queries. Additional values are not consumed from the stream.

---

Related ticket: [DATACMNS-1063](https://jira.spring.io/browse/DATACMNS-1063).