### PR TITLE
DATACMNS-1170 - Fallback to default constructor discovery for Kotlin classes without a primary constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1170-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java
+++ b/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java
@@ -166,6 +166,11 @@ public interface PreferredConstructorDiscoverer<T, P extends PersistentProperty<
 
 							KFunction<T> primaryConstructor = KClasses
 									.getPrimaryConstructor(JvmClassMappingKt.getKotlinClass(type.getType()));
+
+							if (primaryConstructor == null) {
+								return DEFAULT.discover(type, entity);
+							}
+
 							Constructor<T> javaConstructor = ReflectJvmMapping.getJavaConstructor(primaryConstructor);
 
 							return javaConstructor != null ? buildPreferredConstructor(javaConstructor, type, entity) : null;

--- a/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
@@ -43,6 +43,14 @@ class PreferredConstructorDiscovererUnitTests {
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(1)
 	}
 
+	@Test // DATACMNS-1170
+	fun `should fall back to no-args constructor if no primary constructor available`() {
+
+		val constructor = PreferredConstructorDiscoverer.discover<TwoConstructorsWithoutDefault, SamplePersistentProperty>(TwoConstructorsWithoutDefault::class.java)
+
+		Assertions.assertThat(constructor.parameters).isEmpty()
+	}
+
 	@Test // DATACMNS-1126
 	fun `should discover annotated constructor`() {
 
@@ -68,6 +76,17 @@ class PreferredConstructorDiscovererUnitTests {
 	}
 
 	data class Simple(val firstname: String)
+
+	class TwoConstructorsWithoutDefault {
+
+		var firstname: String? = null
+
+		constructor() {}
+
+		constructor(firstname: String?) {
+			this.firstname = firstname
+		}
+	}
 
 	class TwoConstructors(val firstname: String) {
 		constructor(firstname: String, lastname: String) : this(firstname)


### PR DESCRIPTION
We now fall back to default preferred constructor discovery if a Kotlin class has no primary constructor and no preferred constructor is resolved. Previously, primary constructor resolution yielded no result (returned `null`) which caused the subsequent Java constructor lookup to fail.

---

Related ticket: [DATACMNS-1170](https://jira.spring.io/browse/DATACMNS-1170).


