### PR TITLE
DATACMNS-1172 - Limit repository custom implementation scanning by default to repository interface packages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1172-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Darimont
  * @author Peter Rietzler
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 public class AnnotationRepositoryConfigurationSource extends RepositoryConfigurationSourceSupport {
 
@@ -64,6 +65,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	private static final String REPOSITORY_FACTORY_BEAN_CLASS = "repositoryFactoryBeanClass";
 	private static final String REPOSITORY_BASE_CLASS = "repositoryBaseClass";
 	private static final String CONSIDER_NESTED_REPOSITORIES = "considerNestedRepositories";
+	private static final String LIMIT_IMPLEMENTATION_BASE_PACKAGES = "limitImplementationBasePackages";
 
 	private final AnnotationMetadata configMetadata;
 	private final AnnotationMetadata enableAnnotationMetadata;
@@ -318,6 +320,20 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	@Override
 	public boolean shouldConsiderNestedRepositories() {
 		return attributes.containsKey(CONSIDER_NESTED_REPOSITORIES) && attributes.getBoolean(CONSIDER_NESTED_REPOSITORIES);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationSourceSupport#shouldLimitRepositoryImplementationBasePackages()
+	 */
+	@Override
+	public boolean shouldLimitRepositoryImplementationBasePackages() {
+
+		if (!attributes.containsKey(LIMIT_IMPLEMENTATION_BASE_PACKAGES)) {
+			return true;
+		}
+
+		return attributes.getBoolean(LIMIT_IMPLEMENTATION_BASE_PACKAGES);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetector.java
+++ b/src/main/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetector.java
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Peter Rietzler
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 @RequiredArgsConstructor
 public class CustomRepositoryImplementationDetector {
@@ -71,7 +72,7 @@ public class CustomRepositoryImplementationDetector {
 		return detectCustomImplementation( //
 				configuration.getImplementationClassName(), //
 				configuration.getImplementationBeanName(), //
-				configuration.getBasePackages(), //
+				configuration.getImplementationBasePackages(configuration.getImplementationClassName()), //
 				configuration.getExcludeFilters(), //
 				bd -> configuration.getConfigurationSource().generateBeanName(bd));
 	}

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 @RequiredArgsConstructor
 public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSource>
@@ -69,6 +70,18 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	 */
 	public Streamable<String> getBasePackages() {
 		return configurationSource.getBasePackages();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfiguration#getBasePackages(String)
+	 */
+	@Override
+	public Streamable<String> getImplementationBasePackages(String interfaceClassName) {
+
+		return configurationSource.shouldLimitRepositoryImplementationBasePackages()
+				? Streamable.of(ClassUtils.getPackageName(interfaceClassName))
+				: getBasePackages();
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -202,7 +202,8 @@ class RepositoryBeanDefinitionBuilder {
 				.concat(configuration.getConfigurationSource().getRepositoryImplementationPostfix().orElse("Impl"));
 
 		Optional<AbstractBeanDefinition> beanDefinition = implementationDetector.detectCustomImplementation(className, null,
-				configuration.getBasePackages(), exclusions, bd -> configuration.getConfigurationSource().generateBeanName(bd));
+				configuration.getImplementationBasePackages(fragmentInterfaceName), exclusions,
+				bd -> configuration.getConfigurationSource().generateBeanName(bd));
 
 		return beanDefinition.map(bd -> new RepositoryFragmentConfiguration(fragmentInterfaceName, bd));
 	}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -38,6 +38,15 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	Streamable<String> getBasePackages();
 
 	/**
+	 * Returns the base packages to scan for repository implementations.
+	 *
+	 * @param interfaceClassName class name of the interface.
+	 * @return
+	 * @since 2.0
+	 */
+	Streamable<String> getImplementationBasePackages(String interfaceClassName);
+
+	/**
 	 * Returns the interface name of the repository.
 	 *
 	 * @return

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
@@ -31,6 +31,7 @@ import org.springframework.lang.Nullable;
  * @author Thomas Darimont
  * @author Peter Rietzler
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 public interface RepositoryConfigurationSource {
 
@@ -61,6 +62,17 @@ public interface RepositoryConfigurationSource {
 	 * @return the postfix to use or {@link Optional#empty()} in case none is configured.
 	 */
 	Optional<String> getRepositoryImplementationPostfix();
+
+	/**
+	 * Returns whether to limit repository implementation base packages for custom implementation scanning. If
+	 * {@literal true}, then custom implementation scanning considers only the package of the repository/fragment
+	 * interface and its subpackages for a scan. Otherwise, all {@link #getBasePackages()} are scanned for repository
+	 * implementations
+	 * 
+	 * @return {@literal true} if base packages are limited to the actual repository package.
+	 * @since 2.0
+	 */
+	boolean shouldLimitRepositoryImplementationBasePackages();
 
 	/**
 	 * @return

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSourceSupport.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSourceSupport.java
@@ -117,4 +117,13 @@ public abstract class RepositoryConfigurationSourceSupport implements Repository
 	public boolean shouldConsiderNestedRepositories() {
 		return false;
 	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationSource#isLimitRepositoryImplementationBasePackages()
+	 */
+	@Override
+	public boolean shouldLimitRepositoryImplementationBasePackages() {
+		return true;
+	}
 }

--- a/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
@@ -73,8 +73,9 @@ public class AnnotationRepositoryConfigurationSourceUnitTests {
 
 		Streamable<BeanDefinition> candidates = source.getCandidates(new DefaultResourceLoader());
 
-		assertThat(candidates).hasSize(2).extracting("beanClassName").containsOnly(MyRepository.class.getName(),
-				ComposedRepository.class.getName());
+		assertThat(candidates).extracting("beanClassName")
+				.contains(MyRepository.class.getName(), ComposedRepository.class.getName())
+				.doesNotContain(MyOtherRepository.class.getName(), ExcludedRepository.class.getName());
 	}
 
 	@Test // DATACMNS-47
@@ -100,6 +101,14 @@ public class AnnotationRepositoryConfigurationSourceUnitTests {
 
 		AnnotationRepositoryConfigurationSource source = getConfigSource(DefaultConfigurationWithNestedRepositories.class);
 		assertThat(source.shouldConsiderNestedRepositories()).isTrue();
+	}
+
+	@Test // DATACMNS-1172
+	public void returnsLimitImplementationBasePackages() {
+
+		assertThat(getConfigSource(DefaultConfiguration.class).shouldLimitRepositoryImplementationBasePackages()).isTrue();
+		assertThat(getConfigSource(DefaultConfigurationWithoutBasePackageLimit.class)
+				.shouldLimitRepositoryImplementationBasePackages()).isFalse();
 	}
 
 	@Test // DATACMNS-456
@@ -154,6 +163,9 @@ public class AnnotationRepositoryConfigurationSourceUnitTests {
 
 	@EnableRepositories(considerNestedRepositories = true)
 	static class DefaultConfigurationWithNestedRepositories {}
+
+	@EnableRepositories(limitImplementationBasePackages = false)
+	static class DefaultConfigurationWithoutBasePackageLimit {}
 
 	@EnableRepositories(excludeFilters = { @Filter(Primary.class) })
 	static class ConfigurationWithExplicitFilter {}

--- a/src/test/java/org/springframework/data/repository/config/EnableRepositories.java
+++ b/src/test/java/org/springframework/data/repository/config/EnableRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,4 +49,6 @@ public @interface EnableRepositories {
 	String repositoryImplementationPostfix() default "Impl";
 
 	boolean considerNestedRepositories() default false;
+
+	boolean limitImplementationBasePackages() default true;
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionRegistrarSupportUnitTests.java
@@ -34,6 +34,7 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.data.repository.config.basepackage.FragmentImpl;
 import org.springframework.data.repository.core.support.DummyRepositoryFactoryBean;
 
 /**
@@ -82,6 +83,28 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 
 		assertBeanDefinitionRegisteredFor("repositoryWithFragmentExclusion");
 		assertNoBeanDefinitionRegisteredFor("excludedRepositoryImpl");
+	}
+
+	@Test // DATACMNS-1172
+	public void shouldLimitImplementationBasePackages() {
+
+		AnnotationMetadata metadata = new StandardAnnotationMetadata(LimitsImplementationBasePackages.class, true);
+
+		registrar.registerBeanDefinitions(metadata, registry);
+
+		assertBeanDefinitionRegisteredFor("personRepository");
+		assertNoBeanDefinitionRegisteredFor("fragmentImpl");
+	}
+
+	@Test // DATACMNS-1172
+	public void shouldNotLimitImplementationBasePackages() {
+
+		AnnotationMetadata metadata = new StandardAnnotationMetadata(UnlimitedImplementationBasePackages.class, true);
+
+		registrar.registerBeanDefinitions(metadata, registry);
+
+		assertBeanDefinitionRegisteredFor("personRepository");
+		assertBeanDefinitionRegisteredFor("fragmentImpl");
 	}
 
 	@Test // DATACMNS-360
@@ -152,7 +175,11 @@ public class RepositoryBeanDefinitionRegistrarSupportUnitTests {
 	@EnableRepositories(
 			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = RepositoryWithFragmentExclusion.class),
 			basePackageClasses = RepositoryWithFragmentExclusion.class)
-	static class FragmentExclusionConfiguration {
+	static class FragmentExclusionConfiguration {}
 
-	}
+	@EnableRepositories(basePackageClasses = FragmentImpl.class)
+	static class LimitsImplementationBasePackages {}
+
+	@EnableRepositories(basePackageClasses = FragmentImpl.class, limitImplementationBasePackages = false)
+	static class UnlimitedImplementationBasePackages {}
 }

--- a/src/test/java/org/springframework/data/repository/config/basepackage/FragmentImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/basepackage/FragmentImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.basepackage;
+
+import org.springframework.data.repository.config.basepackage.repo.Fragment;
+
+/**
+ * @author Mark Paluch
+ */
+public class FragmentImpl implements Fragment {}

--- a/src/test/java/org/springframework/data/repository/config/basepackage/repo/Fragment.java
+++ b/src/test/java/org/springframework/data/repository/config/basepackage/repo/Fragment.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.basepackage.repo;
+
+/**
+ * @author Mark Paluch
+ */
+public interface Fragment {}

--- a/src/test/java/org/springframework/data/repository/config/basepackage/repo/PersonRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/basepackage/repo/PersonRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.basepackage.repo;
+
+import org.springframework.data.mapping.Person;
+import org.springframework.data.repository.Repository;
+
+/**
+ * @author Mark Paluch
+ */
+public interface PersonRepository extends Repository<Person, String>, Fragment {}


### PR DESCRIPTION
Custom repository implementation scan defaults to the repository interface package and its subpackages and no longer scans all configured base packages. Scan for fragment implementations defaults to the fragment interface package. Using the interface package for scanning aligns the behavior with the documentation.

This default can be changed with `@Enable…Repositories` annotations that support the limitImplementationBasePackages parameter to scan in repository base packages for custom implementations:

```
@EnableJpaRepositories(limitImplementationBasePackages = false)
@Configuration
class AppConfiguration {
  // …
}
```

Declaring the implementation along with the interface in the same package is an established design pattern allowing to limit the scanning scope. A limited scope improves scanning performance as it can skip elements on the classpath, that do not provide that particular package.

Previously, we scanned for implementations using the configured base packages that were also used to discover repository interfaces. These base packages can be broader for applications that spread repository interfaces across multiple packages.

---

Related ticket: [DATACMNS-1172](https://jira.spring.io/browse/DATACMNS-1172).