### PR TITLE
DATACMNS-1171 - Limit Kotlin reflection support to regular classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1171-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiator.java
@@ -50,7 +50,7 @@ public class KotlinClassGeneratingEntityInstantiator extends ClassGeneratingEnti
 
 		PreferredConstructor<?, ?> constructor = entity.getPersistenceConstructor();
 
-		if (ReflectionUtils.isKotlinClass(entity.getType()) && constructor != null) {
+		if (ReflectionUtils.isSupportedKotlinClass(entity.getType()) && constructor != null) {
 
 			PreferredConstructor<?, ?> defaultConstructor = new DefaultingKotlinConstructorResolver(entity)
 					.getDefaultConstructor();

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -471,15 +471,22 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 	/**
 	 * Returns whether a {@link PersistentEntity} instance should be created for the given {@link TypeInformation}. By
-	 * default this will reject this for all types considered simple, but it might be necessary to tweak that in case you
-	 * have registered custom converters for top level types (which renders them to be considered simple) but still need
-	 * meta-information about them.
+	 * default this will reject all types considered simple and non-supported Kotlin classes, but it might be necessary to
+	 * tweak that in case you have registered custom converters for top level types (which renders them to be considered
+	 * simple) but still need meta-information about them.
+	 * <p/>
 	 *
 	 * @param type will never be {@literal null}.
 	 * @return
 	 */
 	protected boolean shouldCreatePersistentEntityFor(TypeInformation<?> type) {
-		return !simpleTypeHolder.isSimpleType(type.getType());
+
+		if (simpleTypeHolder.isSimpleType(type.getType())) {
+			return false;
+		}
+
+		return !org.springframework.data.util.ReflectionUtils.isKotlinClass(type.getType())
+				|| org.springframework.data.util.ReflectionUtils.isSupportedKotlinClass(type.getType());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java
+++ b/src/main/java/org/springframework/data/mapping/model/PreferredConstructorDiscoverer.java
@@ -187,7 +187,7 @@ public interface PreferredConstructorDiscoverer<T, P extends PersistentProperty<
 		 * @return the appropriate discoverer for {@code type}.
 		 */
 		private static Discoverers findDiscoverer(Class<?> type) {
-			return ReflectionUtils.isKotlinClass(type) ? KOTLIN : DEFAULT;
+			return ReflectionUtils.isSupportedKotlinClass(type) ? KOTLIN : DEFAULT;
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/repository/core/support/MethodInvocationValidator.java
+++ b/src/main/java/org/springframework/data/repository/core/support/MethodInvocationValidator.java
@@ -59,7 +59,7 @@ public class MethodInvocationValidator implements MethodInterceptor {
 	 */
 	public static boolean supports(Class<?> repositoryInterface) {
 
-		return ReflectionUtils.isKotlinClass(repositoryInterface)
+		return ReflectionUtils.isSupportedKotlinClass(repositoryInterface)
 				|| NullableUtils.isNonNull(repositoryInterface, ElementType.METHOD)
 				|| NullableUtils.isNonNull(repositoryInterface, ElementType.PARAMETER);
 	}
@@ -153,7 +153,8 @@ public class MethodInvocationValidator implements MethodInterceptor {
 		private static boolean isNullableParameter(MethodParameter parameter) {
 
 			return requiresNoValue(parameter) || NullableUtils.isExplicitNullable(parameter)
-					|| (ReflectionUtils.isKotlinClass(parameter.getDeclaringClass()) && ReflectionUtils.isNullable(parameter));
+					|| (ReflectionUtils.isSupportedKotlinClass(parameter.getDeclaringClass())
+							&& ReflectionUtils.isNullable(parameter));
 		}
 
 		private static boolean requiresNoValue(MethodParameter parameter) {

--- a/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class AbstractMappingContextUnitTests {
 
@@ -208,6 +209,16 @@ public class AbstractMappingContextUnitTests {
 
 		context.getPersistentEntity(Sample.class);
 		assertHasEntityFor(TreeMap.class, context, false);
+	}
+
+	@Test // DATACMNS-1171
+	public void shouldCreateEntityForKotlinDataClass() {
+		assertThat(context.getPersistentEntity(SimpleDataClass.class)).isNotNull();
+	}
+
+	@Test // DATACMNS-1171
+	public void shouldNotCreateEntityForSyntheticKotlinClass() {
+		assertThat(context.getPersistentEntity(TypeCreatingSyntheticClass.class)).isNotNull();
 	}
 
 	@Test // DATACMNS-695

--- a/src/test/java/org/springframework/data/util/ReflectionUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/util/ReflectionUtilsUnitTests.java
@@ -24,12 +24,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
+import org.springframework.data.mapping.model.TypeCreatingSyntheticClassKt;
 import org.springframework.data.repository.sample.User;
 import org.springframework.data.util.ReflectionUtils.DescribedFieldFilter;
 import org.springframework.util.ReflectionUtils.FieldFilter;
 
 /**
+ * Unit tests for {@link ReflectionUtils}.
+ *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class ReflectionUtilsUnitTests {
 
@@ -142,6 +146,20 @@ public class ReflectionUtilsUnitTests {
 
 		MethodParameter parameter = new MethodParameter(DummyInterface.class.getDeclaredMethod("primitive", int.class), 0);
 		assertThat(ReflectionUtils.isNullable(parameter)).isFalse();
+	}
+	
+	@Test // DATACMNS-1171
+	public void discoversKotlinClass() {
+
+		assertThat(ReflectionUtils.isKotlinClass(TypeCreatingSyntheticClass.class)).isTrue();
+		assertThat(ReflectionUtils.isSupportedKotlinClass(TypeCreatingSyntheticClass.class)).isTrue();
+	}
+	
+	@Test // DATACMNS-1171
+	public void discoversUnsupportedKotlinClass() {
+
+		assertThat(ReflectionUtils.isKotlinClass(TypeCreatingSyntheticClassKt.class)).isTrue();
+		assertThat(ReflectionUtils.isSupportedKotlinClass(TypeCreatingSyntheticClassKt.class)).isFalse();
 	}
 
 	static class Sample {

--- a/src/test/kotlin/org/springframework/data/mapping/context/SimpleDataClass.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/context/SimpleDataClass.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.context
+
+/**
+ * @author Mark Paluch
+ */
+data class SimpleDataClass(val firstname: String) {
+}

--- a/src/test/kotlin/org/springframework/data/mapping/context/TypeCreatingSyntheticClass.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/context/TypeCreatingSyntheticClass.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.context
+
+/**
+ * @author Mark Paluch
+ */
+class TypeCreatingSyntheticClass {
+}
+
+fun foobar(args: Array<String>) {
+}

--- a/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/PreferredConstructorDiscovererUnitTests.kt
@@ -74,6 +74,17 @@ class PreferredConstructorDiscovererUnitTests {
 
 		Assertions.assertThat(constructor.parameters.size).isEqualTo(3)
 	}
+	
+	@Test // DATACMNS-1171
+	@Suppress("UNCHECKED_CAST")
+	fun `should not resolve constructor for synthetic Kotlin class`() {
+
+		val c = Class.forName("org.springframework.data.mapping.model.TypeCreatingSyntheticClassKt") as Class<Any>
+		
+		val constructor = PreferredConstructorDiscoverer.discover<Any, SamplePersistentProperty>(c)
+
+		Assertions.assertThat(constructor).isNull()
+	}
 
 	data class Simple(val firstname: String)
 

--- a/src/test/kotlin/org/springframework/data/mapping/model/TypeCreatingSyntheticClass.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/TypeCreatingSyntheticClass.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model
+
+/**
+ * @author Mark Paluch
+ */
+class TypeCreatingSyntheticClass {
+}
+
+fun foobar(args: Array<String>) {
+}

--- a/src/test/kotlin/org/springframework/data/util/TypeCreatingSyntheticClass.kt
+++ b/src/test/kotlin/org/springframework/data/util/TypeCreatingSyntheticClass.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.util
+
+/**
+ * @author Mark Paluch
+ */
+class TypeCreatingSyntheticClass {
+}
+
+fun foobar(args: Array<String>) {
+}


### PR DESCRIPTION
We now only inspect regular Kotlin classes with inspection to adapt Kotlin-specific behavior. Multipart-, synthetic and unknown classes are not supported. In such cases, we fall back to the JVM reflection mechanism.

The second commit rejects by default unsupported Kotlin classes from the `MappingContext` by not creating persistent entities, if we want to alter the behavior of `MappingContext`.

---

Related ticket: [DATACMNS-1171](https://jira.spring.io/browse/DATACMNS-1171).