### PR TITLE
DATACMNS-1091 Sporadic test failures in Tests for JSR-310 conversions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1091-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/test/java/org/springframework/data/convert/Jsr310ConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/Jsr310ConvertersUnitTests.java
@@ -25,12 +25,15 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +55,7 @@ import org.springframework.data.convert.Jsr310ConvertersUnitTests.PeriodConversi
  * 
  * @author Oliver Gierke
  * @author Barak Schoster
+ * @author Jens Schauder
  */
 @RunWith(Suite.class)
 @SuiteClasses({ CommonTests.class, DurationConversionTests.class, PeriodConversionTests.class })
@@ -75,40 +79,42 @@ public class Jsr310ConvertersUnitTests {
 
 		@Test // DATACMNS-606
 		public void convertsDateToLocalDateTime() {
-			assertThat(CONVERSION_SERVICE.convert(NOW, LocalDateTime.class).toString())
-					.isEqualTo(format(NOW, "yyyy-MM-dd'T'HH:mm:ss.SSS"));
+
+			assertThat(CONVERSION_SERVICE.convert(NOW, LocalDateTime.class)) //
+					.matches(date(NOW, "yyyy-MM-dd'T'HH:mm:ss.SSS"));
 		}
 
 		@Test // DATACMNS-606
 		public void convertsLocalDateTimeToDate() {
 
 			LocalDateTime now = LocalDateTime.now();
-			assertThat(format(CONVERSION_SERVICE.convert(now, Date.class), "yyyy-MM-dd'T'HH:mm:ss.SSS"))
-					.isEqualTo(now.toString());
+			assertThat(CONVERSION_SERVICE.convert(now, Date.class)) //
+					.matches(temporal(now, "yyyy-MM-dd'T'HH:mm:ss.SSS"));
 		}
 
 		@Test // DATACMNS-606
 		public void convertsDateToLocalDate() {
-			assertThat(CONVERSION_SERVICE.convert(NOW, LocalDate.class).toString()).isEqualTo(format(NOW, "yyyy-MM-dd"));
+			assertThat(CONVERSION_SERVICE.convert(NOW, LocalDate.class)).matches(date(NOW, "yyyy-MM-dd"));
 		}
 
 		@Test // DATACMNS-606
 		public void convertsLocalDateToDate() {
 
 			LocalDate now = LocalDate.now();
-			assertThat(format(CONVERSION_SERVICE.convert(now, Date.class), "yyyy-MM-dd")).isEqualTo(now.toString());
+			assertThat(CONVERSION_SERVICE.convert(now, Date.class)).matches(temporal(now, "yyyy-MM-dd"));
 		}
 
 		@Test // DATACMNS-606
 		public void convertsDateToLocalTime() {
-			assertThat(CONVERSION_SERVICE.convert(NOW, LocalTime.class).toString()).isEqualTo(format(NOW, "HH:mm:ss.SSS"));
+
+			assertThat(CONVERSION_SERVICE.convert(NOW, LocalTime.class)).matches(date(NOW, "HH:mm:ss.SSS"));
 		}
 
 		@Test // DATACMNS-606
 		public void convertsLocalTimeToDate() {
 
 			LocalTime now = LocalTime.now();
-			assertThat(format(CONVERSION_SERVICE.convert(now, Date.class), "HH:mm:ss.SSS")).isEqualTo(now.toString());
+			assertThat(CONVERSION_SERVICE.convert(now, Date.class)).matches(temporal(now, "HH:mm:ss.SSS"));
 		}
 
 		@Test // DATACMNS-623
@@ -140,6 +146,18 @@ public class Jsr310ConvertersUnitTests {
 
 		private static String format(Date date, String format) {
 			return new SimpleDateFormat(format).format(date);
+		}
+
+		private static Predicate<Date> temporal(Temporal expected, String format) {
+
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+			return d -> format(d, format).equals(formatter.format(expected));
+		}
+
+		private static Predicate<Temporal> date(Date expected, String format) {
+
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+			return d -> formatter.format(d).equals(format(expected, format));
 		}
 	}
 


### PR DESCRIPTION
We now use specified date formats for converting various date types to Strings and comparing them.

Before, in some cases toString() was used which strips trailing zeros, causing sporadic failures.

JDK9 changed the behavior of Date related toString methods, making tests fail all the time.
Therefore this fix is required for executing tests with JDK9.