### PR TITLE
DATACMNS-1151 - Define generated PropertyAccessor classes with the entity protection domain.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.7.BUILD-SNAPSHOT</version>
+	<version>1.13.7.DATACMNS-1151-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1469,15 +1469,15 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 		 */
 		Class<?> defineClass(String name, byte[] bytes, int offset, int len, PersistentEntity<?, ?> persistentEntity) {
 
-			ClassLoader classLoader = persistentEntity.getType().getClassLoader();
+			Class<?> entityType = persistentEntity.getType();
+			ClassLoader classLoader = entityType.getClassLoader();
 
 			try {
 
 				Method defineClass = getClassLoaderMethod(persistentEntity);
 				defineClass.setAccessible(true);
 
-				return (Class<?>) defineClass.invoke(classLoader, name, bytes, offset, len,
-						persistentEntity.getClass().getProtectionDomain());
+				return (Class<?>) defineClass.invoke(classLoader, name, bytes, offset, len, entityType.getProtectionDomain());
 
 			} catch (ReflectiveOperationException e) {
 				throw new IllegalStateException(e);


### PR DESCRIPTION
We now define generated `PropertyAccessor` classes using the entities' protection domain. Reusing the same protection domain preserves the same security and visibility rules as if the class was shipped within the source of the class loaded and prevents `SecurityException`s caused by signature certificate mismatch.  

Previously we used the protection domain of the `PersistentEntity` class implementation. This mismatch caused `SecurityException`s if the JAR file of the `PersistentEntity` was signed but not the JAR file where the domain class resides.

---

Related ticket: [DATACMNS-1151](https://jira.spring.io/browse/DATACMNS-1151).