### PR TITLE
DATACMNS-1161 - Rename PersistentProperty.getPersistentEntityType() to a plural name since it returns an Iterable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1161-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/PersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentProperty.java
@@ -30,6 +30,7 @@ import org.springframework.lang.Nullable;
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public interface PersistentProperty<P extends PersistentProperty<P>> {
 
@@ -66,9 +67,21 @@ public interface PersistentProperty<P extends PersistentProperty<P>> {
 	 * {@literal null} in case it refers to a simple type. Will return {@link Collection}'s component type or the
 	 * {@link Map}'s value type transparently.
 	 *
+	 * @Deprecated Use getPersistentEntityTypes instead.
+	 */
+	@Deprecated
+	Iterable<? extends TypeInformation<?>> getPersistentEntityType();
+
+	/**
+	 * Returns the {@link TypeInformation} if the property references a {@link PersistentEntity}. Will return
+	 * {@literal null} in case it refers to a simple type. Will return {@link Collection}'s component type or the
+	 * {@link Map}'s value type transparently.
+	 *
 	 * @return
 	 */
-	Iterable<? extends TypeInformation<?>> getPersistentEntityType();
+	default Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
+		return getPersistentEntityType();
+	};
 
 	/**
 	 * Returns the getter method to access the property value if available. Might return {@literal null} in case there is

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -554,7 +554,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 				return;
 			}
 
-			property.getPersistentEntityType().forEach(AbstractMappingContext.this::addPersistentEntity);
+			property.getPersistentEntityTypes().forEach(AbstractMappingContext.this::addPersistentEntity);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
@@ -133,6 +133,7 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.PersistentProperty#getPersistentEntityType()
 	 */
+	@Deprecated
 	@Override
 	public Iterable<? extends TypeInformation<?>> getPersistentEntityType() {
 

--- a/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextIntegrationTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextIntegrationTests.java
@@ -113,7 +113,7 @@ public class AbstractMappingContextIntegrationTests<T extends PersistentProperty
 
 			when(prop.getTypeInformation()).thenReturn(owner.getTypeInformation());
 			when(prop.getName()).thenReturn(property.getName());
-			when(prop.getPersistentEntityType()).thenReturn(Collections.EMPTY_SET);
+			when(prop.getPersistentEntityTypes()).thenReturn(Collections.EMPTY_SET);
 
 			try {
 				Thread.sleep(200);

--- a/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
@@ -44,6 +44,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Jens Schauder
  */
 public class AbstractPersistentPropertyUnitTests {
 
@@ -66,6 +67,7 @@ public class AbstractPersistentPropertyUnitTests {
 
 	@Test // DATACMNS-101
 	public void returnsNestedEntityTypeCorrectly() {
+		assertThat(getProperty(TestClassComplex.class, "testClassSet").getPersistentEntityTypes()).isEmpty();
 		assertThat(getProperty(TestClassComplex.class, "testClassSet").getPersistentEntityType()).isEmpty();
 	}
 
@@ -189,6 +191,7 @@ public class AbstractPersistentPropertyUnitTests {
 	public void doesNotConsiderPropertyWithTreeMapMapValueAnEntity() {
 
 		SamplePersistentProperty property = getProperty(TreeMapWrapper.class, "map");
+		assertThat(property.getPersistentEntityTypes()).isEmpty();
 		assertThat(property.getPersistentEntityType()).isEmpty();
 		assertThat(property.isEntity()).isFalse();
 	}


### PR DESCRIPTION
Issue: https://jira.spring.io/browse/DATACMNS-1161