### PR TITLE
DATACMNS-1175 - Remove argument array caching from EntityInstantiators.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1175-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/ClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/ClassGeneratingEntityInstantiator.java
@@ -55,18 +55,7 @@ import org.springframework.util.ClassUtils;
  */
 public class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 
-	private static final int ARG_CACHE_SIZE = 100;
-
-	private static final ThreadLocal<Object[][]> OBJECT_POOL = ThreadLocal.withInitial(() -> {
-
-		Object[][] cached = new Object[ARG_CACHE_SIZE][];
-
-		for (int i = 0; i < ARG_CACHE_SIZE; i++) {
-			cached[i] = new Object[i];
-		}
-
-		return cached;
-	});
+	private static final Object[] EMPTY_ARGS = new Object[0];
 
 	private final ObjectInstantiatorClassGenerator generator;
 
@@ -170,30 +159,14 @@ public class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 	}
 
 	/**
-	 * Allocates an object array for instance creation. This method uses the argument array cache if possible.
+	 * Allocates an object array for instance creation.
 	 *
 	 * @param argumentCount
 	 * @return
 	 * @since 2.0
-	 * @see #ARG_CACHE_SIZE
 	 */
 	static Object[] allocateArguments(int argumentCount) {
-		return argumentCount < ARG_CACHE_SIZE ? OBJECT_POOL.get()[argumentCount] : new Object[argumentCount];
-	}
-
-	/**
-	 * Deallocates an object array used for instance creation. Parameters are cleared if the array was cached.
-	 *
-	 * @param argumentCount
-	 * @return
-	 * @since 2.0
-	 * @see #ARG_CACHE_SIZE
-	 */
-	static void deallocateArguments(Object[] params) {
-
-		if (params.length != 0 && params.length < ARG_CACHE_SIZE) {
-			Arrays.fill(params, null);
-		}
+		return argumentCount == 0 ? EMPTY_ARGS : new Object[argumentCount];
 	}
 
 	/**
@@ -250,8 +223,6 @@ public class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 				return (T) instantiator.newInstance(params);
 			} catch (Exception e) {
 				throw new MappingInstantiationException(entity, Arrays.asList(params), e);
-			} finally {
-				deallocateArguments(params);
 			}
 		}
 

--- a/src/main/java/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiator.java
@@ -237,11 +237,7 @@ public class KotlinClassGeneratingEntityInstantiator extends ClassGeneratingEnti
 				params[userParameterCount + i] = defaulting[i];
 			}
 
-			try {
-				return (T) instantiator.newInstance(params);
-			} finally {
-				deallocateArguments(params);
-			}
+			return (T) instantiator.newInstance(params);
 		}
 	}
 }


### PR DESCRIPTION
We no longer cache argument arrays in our `EntityInstantiator`s to prevent changes to shared mutable state caused by reentrant calls.

Previously, a reentrant call requesting an argument array of the same size as a previous call in the call stack reused the same array instance. Changes to this shared mutable state by multiple invocations caused an invalid state rendering wrong parameters for object instantiation. Removing the caching and only reusing an empty array for zero-arg constructors is the only safe approach for now. 

Reinstantiation of object allocations results in a higher GC pressure but guarantee side effect-free instantiation and should be on-par with previous versions performance profile.

---

Related ticket: [DATACMNS-1175](https://jira.spring.io/browse/DATACMNS-1175).