### PR TITLE
DATACMNS-1147 - Do not consider @NoRepositoryBean interfaces as fragment interfaces.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1147-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/test/java/org/springframework/data/repository/config/ExcludedRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/ExcludedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,15 @@
  */
 package org.springframework.data.repository.config;
 
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
 
-@EnableRepositories(
-		excludeFilters = { @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MyOtherRepository.class),
-				@Filter(type = FilterType.ASSIGNABLE_TYPE, value = ExcludedRepository.class) },
-		basePackageClasses = AnnotationRepositoryConfigurationSourceUnitTests.class)
-class SampleConfiguration {
-
+/**
+ * Interface specifying customizations for a base repository implementation.
+ *
+ * @author Mark Paluch
+ */
+@NoRepositoryBean
+public interface ExcludedRepository<T, ID> extends Repository<T, ID> {
+	String getImplementationId();
 }

--- a/src/test/java/org/springframework/data/repository/config/ExcludedRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/ExcludedRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,17 @@
  */
 package org.springframework.data.repository.config;
 
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
+/**
+ * @author Mark Paluch
+ */
+public class ExcludedRepositoryImpl<T, ID> implements ExcludedRepository<T, ID> {
 
-@EnableRepositories(
-		excludeFilters = { @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MyOtherRepository.class),
-				@Filter(type = FilterType.ASSIGNABLE_TYPE, value = ExcludedRepository.class) },
-		basePackageClasses = AnnotationRepositoryConfigurationSourceUnitTests.class)
-class SampleConfiguration {
-
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.ExcludedRepository#getImplementationId()
+	 */
+	@Override
+	public String getImplementationId() {
+		return getClass().getName();
+	}
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportUnitTests.java
@@ -28,6 +28,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
@@ -69,6 +71,17 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 		assertBeanDefinitionRegisteredFor("mixinImpl");
 		assertBeanDefinitionRegisteredFor("mixinImplFragment");
 		assertNoBeanDefinitionRegisteredFor("profileRepository");
+	}
+
+	@Test // DATACMNS-1147
+	public void registersBeanDefinitionWithoutFragmentImplementations() {
+
+		AnnotationMetadata metadata = new StandardAnnotationMetadata(FragmentExclusionConfiguration.class, true);
+
+		registrar.registerBeanDefinitions(metadata, registry);
+
+		assertBeanDefinitionRegisteredFor("repositoryWithFragmentExclusion");
+		assertNoBeanDefinitionRegisteredFor("excludedRepositoryImpl");
 	}
 
 	@Test // DATACMNS-360
@@ -134,5 +147,12 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 		protected String getModulePrefix() {
 			return "commons";
 		}
+	}
+
+	@EnableRepositories(
+			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = RepositoryWithFragmentExclusion.class),
+			basePackageClasses = RepositoryWithFragmentExclusion.class)
+	static class FragmentExclusionConfiguration {
+
 	}
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryWithFragmentExclusion.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryWithFragmentExclusion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,11 @@
  */
 package org.springframework.data.repository.config;
 
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
+import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSourceUnitTests.Person;
 
-@EnableRepositories(
-		excludeFilters = { @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MyOtherRepository.class),
-				@Filter(type = FilterType.ASSIGNABLE_TYPE, value = ExcludedRepository.class) },
-		basePackageClasses = AnnotationRepositoryConfigurationSourceUnitTests.class)
-class SampleConfiguration {
-
-}
+/**
+ * Repository with customized base base interface.
+ *
+ * @author Mark Paluch
+ */
+public interface RepositoryWithFragmentExclusion extends ExcludedRepository<Person, Long> {}


### PR DESCRIPTION
We filter interfaces annotated with `@NoRepositoryBean` from fragment interface candidates and not longer scan for implementations of these.

Extending a base repository usually requires an interface which is used as base interface instead of `Repository`/`CrudRepository` in user repositories. If the naming scheme of the extended interface and the implementation fits to fragment interfaces, then we previously registered the class additionally as fragment implementation. The bean registration caused container startup failures because of unsatisfied dependencies or would shadow the base repository implementation.

--

Related ticket: [DATACMNS-1147](https://jira.spring.io/browse/DATACMNS-1147).