### PR TITLE
DATACMNS-1097 - Move classes to better matching packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/ant/.ant-targets-upload-dist.xml
 *.ipr
 *.iws
 /.idea/
+*.graphml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1097-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>de.schauderhaft.degraph</groupId>
+			<artifactId>degraph-check</artifactId>
+			<version>0.1.4</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/springframework/data/domain/ExampleMatcher.java
+++ b/src/main/java/org/springframework/data/domain/ExampleMatcher.java
@@ -41,10 +41,18 @@ import org.springframework.util.Assert;
  * {@link NullHandler#IGNORE} and case-sensitive {@link StringMatcher#DEFAULT} string matching.
  * <p>
  * This class is immutable.
+ * <p>
+ * Note that this class contains methods returning instances of the deprecated
+ * {@link StringMatcher}. They will change in an upcomming version to return the new
+ * {@link org.springframework.data.util.StringMatcher}. Users should use the new
+ * {@link org.springframework.data.util.StringMatcher} class in all their code and convert to/from the old and
+ * deprecated version using {@link StringMatcher#toNewStringMatcher()} and
+ * {@link StringMatcher#fromNewStringMatcher(org.springframework.data.util.StringMatcher)}
  *
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Oliver Gierke
+ * @author Jens Schauder
  * @param <T>
  * @since 1.12
  */
@@ -125,13 +133,30 @@ public class ExampleMatcher {
 	 *
 	 * @param defaultStringMatcher must not be {@literal null}.
 	 * @return
+	 * @deprecated Use {@link #withStringMatcher(org.springframework.data.util.StringMatcher)} instead.
 	 */
+	@Deprecated
 	public ExampleMatcher withStringMatcher(StringMatcher defaultStringMatcher) {
 
 		Assert.notNull(ignoredPaths, "DefaultStringMatcher must not be empty!");
 
 		return new ExampleMatcher(nullHandler, defaultStringMatcher, propertySpecifiers, ignoredPaths, defaultIgnoreCase,
 				mode);
+	}
+
+	/**
+	 * Returns a copy of this {@link ExampleMatcher} with the specified string matching of {@code defaultStringMatcher}.
+	 * This instance is immutable and unaffected by this method call.
+	 *
+	 * @param defaultStringMatcher must not be {@literal null}.
+	 * @return
+	 */
+	public ExampleMatcher withStringMatcher(org.springframework.data.util.StringMatcher defaultStringMatcher) {
+
+		Assert.notNull(ignoredPaths, "DefaultStringMatcher must not be empty!");
+
+		return new ExampleMatcher(nullHandler, StringMatcher.fromNewStringMatcher(defaultStringMatcher), propertySpecifiers,
+				ignoredPaths, defaultIgnoreCase, mode);
 	}
 
 	/**
@@ -407,7 +432,9 @@ public class ExampleMatcher {
 		 * @param stringMatcher must not be {@literal null}.
 		 * @param ignoreCase
 		 * @return
+		 * @deprecated Use {@link #of(org.springframework.data.util.StringMatcher, boolean)} instead.
 		 */
+		@Deprecated
 		public static GenericPropertyMatcher of(StringMatcher stringMatcher, boolean ignoreCase) {
 			return new GenericPropertyMatcher().stringMatcher(stringMatcher).ignoreCase(ignoreCase);
 		}
@@ -416,10 +443,35 @@ public class ExampleMatcher {
 		 * Creates a new {@link GenericPropertyMatcher} with a {@link StringMatcher} and {@code ignoreCase}.
 		 *
 		 * @param stringMatcher must not be {@literal null}.
+		 * @param ignoreCase
 		 * @return
 		 */
+		public static GenericPropertyMatcher of(org.springframework.data.util.StringMatcher stringMatcher,
+				boolean ignoreCase) {
+			return new GenericPropertyMatcher().stringMatcher(StringMatcher.fromNewStringMatcher(stringMatcher))
+					.ignoreCase(ignoreCase);
+		}
+
+		/**
+		 * Creates a new {@link GenericPropertyMatcher} with a {@link StringMatcher} and {@code ignoreCase}.
+		 *
+		 * @param stringMatcher must not be {@literal null}.
+		 * @return
+		 * @deprecated Use {@link #of(org.springframework.data.util.StringMatcher)} instead.
+		 */
+		@Deprecated
 		public static GenericPropertyMatcher of(StringMatcher stringMatcher) {
 			return new GenericPropertyMatcher().stringMatcher(stringMatcher);
+		}
+
+		/**
+		 * Creates a new {@link GenericPropertyMatcher} with a {@link StringMatcher} and {@code ignoreCase}.
+		 *
+		 * @param stringMatcher must not be {@literal null}.
+		 * @return
+		 */
+		public static GenericPropertyMatcher of(org.springframework.data.util.StringMatcher stringMatcher) {
+			return new GenericPropertyMatcher().stringMatcher(StringMatcher.fromNewStringMatcher(stringMatcher));
 		}
 
 		/**
@@ -527,11 +579,26 @@ public class ExampleMatcher {
 		 *
 		 * @param stringMatcher must not be {@literal null}.
 		 * @return
+		 * @deprecated Use {@link #stringMatcher(org.springframework.data.util.StringMatcher)} instead.
 		 */
+		@Deprecated
 		public GenericPropertyMatcher stringMatcher(StringMatcher stringMatcher) {
 
 			Assert.notNull(stringMatcher, "StringMatcher must not be null!");
 			this.stringMatcher = stringMatcher;
+			return this;
+		}
+
+		/**
+		 * Sets string matcher to {@code stringMatcher}.
+		 *
+		 * @param stringMatcher must not be {@literal null}.
+		 * @return
+		 */
+		public GenericPropertyMatcher stringMatcher(org.springframework.data.util.StringMatcher stringMatcher) {
+
+			Assert.notNull(stringMatcher, "StringMatcher must not be null!");
+			this.stringMatcher = StringMatcher.fromNewStringMatcher(stringMatcher);
 			return this;
 		}
 
@@ -634,8 +701,11 @@ public class ExampleMatcher {
 	 * Match modes for treatment of {@link String} values.
 	 *
 	 * @author Christoph Strobl
+	 * @author Jens Schauder
+	 * @deprecated use {@link org.springframework.data.util.StringMatcher} instead.
 	 */
-	public static enum StringMatcher {
+	@Deprecated
+	public enum StringMatcher {
 
 		/**
 		 * Store specific default.
@@ -662,6 +732,18 @@ public class ExampleMatcher {
 		 */
 		REGEX;
 
+		public org.springframework.data.util.StringMatcher toNewStringMatcher() {
+			return org.springframework.data.util.StringMatcher.valueOf(name());
+		}
+
+		public static StringMatcher fromNewStringMatcher(org.springframework.data.util.StringMatcher stringMatcher) {
+
+			try {
+				return StringMatcher.valueOf(stringMatcher.name());
+			} catch (IllegalArgumentException iae) {
+				return StringMatcher.DEFAULT;
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/core/support/ExampleMatcherAccessor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/ExampleMatcherAccessor.java
@@ -15,11 +15,7 @@
  */
 package org.springframework.data.repository.core.support;
 
-import java.util.Collection;
-
 import org.springframework.data.domain.ExampleMatcher;
-import org.springframework.data.domain.ExampleMatcher.PropertySpecifier;
-import org.springframework.util.Assert;
 
 /**
  * Accessor for the {@link ExampleMatcher} to use in modules that support query by example (QBE) querying.
@@ -27,139 +23,22 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Jens Schauder
+ *
  * @since 1.12
+ *
+ * @deprecated use {@link org.springframework.data.support.ExampleMatcherAccessor} instead.
  */
-public class ExampleMatcherAccessor {
+@Deprecated
+public class ExampleMatcherAccessor extends org.springframework.data.support.ExampleMatcherAccessor {
 
-	private final ExampleMatcher matcher;
 
 	/**
 	 * Creates a new {@link ExampleMatcherAccessor} for the given {@link ExampleMatcher}.
-	 * 
+	 *
 	 * @param matcher must not be {@literal null}.
 	 */
 	public ExampleMatcherAccessor(ExampleMatcher matcher) {
-
-		Assert.notNull(matcher, "ExampleMatcher must not be null!");
-
-		this.matcher = matcher;
-	}
-
-	/**
-	 * Returns the {@link PropertySpecifier}s of the underlying {@link ExampleMatcher}.
-	 * 
-	 * @return unmodifiable {@link Collection} of {@link ExampleMatcher.PropertySpecifier}s.
-	 */
-	public Collection<ExampleMatcher.PropertySpecifier> getPropertySpecifiers() {
-		return matcher.getPropertySpecifiers().getSpecifiers();
-	}
-
-	/**
-	 * Returns whether the underlying {@link ExampleMatcher} contains a {@link PropertySpecifier} for the given path.
-	 * 
-	 * @param path the dot-path identifying a property.
-	 * @return {@literal true} in case {@link ExampleMatcher.PropertySpecifier} defined for given path.
-	 */
-	public boolean hasPropertySpecifier(String path) {
-		return matcher.getPropertySpecifiers().hasSpecifierForPath(path);
-	}
-
-	/**
-	 * Get the {@link ExampleMatcher.PropertySpecifier} for given path. <br />
-	 * Please check if {@link #hasPropertySpecifier(String)} to avoid running into {@literal null} values.
-	 *
-	 * @param path Dot-Path to property.
-	 * @return {@literal null} when no {@link ExampleMatcher.PropertySpecifier} defined for path.
-	 */
-	public ExampleMatcher.PropertySpecifier getPropertySpecifier(String path) {
-		return matcher.getPropertySpecifiers().getForPath(path);
-	}
-
-	/**
-	 * @return true if at least one {@link ExampleMatcher.PropertySpecifier} defined.
-	 */
-	public boolean hasPropertySpecifiers() {
-		return matcher.getPropertySpecifiers().hasValues();
-	}
-
-	/**
-	 * Get the {@link ExampleMatcher.StringMatcher} for a given path or return the default one if none defined.
-	 *
-	 * @param path
-	 * @return never {@literal null}.
-	 */
-	public ExampleMatcher.StringMatcher getStringMatcherForPath(String path) {
-
-		if (!hasPropertySpecifier(path)) {
-			return matcher.getDefaultStringMatcher();
-		}
-
-		ExampleMatcher.PropertySpecifier specifier = getPropertySpecifier(path);
-		return specifier.getStringMatcher() != null ? specifier.getStringMatcher() : matcher.getDefaultStringMatcher();
-	}
-
-	/**
-	 * Get defined null handling.
-	 *
-	 * @return never {@literal null}
-	 */
-	public ExampleMatcher.NullHandler getNullHandler() {
-		return matcher.getNullHandler();
-	}
-
-	/**
-	 * Get defined {@link ExampleMatcher.StringMatcher}.
-	 *
-	 * @return never {@literal null}.
-	 */
-	public ExampleMatcher.StringMatcher getDefaultStringMatcher() {
-		return matcher.getDefaultStringMatcher();
-	}
-
-	/**
-	 * @return {@literal true} if {@link String} should be matched with ignore case option.
-	 */
-	public boolean isIgnoreCaseEnabled() {
-		return matcher.isIgnoreCaseEnabled();
-	}
-
-	/**
-	 * @param path
-	 * @return return {@literal true} if path was set to be ignored.
-	 */
-	public boolean isIgnoredPath(String path) {
-		return matcher.isIgnoredPath(path);
-	}
-
-	/**
-	 * Get the ignore case flag for a given path or return the default one if none defined.
-	 *
-	 * @param path
-	 * @return never {@literal null}.
-	 */
-	public boolean isIgnoreCaseForPath(String path) {
-
-		if (!hasPropertySpecifier(path)) {
-			return matcher.isIgnoreCaseEnabled();
-		}
-
-		ExampleMatcher.PropertySpecifier specifier = getPropertySpecifier(path);
-		return specifier.getIgnoreCase() != null ? specifier.getIgnoreCase() : matcher.isIgnoreCaseEnabled();
-	}
-
-	/**
-	 * Get the ignore case flag for a given path or return {@link ExampleMatcher.NoOpPropertyValueTransformer} if none
-	 * defined.
-	 *
-	 * @param path
-	 * @return never {@literal null}.
-	 */
-	public ExampleMatcher.PropertyValueTransformer getValueTransformerForPath(String path) {
-
-		if (!hasPropertySpecifier(path)) {
-			return ExampleMatcher.NoOpPropertyValueTransformer.INSTANCE;
-		}
-
-		return getPropertySpecifier(path).getPropertyValueTransformer();
+		super(matcher);
 	}
 }

--- a/src/main/java/org/springframework/data/support/ExampleMatcherAccessor.java
+++ b/src/main/java/org/springframework/data/support/ExampleMatcherAccessor.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.support;
+
+import java.util.Collection;
+
+import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.domain.ExampleMatcher.PropertySpecifier;
+import org.springframework.data.util.StringMatcher;
+import org.springframework.util.Assert;
+
+/**
+ * Accessor for the {@link ExampleMatcher} to use in modules that support query by example (QBE) querying.
+ *
+ * @author Mark Paluch
+ * @author Oliver Gierke
+ * @author Christoph Strobl
+ * @author Jens Schauder
+ * @since 1.12
+ */
+public class ExampleMatcherAccessor {
+
+	private final ExampleMatcher matcher;
+
+	/**
+	 * Creates a new {@link ExampleMatcherAccessor} for the given {@link ExampleMatcher}.
+	 * 
+	 * @param matcher must not be {@literal null}.
+	 */
+	public ExampleMatcherAccessor(ExampleMatcher matcher) {
+
+		Assert.notNull(matcher, "ExampleMatcher must not be null!");
+
+		this.matcher = matcher;
+	}
+
+	/**
+	 * Returns the {@link PropertySpecifier}s of the underlying {@link ExampleMatcher}.
+	 * 
+	 * @return unmodifiable {@link Collection} of {@link ExampleMatcher.PropertySpecifier}s.
+	 */
+	public Collection<ExampleMatcher.PropertySpecifier> getPropertySpecifiers() {
+		return matcher.getPropertySpecifiers().getSpecifiers();
+	}
+
+	/**
+	 * Returns whether the underlying {@link ExampleMatcher} contains a {@link PropertySpecifier} for the given path.
+	 * 
+	 * @param path the dot-path identifying a property.
+	 * @return {@literal true} in case {@link ExampleMatcher.PropertySpecifier} defined for given path.
+	 */
+	public boolean hasPropertySpecifier(String path) {
+		return matcher.getPropertySpecifiers().hasSpecifierForPath(path);
+	}
+
+	/**
+	 * Get the {@link ExampleMatcher.PropertySpecifier} for given path. <br />
+	 * Please check if {@link #hasPropertySpecifier(String)} to avoid running into {@literal null} values.
+	 *
+	 * @param path Dot-Path to property.
+	 * @return {@literal null} when no {@link ExampleMatcher.PropertySpecifier} defined for path.
+	 */
+	public ExampleMatcher.PropertySpecifier getPropertySpecifier(String path) {
+		return matcher.getPropertySpecifiers().getForPath(path);
+	}
+
+	/**
+	 * @return true if at least one {@link ExampleMatcher.PropertySpecifier} defined.
+	 */
+	public boolean hasPropertySpecifiers() {
+		return matcher.getPropertySpecifiers().hasValues();
+	}
+
+	/**
+	 * Get the {@link ExampleMatcher.StringMatcher} for a given path or return the default one if none defined.
+	 *
+	 * @param path
+	 * @return never {@literal null}.
+	 */
+	public ExampleMatcher.StringMatcher getStringMatcherForPath(String path) {
+
+		if (!hasPropertySpecifier(path)) {
+			return matcher.getDefaultStringMatcher();
+		}
+
+		ExampleMatcher.PropertySpecifier specifier = getPropertySpecifier(path);
+		return specifier.getStringMatcher() != null ? specifier.getStringMatcher() : matcher.getDefaultStringMatcher();
+	}
+
+	/**
+	 * Get defined null handling.
+	 *
+	 * @return never {@literal null}
+	 */
+	public ExampleMatcher.NullHandler getNullHandler() {
+		return matcher.getNullHandler();
+	}
+
+	/**
+	 * Get defined {@link ExampleMatcher.StringMatcher}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public ExampleMatcher.StringMatcher getDefaultStringMatcher() {
+		return matcher.getDefaultStringMatcher();
+	}
+
+	/**
+	 * @return {@literal true} if {@link String} should be matched with ignore case option.
+	 */
+	public boolean isIgnoreCaseEnabled() {
+		return matcher.isIgnoreCaseEnabled();
+	}
+
+	/**
+	 * @param path
+	 * @return return {@literal true} if path was set to be ignored.
+	 */
+	public boolean isIgnoredPath(String path) {
+		return matcher.isIgnoredPath(path);
+	}
+
+	/**
+	 * Get the ignore case flag for a given path or return the default one if none defined.
+	 *
+	 * @param path
+	 * @return never {@literal null}.
+	 */
+	public boolean isIgnoreCaseForPath(String path) {
+
+		if (!hasPropertySpecifier(path)) {
+			return matcher.isIgnoreCaseEnabled();
+		}
+
+		ExampleMatcher.PropertySpecifier specifier = getPropertySpecifier(path);
+		return specifier.getIgnoreCase() != null ? specifier.getIgnoreCase() : matcher.isIgnoreCaseEnabled();
+	}
+
+	/**
+	 * Get the ignore case flag for a given path or return {@link ExampleMatcher.NoOpPropertyValueTransformer} if none
+	 * defined.
+	 *
+	 * @param path
+	 * @return never {@literal null}.
+	 */
+	public ExampleMatcher.PropertyValueTransformer getValueTransformerForPath(String path) {
+
+		if (!hasPropertySpecifier(path)) {
+			return ExampleMatcher.NoOpPropertyValueTransformer.INSTANCE;
+		}
+
+		return getPropertySpecifier(path).getPropertyValueTransformer();
+	}
+}

--- a/src/main/java/org/springframework/data/util/StringMatcher.java
+++ b/src/main/java/org/springframework/data/util/StringMatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.util;
+
+/**
+ * Match modes for treatment of {@link String} values.
+ *
+ * @author Christoph Strobl
+ * @author Jens Schauder
+ */
+public enum StringMatcher {
+
+	/**
+	 * Store specific default.
+	 */
+	DEFAULT,
+	/**
+	 * Matches the exact string
+	 */
+	EXACT,
+	/**
+	 * Matches string starting with pattern
+	 */
+	STARTING,
+	/**
+	 * Matches string ending with pattern
+	 */
+	ENDING,
+	/**
+	 * Matches string containing pattern
+	 */
+	CONTAINING,
+	/**
+	 * Treats strings as regular expression patterns
+	 */
+	REGEX,
+
+	// might be a temporary thing.
+	LIKE
+
+}
+

--- a/src/test/java/org/springframework/data/DependencyTests.java
+++ b/src/test/java/org/springframework/data/DependencyTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data;
+
+import static de.schauderhaft.degraph.check.JCheck.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author Jens Schauder
+ */
+public class DependencyTests {
+
+	@Test
+	public void noInternalPackageCycles() {
+
+		assertThat(
+				classpath() //
+						.noJars() //
+						.including("org.springframework.data.**") //
+						.filterClasspath("*target/classes") //
+						.printOnFailure("degraph.graphml"), //
+				violationFree() //
+		);
+	}
+
+}

--- a/src/test/java/org/springframework/data/repository/core/support/ExampleSpecificationAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/ExampleSpecificationAccessorUnitTests.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.ExampleMatcher.NoOpPropertyValueTransform
 import org.springframework.data.domain.ExampleMatcher.NullHandler;
 import org.springframework.data.domain.ExampleMatcher.PropertyValueTransformer;
 import org.springframework.data.domain.ExampleMatcher.StringMatcher;
+import org.springframework.data.support.ExampleMatcherAccessor;
 
 /**
  * Unit tests for {@link ExampleMatcherAccessor}.


### PR DESCRIPTION
Moved/copied ExampleMatcherAccessor to data.util
Copied StringMatcher to data.util
Both were under repository, although they aren't really repository related and used independently from repositories.

The new StringMatcher got an additional element to mimic {{Part.Type}} which it is going to replace in SD MongoDb.

Added Degraph based test in order to avoid future dependency violations.

Related ticket: DATACMNS-1721.

Jira issue: https://jira.spring.io/browse/DATACMNS-1097