### PR TITLE
DATACMNS-1126 - Add Kotlin constructor support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1126-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,49 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Kotlin extension -->
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>${kotlin}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<version>${kotlin}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-test</artifactId>
+			<version>${kotlin}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.nhaarman</groupId>
+			<artifactId>mockito-kotlin</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<artifactId>kotlin-stdlib</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<artifactId>kotlin-reflect</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<!-- Scala -->
 		<dependency>
 			<groupId>org.scala-lang</groupId>

--- a/src/main/java/org/springframework/data/convert/ClassGeneratingKotlinEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/ClassGeneratingKotlinEntityInstantiator.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import kotlin.reflect.KFunction;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.mapping.PreferredConstructor.Parameter;
+import org.springframework.data.mapping.model.ParameterValueProvider;
+import org.springframework.data.util.ReflectionUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Kotlin-specific extension to {@link ClassGeneratingEntityInstantiator} that adapts Kotlin constructors with
+ * defaulting.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class ClassGeneratingKotlinEntityInstantiator extends ClassGeneratingEntityInstantiator {
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.ClassGeneratingEntityInstantiator#doCreateEntityInstantiator(org.springframework.data.mapping.PersistentEntity)
+	 */
+	@Override
+	protected EntityInstantiator doCreateEntityInstantiator(PersistentEntity<?, ?> entity) {
+
+		if (ReflectionUtils.isKotlinClass(entity.getType()) && entity.getPersistenceConstructor() != null) {
+
+			PreferredConstructor<?, ?> defaultConstructor = new DefaultingKotlinConstructorResolver(entity)
+					.getDefaultConstructor();
+
+			if (defaultConstructor != null) {
+				return new DefaultingKotlinClassInstantiatorAdapter(createObjectInstantiator(entity, defaultConstructor),
+						entity.getPersistenceConstructor());
+			}
+		}
+
+		return super.doCreateEntityInstantiator(entity);
+	}
+
+	/**
+	 * Resolves a {@link PreferredConstructor} to a synthetic Kotlin constructor accepting the same user-space parameters
+	 * suffixed by Kotlin-specifics required for defaulting and the {@code kotlin.jvm.internal.DefaultConstructorMarker}.
+	 *
+	 * @since 2.0
+	 * @author Mark Paluch
+	 */
+	static class DefaultingKotlinConstructorResolver {
+
+		@Nullable private final PreferredConstructor<?, ?> defaultConstructor;
+
+		@SuppressWarnings("unchecked")
+		DefaultingKotlinConstructorResolver(PersistentEntity<?, ?> entity) {
+
+			Constructor<?> hit = resolveDefaultConstructor(entity);
+			PreferredConstructor<?, ?> persistenceConstructor = entity.getPersistenceConstructor();
+
+			if (hit != null && persistenceConstructor != null) {
+				this.defaultConstructor = new PreferredConstructor<>(hit,
+						persistenceConstructor.getParameters().toArray(new Parameter[0]));
+			} else {
+				this.defaultConstructor = null;
+			}
+		}
+
+		@Nullable
+		private static Constructor<?> resolveDefaultConstructor(PersistentEntity<?, ?> entity) {
+
+			if (entity.getPersistenceConstructor() == null) {
+				return null;
+			}
+
+			Constructor<?> hit = null;
+			Constructor<?> constructor = entity.getPersistenceConstructor().getConstructor();
+
+			for (Constructor<?> candidate : entity.getType().getDeclaredConstructors()) {
+
+				// use only synthetic constructors
+				if (!candidate.isSynthetic()) {
+					continue;
+				}
+
+				// with a parameter count greater zero
+				if (constructor.getParameterCount() == 0) {
+					continue;
+				}
+
+				// candidates must contain at least two additional parameters (int, DefaultConstructorMarker)
+				if (constructor.getParameterCount() + 2 > candidate.getParameterCount()) {
+					continue;
+				}
+
+				java.lang.reflect.Parameter[] constructorParameters = constructor.getParameters();
+				java.lang.reflect.Parameter[] candidateParameters = candidate.getParameters();
+
+				if (!candidateParameters[candidateParameters.length - 1].getType().getName()
+						.equals("kotlin.jvm.internal.DefaultConstructorMarker")) {
+					continue;
+				}
+
+				if (parametersMatch(constructorParameters, candidateParameters)) {
+					hit = candidate;
+					break;
+				}
+			}
+
+			return hit;
+		}
+
+		private static boolean parametersMatch(java.lang.reflect.Parameter[] constructorParameters,
+				java.lang.reflect.Parameter[] candidateParameters) {
+
+			return IntStream.range(0, constructorParameters.length)
+					.allMatch(i -> constructorParameters[i].getType().equals(candidateParameters[i].getType()));
+		}
+
+		@Nullable
+		PreferredConstructor<?, ?> getDefaultConstructor() {
+			return defaultConstructor;
+		}
+	}
+
+	/**
+	 * Entity instantiator for Kotlin constructors that apply parameter defaulting. Kotlin constructors that apply
+	 * argument defaulting are marked with {@link kotlin.jvm.internal.DefaultConstructorMarker} and accept additional
+	 * parameters besides the regular (user-space) parameters. Additional parameters are:
+	 * <ul>
+	 * <li>defaulting bitmask ({@code int}), a bit mask slot for each 32 parameters</li>
+	 * <li>{@code DefaultConstructorMarker} (usually null)</li>
+	 * </ul>
+	 * <strong>Defaulting bitmask</strong>
+	 * <p/>
+	 * The defaulting bitmask is a 32 bit integer representing which positional argument should be defaulted. Defaulted
+	 * arguments are passed as {@literal null} and require the appropriate positional bit set ( {@code 1 << 2} for the 2.
+	 * argument)). Since the bitmask represents only 32 bit states, it requires additional masks (slots) if more than 32
+	 * arguments are represented.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.0
+	 */
+	static class DefaultingKotlinClassInstantiatorAdapter implements EntityInstantiator {
+
+		private final ObjectInstantiator instantiator;
+		private final List<KParameter> kParameters;
+		private final Constructor<?> synthetic;
+
+		DefaultingKotlinClassInstantiatorAdapter(ObjectInstantiator instantiator, PreferredConstructor<?, ?> constructor) {
+
+			KFunction<?> kotlinConstructor = ReflectJvmMapping.getKotlinFunction(constructor.getConstructor());
+
+			if (kotlinConstructor == null) {
+				throw new IllegalArgumentException(
+						"No corresponding Kotlin constructor found for " + constructor.getConstructor());
+			}
+
+			this.instantiator = instantiator;
+			this.kParameters = kotlinConstructor.getParameters();
+			this.synthetic = constructor.getConstructor();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.convert.EntityInstantiator#createInstance(org.springframework.data.mapping.PersistentEntity, org.springframework.data.mapping.model.ParameterValueProvider)
+		 */
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T, E extends PersistentEntity<? extends T, P>, P extends PersistentProperty<P>> T createInstance(E entity,
+				ParameterValueProvider<P> provider) {
+
+			PreferredConstructor<? extends T, P> preferredConstructor = entity.getPersistenceConstructor();
+			Assert.notNull(preferredConstructor, "PreferredConstructor must not be null!");
+
+			int[] defaulting = new int[(synthetic.getParameterCount() / 32) + 1];
+
+			Object[] params = allocateArguments(
+					synthetic.getParameterCount() + defaulting.length + /* DefaultConstructorMarker */1);
+			int userParameterCount = kParameters.size();
+
+			List<Parameter<Object, P>> parameters = preferredConstructor.getParameters();
+
+			// Prepare user-space arguments
+			for (int i = 0; i < userParameterCount; i++) {
+
+				int slot = i / 32;
+				int offset = slot * 32;
+
+				Object param = provider.getParameterValue(parameters.get(i));
+
+				KParameter kParameter = kParameters.get(i);
+
+				// what about null and parameter is mandatory? What if parameter is non-null?
+				if (kParameter.isOptional()) {
+
+					if (param == null) {
+						defaulting[slot] = defaulting[slot] | (1 << (i - offset));
+					}
+				}
+
+				params[i] = param;
+			}
+
+			// append nullability masks to creation arguments
+			for (int i = 0; i < defaulting.length; i++) {
+				params[userParameterCount + i] = defaulting[i];
+			}
+
+			try {
+				return (T) instantiator.newInstance(params);
+			} finally {
+				deallocateArguments(params);
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/convert/EntityInstantiators.java
+++ b/src/main/java/org/springframework/data/convert/EntityInstantiators.java
@@ -24,10 +24,11 @@ import org.springframework.util.Assert;
 /**
  * Simple value object allowing access to {@link EntityInstantiator} instances for a given type falling back to a
  * default one.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class EntityInstantiators {
 
@@ -43,7 +44,7 @@ public class EntityInstantiators {
 
 	/**
 	 * Creates a new {@link EntityInstantiators} using the given {@link EntityInstantiator} as fallback.
-	 * 
+	 *
 	 * @param fallback must not be {@literal null}.
 	 */
 	public EntityInstantiators(EntityInstantiator fallback) {
@@ -52,17 +53,17 @@ public class EntityInstantiators {
 
 	/**
 	 * Creates a new {@link EntityInstantiators} using the default fallback instantiator and the given custom ones.
-	 * 
+	 *
 	 * @param customInstantiators must not be {@literal null}.
 	 */
 	public EntityInstantiators(Map<Class<?>, EntityInstantiator> customInstantiators) {
-		this(new ClassGeneratingEntityInstantiator(), customInstantiators);
+		this(new ClassGeneratingKotlinEntityInstantiator(), customInstantiators);
 	}
 
 	/**
 	 * Creates a new {@link EntityInstantiator} using the given fallback {@link EntityInstantiator} and the given custom
 	 * ones.
-	 * 
+	 *
 	 * @param defaultInstantiator must not be {@literal null}.
 	 * @param customInstantiators must not be {@literal null}.
 	 */
@@ -78,7 +79,7 @@ public class EntityInstantiators {
 
 	/**
 	 * Returns the {@link EntityInstantiator} to be used to create the given {@link PersistentEntity}.
-	 * 
+	 *
 	 * @param entity must not be {@literal null}.
 	 * @return will never be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -20,34 +20,12 @@ import lombok.RequiredArgsConstructor;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.data.annotation.TypeAlias;
-import org.springframework.data.mapping.Alias;
-import org.springframework.data.mapping.Association;
-import org.springframework.data.mapping.AssociationHandler;
-import org.springframework.data.mapping.IdentifierAccessor;
-import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mapping.PersistentEntity;
-import org.springframework.data.mapping.PersistentProperty;
-import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.springframework.data.mapping.PreferredConstructor;
-import org.springframework.data.mapping.PropertyHandler;
-import org.springframework.data.mapping.SimpleAssociationHandler;
-import org.springframework.data.mapping.SimplePropertyHandler;
-import org.springframework.data.mapping.TargetAwareIdentifierAccessor;
+import org.springframework.data.mapping.*;
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
@@ -112,7 +90,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		this.properties = new ArrayList<>();
 		this.persistentPropertiesCache = new ArrayList<>();
 		this.comparator = comparator;
-		this.constructor = new PreferredConstructorDiscoverer<>(this).getConstructor();
+		this.constructor = PreferredConstructorDiscoverer.discover(this);
 		this.associations = comparator == null ? new HashSet<>() : new TreeSet<>(new AssociationComparator<>(comparator));
 
 		this.propertyCache = new HashMap<>();

--- a/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java
+++ b/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java
@@ -15,25 +15,13 @@
  */
 package org.springframework.data.mapping.model;
 
-import kotlin.jvm.JvmClassMappingKt;
-import kotlin.reflect.KFunction;
-import kotlin.reflect.full.KClasses;
-import kotlin.reflect.jvm.ReflectJvmMapping;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.util.List;
-
-import org.springframework.core.DefaultParameterNameDiscoverer;
-import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PreferredConstructor;
-import org.springframework.data.mapping.PreferredConstructor.Parameter;
 import org.springframework.data.util.ClassTypeInformation;
-import org.springframework.data.util.ReflectionUtils;
-import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
+
+import com.mysema.commons.lang.Assert;
 
 /**
  * Helper class to find a {@link PreferredConstructor}.
@@ -43,135 +31,34 @@ import org.springframework.lang.Nullable;
  * @author Roman Rodov
  * @author Mark Paluch
  */
-public class PreferredConstructorDiscoverer<T, P extends PersistentProperty<P>> {
-
-	private final ParameterNameDiscoverer discoverer = new DefaultParameterNameDiscoverer();
-
-	private @Nullable PreferredConstructor<T, P> constructor;
+public interface PreferredConstructorDiscoverer<T, P extends PersistentProperty<P>> {
 
 	/**
-	 * Creates a new {@link PreferredConstructorDiscoverer} for the given type.
+	 * Discovers the {@link PreferredConstructor} for the given type.
 	 *
 	 * @param type must not be {@literal null}.
-	 */
-	public PreferredConstructorDiscoverer(Class<T> type) {
-		this(ClassTypeInformation.from(type), null);
-	}
-
-	/**
-	 * Creates a new {@link PreferredConstructorDiscoverer} for the given {@link PersistentEntity}.
-	 *
-	 * @param entity must not be {@literal null}.
-	 */
-	public PreferredConstructorDiscoverer(PersistentEntity<T, P> entity) {
-		this(entity.getTypeInformation(), entity);
-	}
-
-	/**
-	 * Creates a new {@link PreferredConstructorDiscoverer} for the given type.
-	 *
-	 * @param type must not be {@literal null}.
-	 * @param entity
-	 */
-	protected PreferredConstructorDiscoverer(TypeInformation<T> type, @Nullable PersistentEntity<T, P> entity) {
-
-		boolean noArgConstructorFound = false;
-		int numberOfArgConstructors = 0;
-		Class<?> rawOwningType = type.getType();
-
-		if (ReflectionUtils.isKotlinClass(type.getType())) {
-
-			for (Constructor<?> candidate : rawOwningType.getDeclaredConstructors()) {
-
-				PreferredConstructor<T, P> preferredConstructor = buildPreferredConstructor(candidate, type, entity);
-
-				// Synthetic constructors should not be considered
-				if (preferredConstructor.getConstructor().isSynthetic()) {
-					continue;
-				}
-
-				// Explicitly defined constructor trumps all
-				if (preferredConstructor.isExplicitlyAnnotated()) {
-					this.constructor = preferredConstructor;
-					return;
-				}
-			}
-
-			KFunction<T> primaryConstructor = KClasses
-					.getPrimaryConstructor(JvmClassMappingKt.getKotlinClass(type.getType()));
-			Constructor<T> javaConstructor = ReflectJvmMapping.getJavaConstructor(primaryConstructor);
-			if (javaConstructor != null) {
-				this.constructor = buildPreferredConstructor(javaConstructor, type, entity);
-				return;
-			}
-		}
-
-		for (Constructor<?> candidate : rawOwningType.getDeclaredConstructors()) {
-
-			PreferredConstructor<T, P> preferredConstructor = buildPreferredConstructor(candidate, type, entity);
-
-			// Synthetic constructors should not be considered
-			if (preferredConstructor.getConstructor().isSynthetic()) {
-				continue;
-			}
-
-			// Explicitly defined constructor trumps all
-			if (preferredConstructor.isExplicitlyAnnotated()) {
-				this.constructor = preferredConstructor;
-				return;
-			}
-
-			// No-arg constructor trumps custom ones
-			if (this.constructor == null || preferredConstructor.isNoArgConstructor()) {
-				this.constructor = preferredConstructor;
-			}
-
-			if (preferredConstructor.isNoArgConstructor()) {
-				noArgConstructorFound = true;
-			} else {
-				numberOfArgConstructors++;
-			}
-		}
-
-		if (!noArgConstructorFound && numberOfArgConstructors > 1) {
-			this.constructor = null;
-		}
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private PreferredConstructor<T, P> buildPreferredConstructor(Constructor<?> constructor,
-			TypeInformation<T> typeInformation, @Nullable PersistentEntity<T, P> entity) {
-
-		List<TypeInformation<?>> parameterTypes = typeInformation.getParameterTypes(constructor);
-
-		if (parameterTypes.isEmpty()) {
-			return new PreferredConstructor<>((Constructor<T>) constructor);
-		}
-
-		String[] parameterNames = discoverer.getParameterNames(constructor);
-
-		Parameter<Object, P>[] parameters = new Parameter[parameterTypes.size()];
-		Annotation[][] parameterAnnotations = constructor.getParameterAnnotations();
-
-		for (int i = 0; i < parameterTypes.size(); i++) {
-
-			String name = parameterNames == null ? null : parameterNames[i];
-			TypeInformation<?> type = parameterTypes.get(i);
-			Annotation[] annotations = parameterAnnotations[i];
-
-			parameters[i] = new Parameter(name, type, annotations, entity);
-		}
-
-		return new PreferredConstructor<>((Constructor<T>) constructor, parameters);
-	}
-
-	/**
-	 * Returns the discovered {@link PreferredConstructor}.
-	 *
-	 * @return
+	 * @return the {@link PreferredConstructor} if found or {@literal null}.
 	 */
 	@Nullable
-	public PreferredConstructor<T, P> getConstructor() {
-		return constructor;
+	static <T, P extends PersistentProperty<P>> PreferredConstructor<T, P> discover(Class<T> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+
+		return PreferredConstructorDiscoverers.findDiscoverer(type).discover(ClassTypeInformation.from(type), null);
+	}
+
+	/**
+	 * Discovers the {@link PreferredConstructorDiscoverer} for the given {@link PersistentEntity}.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @return the {@link PreferredConstructor} if found or {@literal null}.
+	 */
+	@Nullable
+	static <T, P extends PersistentProperty<P>> PreferredConstructor<T, P> discover(PersistentEntity<T, P> entity) {
+
+		Assert.notNull(entity, "PersistentEntity must not be null!");
+
+		return PreferredConstructorDiscoverers.findDiscoverer(entity.getType()).discover(entity.getTypeInformation(),
+				entity);
 	}
 }

--- a/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverers.java
+++ b/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverers.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KFunction;
+import kotlin.reflect.full.KClasses;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.mapping.PreferredConstructor.Parameter;
+import org.springframework.data.util.ReflectionUtils;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+
+/**
+ * Helper class to find a {@link PreferredConstructor}.
+ *
+ * @author Oliver Gierke
+ * @author Christoph Strobl
+ * @author Roman Rodov
+ * @author Mark Paluch
+ * @since 2.0
+ */
+enum PreferredConstructorDiscoverers {
+
+	/**
+	 * Discovers a {@link PreferredConstructor} for Java types.
+	 */
+	DEFAULT {
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mapping.model.PreferredConstructorDiscoverers#discover(org.springframework.data.util.TypeInformation, org.springframework.data.mapping.PersistentEntity)
+		 */
+		@Nullable
+		@Override
+		public <T, P extends PersistentProperty<P>> PreferredConstructor<T, P> discover(TypeInformation<T> type,
+				@Nullable PersistentEntity<T, P> entity) {
+
+			boolean noArgConstructorFound = false;
+			int numberOfArgConstructors = 0;
+			Class<?> rawOwningType = type.getType();
+			PreferredConstructor<T, P> constructor = null;
+
+			for (Constructor<?> candidate : rawOwningType.getDeclaredConstructors()) {
+
+				PreferredConstructor<T, P> preferredConstructor = buildPreferredConstructor(candidate, type, entity);
+
+				// Synthetic constructors should not be considered
+				if (preferredConstructor.getConstructor().isSynthetic()) {
+					continue;
+				}
+
+				// Explicitly defined constructor trumps all
+				if (preferredConstructor.isExplicitlyAnnotated()) {
+					return preferredConstructor;
+				}
+
+				// No-arg constructor trumps custom ones
+				if (constructor == null || preferredConstructor.isNoArgConstructor()) {
+					constructor = preferredConstructor;
+				}
+
+				if (preferredConstructor.isNoArgConstructor()) {
+					noArgConstructorFound = true;
+				} else {
+					numberOfArgConstructors++;
+				}
+			}
+
+			if (!noArgConstructorFound && numberOfArgConstructors > 1) {
+				constructor = null;
+			}
+
+			return constructor;
+		}
+	},
+
+	/**
+	 * Discovers a {@link PreferredConstructor} for Kotlin types.
+	 */
+	KOTLIN {
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mapping.model.PreferredConstructorDiscoverers#discover(org.springframework.data.util.TypeInformation, org.springframework.data.mapping.PersistentEntity)
+		 */
+		@Nullable
+		@Override
+		public <T, P extends PersistentProperty<P>> PreferredConstructor<T, P> discover(TypeInformation<T> type,
+				@Nullable PersistentEntity<T, P> entity) {
+
+			Class<?> rawOwningType = type.getType();
+
+			return Arrays.stream(rawOwningType.getDeclaredConstructors()) //
+					.map(it -> buildPreferredConstructor(it, type, entity)) //
+					.filter(it -> !it.getConstructor().isSynthetic()) // Synthetic constructors should not be considered
+					.filter(PreferredConstructor::isExplicitlyAnnotated) // Explicitly defined constructor trumps all
+					.findFirst() //
+					.orElseGet(() -> {
+
+						KFunction<T> primaryConstructor = KClasses
+								.getPrimaryConstructor(JvmClassMappingKt.getKotlinClass(type.getType()));
+						Constructor<T> javaConstructor = ReflectJvmMapping.getJavaConstructor(primaryConstructor);
+
+						return javaConstructor != null ? buildPreferredConstructor(javaConstructor, type, entity) : null;
+					});
+		}
+	};
+
+	private static final ParameterNameDiscoverer discoverer = new DefaultParameterNameDiscoverer();
+
+	/**
+	 * Find the appropriate discoverer for {@code type}.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return the appropriate discoverer for {@code type}.
+	 */
+	public static PreferredConstructorDiscoverers findDiscoverer(Class<?> type) {
+		return ReflectionUtils.isKotlinClass(type) ? KOTLIN : DEFAULT;
+	}
+
+	/**
+	 * Discovers a constructor for the given type.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param entity may be {@literal null}.
+	 * @return the {@link PreferredConstructor} if found or {@literal null}.
+	 */
+	@Nullable
+	public abstract <T, P extends PersistentProperty<P>> PreferredConstructor<T, P> discover(TypeInformation<T> type,
+			@Nullable PersistentEntity<T, P> entity);
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private static <T, P extends PersistentProperty<P>> PreferredConstructor<T, P> buildPreferredConstructor(
+			Constructor<?> constructor, TypeInformation<T> typeInformation, @Nullable PersistentEntity<T, P> entity) {
+
+		List<TypeInformation<?>> parameterTypes = typeInformation.getParameterTypes(constructor);
+
+		if (parameterTypes.isEmpty()) {
+			return new PreferredConstructor<>((Constructor<T>) constructor);
+		}
+
+		String[] parameterNames = discoverer.getParameterNames(constructor);
+
+		Parameter<Object, P>[] parameters = new Parameter[parameterTypes.size()];
+		Annotation[][] parameterAnnotations = constructor.getParameterAnnotations();
+
+		for (int i = 0; i < parameterTypes.size(); i++) {
+
+			String name = parameterNames == null ? null : parameterNames[i];
+			TypeInformation<?> type = parameterTypes.get(i);
+			Annotation[] annotations = parameterAnnotations[i];
+
+			parameters[i] = new Parameter(name, type, annotations, entity);
+		}
+
+		return new PreferredConstructor<>((Constructor<T>) constructor, parameters);
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/ReturnedType.java
+++ b/src/main/java/org/springframework/data/repository/query/ReturnedType.java
@@ -45,6 +45,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.12
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -296,8 +297,7 @@ public abstract class ReturnedType {
 				return Collections.emptyList();
 			}
 
-			PreferredConstructorDiscoverer<?, ?> discoverer = new PreferredConstructorDiscoverer(type);
-			PreferredConstructor<?, ?> constructor = discoverer.getConstructor();
+			PreferredConstructor<?, ?> constructor = PreferredConstructorDiscoverer.discover(type);
 
 			if (constructor == null) {
 				return Collections.emptyList();

--- a/src/main/java/org/springframework/data/util/ReflectionUtils.java
+++ b/src/main/java/org/springframework/data/util/ReflectionUtils.java
@@ -40,19 +40,23 @@ import org.springframework.util.ReflectionUtils.FieldFilter;
 
 /**
  * Spring Data specific reflection utility methods and classes.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.5
  */
 @UtilityClass
 public class ReflectionUtils {
 
+	private static final boolean KOTLIN_IS_PRESENT = ClassUtils.isPresent("kotlin.Unit",
+			BeanUtils.class.getClassLoader());
+
 	/**
 	 * Creates an instance of the class with the given fully qualified name or returns the given default instance if the
 	 * class cannot be loaded or instantiated.
-	 * 
+	 *
 	 * @param classname the fully qualified class name to create an instance for.
 	 * @param defaultInstance the instance to fall back to in case the given class cannot be loaded or instantiated.
 	 * @return
@@ -70,7 +74,7 @@ public class ReflectionUtils {
 
 	/**
 	 * A {@link FieldFilter} that has a description.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	public interface DescribedFieldFilter extends FieldFilter {
@@ -78,7 +82,7 @@ public class ReflectionUtils {
 		/**
 		 * Returns the description of the field filter. Used in exceptions being thrown in case uniqueness shall be enforced
 		 * on the field filter.
-		 * 
+		 *
 		 * @return
 		 */
 		String getDescription();
@@ -86,7 +90,7 @@ public class ReflectionUtils {
 
 	/**
 	 * A {@link FieldFilter} for a given annotation.
-	 * 
+	 *
 	 * @author Oliver Gierke
 	 */
 	@RequiredArgsConstructor
@@ -94,7 +98,7 @@ public class ReflectionUtils {
 
 		private final @NonNull Class<? extends Annotation> annotationType;
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.util.ReflectionUtils.FieldFilter#matches(java.lang.reflect.Field)
 		 */
@@ -102,7 +106,7 @@ public class ReflectionUtils {
 			return AnnotationUtils.getAnnotation(field, annotationType) != null;
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.util.ReflectionUtils.DescribedFieldFilter#getDescription()
 		 */
@@ -113,7 +117,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Finds the first field on the given class matching the given {@link FieldFilter}.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @param filter must not be {@literal null}.
 	 * @return the field matching the filter or {@literal null} in case no field could be found.
@@ -136,7 +140,7 @@ public class ReflectionUtils {
 	/**
 	 * Finds the field matching the given {@link DescribedFieldFilter}. Will make sure there's only one field matching the
 	 * filter.
-	 * 
+	 *
 	 * @see #findField(Class, DescribedFieldFilter, boolean)
 	 * @param type must not be {@literal null}.
 	 * @param filter must not be {@literal null}.
@@ -151,7 +155,7 @@ public class ReflectionUtils {
 	/**
 	 * Finds the field matching the given {@link DescribedFieldFilter}. Will make sure there's only one field matching the
 	 * filter in case {@code enforceUniqueness} is {@literal true}.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @param filter must not be {@literal null}.
 	 * @param enforceUniqueness whether to enforce uniqueness of the field
@@ -194,7 +198,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Finds the field of the given name on the given type.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @param name must not be {@literal null} or empty.
 	 * @return
@@ -213,7 +217,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Sets the given field on the given object to the given value. Will make sure the given field is accessible.
-	 * 
+	 *
 	 * @param field must not be {@literal null}.
 	 * @param target must not be {@literal null}.
 	 * @param value
@@ -226,7 +230,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Finds a constructor on the given type that matches the given constructor arguments.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @param constructorArguments must not be {@literal null}.
 	 * @return a {@link Constructor} that is compatible with the given arguments.
@@ -243,7 +247,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Returns the method with the given name of the given class and parameter types.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @param name must not be {@literal null}.
 	 * @param parameterTypes must not be {@literal null}.
@@ -269,7 +273,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Returns a {@link Stream} of the return and parameters types of the given {@link Method}.
-	 * 
+	 *
 	 * @param method must not be {@literal null}.
 	 * @return
 	 * @since 2.0
@@ -286,7 +290,7 @@ public class ReflectionUtils {
 
 	/**
 	 * Returns the {@link Method} with the given name and parameters declared on the given type, if available.
-	 * 
+	 *
 	 * @param type must not be {@literal null}.
 	 * @param name must not be {@literal null} or empty.
 	 * @param parameterTypes must not be {@literal null}.
@@ -337,5 +341,18 @@ public class ReflectionUtils {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Return true if the specified class is a Kotlin one.
+	 *
+	 * @return {@literal true} if {@code type} is a Kotlin class.
+	 * @since 2.0
+	 */
+	public static boolean isKotlinClass(Class<?> type) {
+
+		return KOTLIN_IS_PRESENT && Arrays.stream(type.getDeclaredAnnotations()) //
+				.map(Annotation::annotationType) //
+				.anyMatch(annotation -> annotation.getName().equals("kotlin.Metadata"));
 	}
 }

--- a/src/test/java/org/springframework/data/convert/ClassGeneratingEntityInstantiatorUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/ClassGeneratingEntityInstantiatorUnitTests.java
@@ -53,8 +53,6 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 
 	@Mock PersistentEntity<?, P> entity;
 	@Mock ParameterValueProvider<P> provider;
-	@Mock PreferredConstructor<?, P> constructor;
-	@Mock Parameter<?, P> parameter;
 
 	@Test
 	public void instantiatesSimpleObjectCorrectly() {
@@ -72,11 +70,10 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		this.instance.createInstance(entity, provider);
 	}
 
-	@Test
+	@Test // DATACMNS-1126
 	public void instantiatesTypeWithPreferredConstructorUsingParameterValueProvider() {
 
-		PreferredConstructor<Foo, P> constructor = new PreferredConstructorDiscoverer<Foo, P>(Foo.class)
-				.getConstructor();
+		PreferredConstructor<Foo, P> constructor = PreferredConstructorDiscoverer.discover(Foo.class);
 
 		doReturn(Foo.class).when(entity).getType();
 		doReturn(constructor).when(entity).getPersistenceConstructor();
@@ -150,23 +147,21 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		}
 	}
 
-	@Test // DATACMNS-578
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test // DATACMNS-578, DATACMNS-1126
 	public void instantiateObjCtorDefault() {
 
 		doReturn(ObjCtorDefault.class).when(entity).getType();
-		doReturn(new PreferredConstructorDiscoverer<>(ObjCtorDefault.class).getConstructor())//
+		doReturn(PreferredConstructorDiscoverer.discover(ObjCtorDefault.class))//
 				.when(entity).getPersistenceConstructor();
 
 		IntStream.range(0, 2).forEach(i -> assertThat(this.instance.createInstance(entity, provider)).isInstanceOf(ObjCtorDefault.class));
 	}
 
-	@Test // DATACMNS-578
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test // DATACMNS-578, DATACMNS-1126
 	public void instantiateObjCtorNoArgs() {
 
 		doReturn(ObjCtorNoArgs.class).when(entity).getType();
-		doReturn(new PreferredConstructorDiscoverer<>(ObjCtorNoArgs.class).getConstructor())//
+		doReturn(PreferredConstructorDiscoverer.discover(ObjCtorNoArgs.class))//
 				.when(entity).getPersistenceConstructor();
 
 		IntStream.range(0, 2).forEach(i -> {
@@ -178,12 +173,11 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		});
 	}
 
-	@Test // DATACMNS-578
-	@SuppressWarnings("unchecked")
+	@Test // DATACMNS-578, DATACMNS-1126
 	public void instantiateObjCtor1ParamString() {
 
 		doReturn(ObjCtor1ParamString.class).when(entity).getType();
-		doReturn(new PreferredConstructorDiscoverer<>(ObjCtor1ParamString.class).getConstructor())//
+		doReturn(PreferredConstructorDiscoverer.discover(ObjCtor1ParamString.class))//
 				.when(entity).getPersistenceConstructor();
 		doReturn("FOO").when(provider).getParameterValue(any());
 
@@ -197,12 +191,11 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		});
 	}
 
-	@Test // DATACMNS-578
-	@SuppressWarnings("unchecked")
+	@Test // DATACMNS-578, DATACMNS-1126
 	public void instantiateObjCtor2ParamStringString() {
 
 		doReturn(ObjCtor2ParamStringString.class).when(entity).getType();
-		doReturn(new PreferredConstructorDiscoverer<>(ObjCtor2ParamStringString.class).getConstructor())//
+		doReturn(PreferredConstructorDiscoverer.discover(ObjCtor2ParamStringString.class))//
 				.when(entity).getPersistenceConstructor();
 
 		IntStream.range(0, 2).forEach(i -> {
@@ -218,12 +211,11 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		});
 	}
 
-	@Test // DATACMNS-578
-	@SuppressWarnings("unchecked")
+	@Test // DATACMNS-578, DATACMNS-1126
 	public void instantiateObjectCtor1ParamInt() {
 
 		doReturn(ObjectCtor1ParamInt.class).when(entity).getType();
-		doReturn(new PreferredConstructorDiscoverer<>(ObjectCtor1ParamInt.class).getConstructor())//
+		doReturn(PreferredConstructorDiscoverer.discover(ObjectCtor1ParamInt.class))//
 				.when(entity).getPersistenceConstructor();
 
 		IntStream.range(0, 2).forEach(i -> {
@@ -237,12 +229,12 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		});
 	}
 
-	@Test // DATACMNS-578
+	@Test // DATACMNS-578, DATACMNS-1126
 	@SuppressWarnings("unchecked")
 	public void instantiateObjectCtor7ParamsString5IntsString() {
 
 		doReturn(ObjectCtor7ParamsString5IntsString.class).when(entity).getType();
-		doReturn(new PreferredConstructorDiscoverer<>(ObjectCtor7ParamsString5IntsString.class).getConstructor())//
+		doReturn(PreferredConstructorDiscoverer.discover(ObjectCtor7ParamsString5IntsString.class))//
 				.when(entity).getPersistenceConstructor();
 
 		IntStream.range(0, 2).forEach(i -> {

--- a/src/test/java/org/springframework/data/convert/ReflectionEntityInstantiatorUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/ReflectionEntityInstantiatorUnitTests.java
@@ -51,8 +51,6 @@ public class ReflectionEntityInstantiatorUnitTests<P extends PersistentProperty<
 
 	@Mock PersistentEntity<?, P> entity;
 	@Mock ParameterValueProvider<P> provider;
-	@Mock PreferredConstructor<?, P> constructor;
-	@Mock Parameter<?, P> parameter;
 
 	@Test
 	public void instantiatesSimpleObjectCorrectly() {
@@ -68,10 +66,10 @@ public class ReflectionEntityInstantiatorUnitTests<P extends PersistentProperty<
 		INSTANCE.createInstance(entity, provider);
 	}
 
-	@Test
+	@Test // DATACMNS-1126
 	public void instantiatesTypeWithPreferredConstructorUsingParameterValueProvider() {
 
-		PreferredConstructor<Foo, P> constructor = new PreferredConstructorDiscoverer<Foo, P>(Foo.class).getConstructor();
+		PreferredConstructor<Foo, P> constructor = PreferredConstructorDiscoverer.discover(Foo.class);
 
 		doReturn(constructor).when(entity).getPersistenceConstructor();
 

--- a/src/test/kotlin/org/springframework/data/convert/ClassGeneratingEntityInstantiatorDataClassUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/ClassGeneratingEntityInstantiatorDataClassUnitTests.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.springframework.data.mapping.PersistentEntity
+import org.springframework.data.mapping.context.SamplePersistentProperty
+import org.springframework.data.mapping.model.ParameterValueProvider
+import org.springframework.data.mapping.model.PreferredConstructorDiscoverer
+
+/**
+ * Unit tests for [ClassGeneratingEntityInstantiator] creating instances using Kotlin data classes.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner::class)
+@Suppress("UNCHECKED_CAST")
+class ClassGeneratingEntityInstantiatorDataClassUnitTests {
+
+	@Mock lateinit var entity: PersistentEntity<*, *>
+	@Mock lateinit var provider: ParameterValueProvider<SamplePersistentProperty>
+
+	@Test // DATACMNS-1126
+	fun `should create instance`() {
+
+		val entity = this.entity as PersistentEntity<Contact, SamplePersistentProperty>
+		val constructor = PreferredConstructorDiscoverer<Contact, SamplePersistentProperty>(Contact::class.java).constructor
+
+		doReturn("Walter", "White").`when`(provider).getParameterValue<SamplePersistentProperty>(any())
+		doReturn(constructor).whenever(entity).persistenceConstructor
+		doReturn(constructor.constructor.declaringClass).whenever(entity).type
+
+		val instance: Contact = ClassGeneratingEntityInstantiator().createInstance(entity, provider)
+
+		Assertions.assertThat(instance.firstname).isEqualTo("Walter")
+		Assertions.assertThat(instance.lastname).isEqualTo("White")
+	}
+
+	@Test // DATACMNS-1126
+	fun `should create instance and fill in defaults`() {
+
+		val entity = this.entity as PersistentEntity<ContactWithDefaulting, SamplePersistentProperty>
+		val constructor = PreferredConstructorDiscoverer<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java).constructor
+
+		doReturn("Walter", null, "Skyler", null, null, null, null, null, null, null, /* 0-9 */
+				null, null, null, null, null, null, null, null, null, null, /* 10-19 */
+				null, null, null, null, null, null, null, null, null, null, /* 20 - 29 */
+				null, "Walter", null, "Junior", null).`when`(provider).getParameterValue<SamplePersistentProperty>(any())
+		doReturn(constructor).whenever(entity).persistenceConstructor
+		doReturn(constructor.constructor.declaringClass).whenever(entity).type
+
+		val instance: ContactWithDefaulting = ClassGeneratingEntityInstantiator().createInstance(entity, provider)
+
+		Assertions.assertThat(instance.prop0).isEqualTo("Walter")
+		Assertions.assertThat(instance.prop2).isEqualTo("Skyler")
+		Assertions.assertThat(instance.prop31).isEqualTo("Walter")
+		Assertions.assertThat(instance.prop32).isEqualTo("White")
+		Assertions.assertThat(instance.prop33).isEqualTo("Junior")
+		Assertions.assertThat(instance.prop34).isEqualTo("White")
+	}
+
+	data class Contact(val firstname: String, val lastname: String)
+
+	data class ContactWithDefaulting(val prop0: String, val prop1: String = "White", val prop2: String,
+									 val prop3: String = "White", val prop4: String = "White", val prop5: String = "White",
+									 val prop6: String = "White", val prop7: String = "White", val prop8: String = "White",
+									 val prop9: String = "White", val prop10: String = "White", val prop11: String = "White",
+									 val prop12: String = "White", val prop13: String = "White", val prop14: String = "White",
+									 val prop15: String = "White", val prop16: String = "White", val prop17: String = "White",
+									 val prop18: String = "White", val prop19: String = "White", val prop20: String = "White",
+									 val prop21: String = "White", val prop22: String = "White", val prop23: String = "White",
+									 val prop24: String = "White", val prop25: String = "White", val prop26: String = "White",
+									 val prop27: String = "White", val prop28: String = "White", val prop29: String = "White",
+									 val prop30: String = "White", val prop31: String = "White", val prop32: String = "White",
+									 val prop33: String, val prop34: String = "White"
+	)
+}
+

--- a/src/test/kotlin/org/springframework/data/convert/ClassGeneratingEntityInstantiatorDataClassUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/ClassGeneratingEntityInstantiatorDataClassUnitTests.kt
@@ -44,7 +44,7 @@ class ClassGeneratingEntityInstantiatorDataClassUnitTests {
 	fun `should create instance`() {
 
 		val entity = this.entity as PersistentEntity<Contact, SamplePersistentProperty>
-		val constructor = PreferredConstructorDiscoverer<Contact, SamplePersistentProperty>(Contact::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<Contact, SamplePersistentProperty>(Contact::class.java)
 
 		doReturn("Walter", "White").`when`(provider).getParameterValue<SamplePersistentProperty>(any())
 		doReturn(constructor).whenever(entity).persistenceConstructor
@@ -60,11 +60,11 @@ class ClassGeneratingEntityInstantiatorDataClassUnitTests {
 	fun `should create instance and fill in defaults`() {
 
 		val entity = this.entity as PersistentEntity<ContactWithDefaulting, SamplePersistentProperty>
-		val constructor = PreferredConstructorDiscoverer<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java)
 
 		doReturn("Walter", null, "Skyler", null, null, null, null, null, null, null, /* 0-9 */
 				null, null, null, null, null, null, null, null, null, null, /* 10-19 */
-				null, null, null, null, null, null, null, null, null, null, /* 20 - 29 */
+				null, null, null, null, null, null, null, null, null, null, /* 20-29 */
 				null, "Walter", null, "Junior", null).`when`(provider).getParameterValue<SamplePersistentProperty>(any())
 		doReturn(constructor).whenever(entity).persistenceConstructor
 		doReturn(constructor.constructor.declaringClass).whenever(entity).type

--- a/src/test/kotlin/org/springframework/data/convert/ClassGeneratingKotlinEntityInstantiatorUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/ClassGeneratingKotlinEntityInstantiatorUnitTests.kt
@@ -29,13 +29,13 @@ import org.springframework.data.mapping.model.ParameterValueProvider
 import org.springframework.data.mapping.model.PreferredConstructorDiscoverer
 
 /**
- * Unit tests for [ClassGeneratingEntityInstantiator] creating instances using Kotlin data classes.
+ * Unit tests for [ClassGeneratingKotlinEntityInstantiator] creating instances using Kotlin data classes.
  *
  * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner::class)
 @Suppress("UNCHECKED_CAST")
-class ClassGeneratingEntityInstantiatorDataClassUnitTests {
+class ClassGeneratingKotlinEntityInstantiatorUnitTests {
 
 	@Mock lateinit var entity: PersistentEntity<*, *>
 	@Mock lateinit var provider: ParameterValueProvider<SamplePersistentProperty>
@@ -50,7 +50,7 @@ class ClassGeneratingEntityInstantiatorDataClassUnitTests {
 		doReturn(constructor).whenever(entity).persistenceConstructor
 		doReturn(constructor.constructor.declaringClass).whenever(entity).type
 
-		val instance: Contact = ClassGeneratingEntityInstantiator().createInstance(entity, provider)
+		val instance: Contact = ClassGeneratingKotlinEntityInstantiator().createInstance(entity, provider)
 
 		Assertions.assertThat(instance.firstname).isEqualTo("Walter")
 		Assertions.assertThat(instance.lastname).isEqualTo("White")
@@ -69,7 +69,7 @@ class ClassGeneratingEntityInstantiatorDataClassUnitTests {
 		doReturn(constructor).whenever(entity).persistenceConstructor
 		doReturn(constructor.constructor.declaringClass).whenever(entity).type
 
-		val instance: ContactWithDefaulting = ClassGeneratingEntityInstantiator().createInstance(entity, provider)
+		val instance: ContactWithDefaulting = ClassGeneratingKotlinEntityInstantiator().createInstance(entity, provider)
 
 		Assertions.assertThat(instance.prop0).isEqualTo("Walter")
 		Assertions.assertThat(instance.prop2).isEqualTo("Skyler")

--- a/src/test/kotlin/org/springframework/data/convert/ReflectionEntityInstantiatorDataClassUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/ReflectionEntityInstantiatorDataClassUnitTests.kt
@@ -30,7 +30,7 @@ import org.springframework.data.mapping.model.PreferredConstructorDiscoverer
 
 /**
  * Unit tests for [ReflectionEntityInstantiator] creating instances using Kotlin data classes.
-
+ *
  * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner::class)
@@ -44,7 +44,7 @@ class ReflectionEntityInstantiatorDataClassUnitTests {
 	fun `should create instance`() {
 
 		val entity = this.entity as PersistentEntity<Contact, SamplePersistentProperty>
-		val constructor = PreferredConstructorDiscoverer<Contact, SamplePersistentProperty>(Contact::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<Contact, SamplePersistentProperty>(Contact::class.java)
 
 		doReturn("Walter", "White").`when`(provider).getParameterValue<SamplePersistentProperty>(any())
 		doReturn(constructor).whenever(entity).persistenceConstructor
@@ -59,7 +59,7 @@ class ReflectionEntityInstantiatorDataClassUnitTests {
 	fun `should create instance and fill in defaults`() {
 
 		val entity = this.entity as PersistentEntity<ContactWithDefaulting, SamplePersistentProperty>
-		val constructor = PreferredConstructorDiscoverer<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java)
 
 		doReturn("Walter", null).`when`(provider).getParameterValue<SamplePersistentProperty>(any())
 		doReturn(constructor).whenever(entity).persistenceConstructor

--- a/src/test/kotlin/org/springframework/data/convert/ReflectionEntityInstantiatorDataClassUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/ReflectionEntityInstantiatorDataClassUnitTests.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.springframework.data.mapping.PersistentEntity
+import org.springframework.data.mapping.context.SamplePersistentProperty
+import org.springframework.data.mapping.model.ParameterValueProvider
+import org.springframework.data.mapping.model.PreferredConstructorDiscoverer
+
+/**
+ * Unit tests for [ReflectionEntityInstantiator] creating instances using Kotlin data classes.
+
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner::class)
+@Suppress("UNCHECKED_CAST")
+class ReflectionEntityInstantiatorDataClassUnitTests {
+
+	@Mock lateinit var entity: PersistentEntity<*, *>
+	@Mock lateinit var provider: ParameterValueProvider<SamplePersistentProperty>
+
+	@Test // DATACMNS-1126
+	fun `should create instance`() {
+
+		val entity = this.entity as PersistentEntity<Contact, SamplePersistentProperty>
+		val constructor = PreferredConstructorDiscoverer<Contact, SamplePersistentProperty>(Contact::class.java).constructor
+
+		doReturn("Walter", "White").`when`(provider).getParameterValue<SamplePersistentProperty>(any())
+		doReturn(constructor).whenever(entity).persistenceConstructor
+
+		val instance: Contact = ReflectionEntityInstantiator.INSTANCE.createInstance(entity, provider)
+
+		Assertions.assertThat(instance.firstname).isEqualTo("Walter")
+		Assertions.assertThat(instance.lastname).isEqualTo("White")
+	}
+
+	@Test // DATACMNS-1126
+	fun `should create instance and fill in defaults`() {
+
+		val entity = this.entity as PersistentEntity<ContactWithDefaulting, SamplePersistentProperty>
+		val constructor = PreferredConstructorDiscoverer<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java).constructor
+
+		doReturn("Walter", null).`when`(provider).getParameterValue<SamplePersistentProperty>(any())
+		doReturn(constructor).whenever(entity).persistenceConstructor
+
+		val instance: ContactWithDefaulting = ReflectionEntityInstantiator.INSTANCE.createInstance(entity, provider)
+
+		Assertions.assertThat(instance.firstname).isEqualTo("Walter")
+		Assertions.assertThat(instance.lastname).isEqualTo("White")
+	}
+
+	data class Contact(val firstname: String, val lastname: String)
+
+	data class ContactWithDefaulting(val firstname: String, val lastname: String = "White")
+}
+

--- a/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
@@ -30,7 +30,7 @@ class PreferredConstructorDiscovererUnitTests {
 	@Test // DATACMNS-1126
 	fun `should discover simple constructor`() {
 
-		val constructor = PreferredConstructorDiscoverer<Simple, SamplePersistentProperty>(Simple::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<Simple, SamplePersistentProperty>(Simple::class.java)
 
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
 	}
@@ -38,7 +38,7 @@ class PreferredConstructorDiscovererUnitTests {
 	@Test // DATACMNS-1126
 	fun `should reject two constructors`() {
 
-		val constructor = PreferredConstructorDiscoverer<TwoConstructors, SamplePersistentProperty>(TwoConstructors::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<TwoConstructors, SamplePersistentProperty>(TwoConstructors::class.java)
 
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
 	}
@@ -46,7 +46,7 @@ class PreferredConstructorDiscovererUnitTests {
 	@Test // DATACMNS-1126
 	fun `should discover annotated constructor`() {
 
-		val constructor = PreferredConstructorDiscoverer<AnnotatedConstructors, SamplePersistentProperty>(AnnotatedConstructors::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<AnnotatedConstructors, SamplePersistentProperty>(AnnotatedConstructors::class.java)
 
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(2)
 	}
@@ -54,7 +54,7 @@ class PreferredConstructorDiscovererUnitTests {
 	@Test // DATACMNS-1126
 	fun `should discover default constructor`() {
 
-		val constructor = PreferredConstructorDiscoverer<DefaultConstructor, SamplePersistentProperty>(DefaultConstructor::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<DefaultConstructor, SamplePersistentProperty>(DefaultConstructor::class.java)
 
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
 	}
@@ -62,7 +62,7 @@ class PreferredConstructorDiscovererUnitTests {
 	@Test // DATACMNS-1126
 	fun `should discover default annotated constructor`() {
 
-		val constructor = PreferredConstructorDiscoverer<TwoDefaultConstructorsAnnotated, SamplePersistentProperty>(TwoDefaultConstructorsAnnotated::class.java).constructor
+		val constructor = PreferredConstructorDiscoverer.discover<TwoDefaultConstructorsAnnotated, SamplePersistentProperty>(TwoDefaultConstructorsAnnotated::class.java)
 
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(3)
 	}

--- a/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model
+
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.springframework.data.annotation.PersistenceConstructor
+import org.springframework.data.mapping.model.AbstractPersistentPropertyUnitTests.*
+
+/**
+ * Unit tests for [PreferredConstructorDiscoverer].
+ *
+ * @author Mark Paluch
+ */
+class PreferredConstructorDiscovererUnitTests {
+
+	@Test // DATACMNS-1126
+	fun `should discover simple constructor`() {
+
+		val constructor = PreferredConstructorDiscoverer<Simple, SamplePersistentProperty>(Simple::class.java).constructor
+
+		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
+	}
+
+	@Test // DATACMNS-1126
+	fun `should reject two constructors`() {
+
+		val constructor = PreferredConstructorDiscoverer<TwoConstructors, SamplePersistentProperty>(TwoConstructors::class.java).constructor
+
+		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
+	}
+
+	@Test // DATACMNS-1126
+	fun `should discover annotated constructor`() {
+
+		val constructor = PreferredConstructorDiscoverer<AnnotatedConstructors, SamplePersistentProperty>(AnnotatedConstructors::class.java).constructor
+
+		Assertions.assertThat(constructor.parameters.size).isEqualTo(2)
+	}
+
+	@Test // DATACMNS-1126
+	fun `should discover default constructor`() {
+
+		val constructor = PreferredConstructorDiscoverer<DefaultConstructor, SamplePersistentProperty>(DefaultConstructor::class.java).constructor
+
+		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
+	}
+
+	@Test // DATACMNS-1126
+	fun `should discover default annotated constructor`() {
+
+		val constructor = PreferredConstructorDiscoverer<TwoDefaultConstructorsAnnotated, SamplePersistentProperty>(TwoDefaultConstructorsAnnotated::class.java).constructor
+
+		Assertions.assertThat(constructor.parameters.size).isEqualTo(3)
+	}
+
+	data class Simple(val firstname: String)
+
+	class TwoConstructors(val firstname: String) {
+		constructor(firstname: String, lastname: String) : this(firstname)
+	}
+
+	class AnnotatedConstructors(val firstname: String) {
+
+		@PersistenceConstructor
+		constructor(firstname: String, lastname: String) : this(firstname)
+	}
+
+	class DefaultConstructor(val firstname: String = "foo") {
+	}
+
+	class TwoDefaultConstructorsAnnotated(val firstname: String = "foo", val lastname: String = "bar") {
+
+		@PersistenceConstructor
+		constructor(firstname: String = "foo", lastname: String = "bar", age: Int) : this(firstname, lastname)
+	}
+}


### PR DESCRIPTION
We now discover Kotlin constructors and apply parameter defaulting to allow construction of immutable value objects. Constructor discovery uses primary constructors by default and considers `@PersistenceConstructor` annotations.

`ClassGeneratingEntityInstantiator` can instantiate Kotlin classes with default parameters by resolving the synthetic constructor. Null values translate to parameter defaults.

```kotlin
class Person(val firstname: String = "Walter") {
}

class Address(val street: String, val city: String) {

	@PersistenceConstructor
	constructor(street: String = "Unknown", city: String = "Unknown", country: String) : this(street, city)
}
```