### PR TITLE
DATACMNS-1087 - Conversion to Vavr's Optional fails

### DIFF
--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -67,6 +67,7 @@ import com.google.common.base.Optional;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Maciek Opała
+ * @author Jacek Jackowiak
  * @since 1.8
  */
 public abstract class QueryExecutionConverters {
@@ -495,7 +496,7 @@ public abstract class QueryExecutionConverters {
 	}
 
 	/**
-	 * Converter to convert from {@link NullableWrapper} into JavaSlang's {@link io.vavr.control.Option}.
+	 * Converter to convert from {@link NullableWrapper} into Vavr's {@link io.vavr.control.Option}.
 	 *
 	 * @author Oliver Gierke
 	 * @since 2.0
@@ -511,7 +512,7 @@ public abstract class QueryExecutionConverters {
 		}
 
 		/**
-		 * Creates a new {@link NullableWrapperToJavaslangOptionConverter} using the given {@link ConversionService}.
+		 * Creates a new {@link NullableWrapperToVavrOptionConverter} using the given {@link ConversionService}.
 		 * 
 		 * @param conversionService must not be {@literal null}.
 		 */
@@ -525,7 +526,7 @@ public abstract class QueryExecutionConverters {
 		 */
 		@Override
 		protected Object wrap(Object source) {
-			return ReflectionUtils.invokeMethod(OF_METHOD, source);
+			return ReflectionUtils.invokeMethod(OF_METHOD, null, source);
 		}
 
 		public static WrapperType getWrapperType() {

--- a/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
@@ -51,6 +51,7 @@ import com.google.common.base.Optional;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Maciek Opała
+ * @author Jacek Jackowiak
  */
 public class QueryExecutionConvertersUnitTests {
 
@@ -240,6 +241,22 @@ public class QueryExecutionConvertersUnitTests {
 	public void unwrapsVavrOption() {
 		assertThat(QueryExecutionConverters.unwrap(vavrOption("string")), is((Object) "string"));
 	}
+
+	@Test // DATACMNS-1087
+	public void wrapsValueIntoVavrOption() {
+
+		io.vavr.control.Option<?> result = conversionService.convert(new NullableWrapper("string"),
+				io.vavr.control.Option.class);
+
+		assertThat(result.isEmpty(), is(false));
+		assertThat(result.get(), is((Object) "string"));
+	}
+
+    @Test // DATACMNS-1087
+    public void turnsNullIntoVavrOption() {
+        assertThat(conversionService.convert(new NullableWrapper(null), io.vavr.control.Option.class),
+                is((Object) vavrOptionNone()));
+    }
 
 	@Test // DATACMNS-1065
 	public void conversListToVavr() {


### PR DESCRIPTION
Calling `io.vavr.control.Option::of` as a static method