### PR TITLE
DATACMNS-1080 - Inject generated property accessor classes via ReflectUtils.defineClass(…).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1080-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
We now use `ReflectUtils.defineClass(…)` to inject classes into the Entities' class loader instead of our own code. `ReflectUtils` discovers itself whether the class loader is encapsulated and falls back to Unsafe for class definition. We no longer require our own code so the evil class was removed.

---

Related ticket: [DATACMNS-1080](https://jira.spring.io/browse/DATACMNS-1080).