### PR TITLE
DATACMNS-1177 (backport) Parameter.isDynamicProjectionParameter uses unwrapped type instead of actual type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.14.0.BUILD-SNAPSHOT</version>
+	<version>1.14.0.DATACMNS-1177-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Jens Schauder
  */
 public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 
@@ -76,7 +77,7 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	 * @see org.springframework.data.repository.core.RepositoryMetadata#getReturnedDomainClass(java.lang.reflect.Method)
 	 */
 	public Class<?> getReturnedDomainClass(Method method) {
-		return unwrapWrapperTypes(typeInformation.getReturnType(method));
+		return QueryExecutionConverters.unwrapWrapperTypes(typeInformation.getReturnType(method)).getType();
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -62,7 +62,6 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	 * 
 	 * @param repositoryInterface must not be {@literal null}.
 	 * @since 1.9
-	 * @return
 	 */
 	public static RepositoryMetadata getMetadata(Class<?> repositoryInterface) {
 

--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * Class to abstract a single parameter of a query method. It is held in the context of a {@link Parameters} instance.
  * 
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 public class Parameter {
 
@@ -201,7 +202,8 @@ public class Parameter {
 
 		TypeInformation<?> bound = parameterTypes.getTypeArguments().get(0);
 		TypeInformation<Object> returnType = ClassTypeInformation.fromReturnTypeOf(method);
-		return bound.equals(returnType.getActualType());
+
+		return bound.equals(QueryExecutionConverters.unwrapWrapperTypes(returnType));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -64,7 +64,6 @@ public class Parameter {
 	/**
 	 * Returns whether the parameter is a special parameter.
 	 * 
-	 * @return
 	 * @see #TYPES
 	 */
 	public boolean isSpecialParameter() {
@@ -73,8 +72,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the {@link Parameter} is to be bound to a query.
-	 * 
-	 * @return
 	 */
 	public boolean isBindable() {
 		return !isSpecialParameter();
@@ -82,8 +79,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the current {@link Parameter} is the one used for dynamic projections.
-	 * 
-	 * @return
 	 */
 	public boolean isDynamicProjectionParameter() {
 		return isDynamicProjectionParameter;
@@ -91,8 +86,6 @@ public class Parameter {
 
 	/**
 	 * Returns the placeholder to be used for the parameter. Can either be a named one or positional.
-	 * 
-	 * @return
 	 */
 	public String getPlaceholder() {
 
@@ -105,8 +98,6 @@ public class Parameter {
 
 	/**
 	 * Returns the position index the parameter is bound to in the context of its surrounding {@link Parameters}.
-	 * 
-	 * @return
 	 */
 	public int getIndex() {
 		return parameter.getParameterIndex();
@@ -114,8 +105,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the parameter is annotated with {@link Param}.
-	 * 
-	 * @return
 	 */
 	public boolean isNamedParameter() {
 		return !isSpecialParameter() && getName() != null;
@@ -123,8 +112,6 @@ public class Parameter {
 
 	/**
 	 * Returns the name of the parameter (through {@link Param} annotation) or null if none can be found.
-	 * 
-	 * @return
 	 */
 	public String getName() {
 
@@ -144,7 +131,6 @@ public class Parameter {
 	/**
 	 * Returns whether the parameter is named explicitly, i.e. annotated with {@link Param}.
 	 * 
-	 * @return
 	 * @since 1.11
 	 */
 	public boolean isExplicitlyNamed() {
@@ -162,8 +148,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the {@link Parameter} is a {@link Pageable} parameter.
-	 * 
-	 * @return
 	 */
 	boolean isPageable() {
 		return Pageable.class.isAssignableFrom(getType());
@@ -171,8 +155,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the {@link Parameter} is a {@link Sort} parameter.
-	 * 
-	 * @return
 	 */
 	boolean isSort() {
 		return Sort.class.isAssignableFrom(getType());
@@ -187,7 +169,6 @@ public class Parameter {
 	 * </code>
 	 * 
 	 * @param parameter must not be {@literal null}.
-	 * @return
 	 */
 	private static boolean isDynamicProjectionParameter(MethodParameter parameter) {
 
@@ -210,7 +191,6 @@ public class Parameter {
 	 * Returns the component type if the given {@link MethodParameter} is a wrapper type.
 	 * 
 	 * @param parameter must not be {@literal null}.
-	 * @return
 	 */
 	private static Class<?> potentiallyUnwrapParameterType(MethodParameter parameter) {
 

--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
@@ -40,6 +41,7 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -67,6 +69,7 @@ import com.google.common.base.Optional;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Maciek Opała
+ * @author Jens Schauder
  * @since 1.8
  */
 public abstract class QueryExecutionConverters {
@@ -236,6 +239,23 @@ public abstract class QueryExecutionConverters {
 		}
 
 		return source;
+	}
+
+	/**
+	 * Recursively unwraps well known wrapper types from the given {@link TypeInformation}.
+	 *
+	 * @param type must not be {@literal null}.
+	 */
+	public static TypeInformation<?> unwrapWrapperTypes(TypeInformation<?> type) {
+
+		Assert.notNull(type, "type must not be null");
+
+		Class<?> rawType = type.getType();
+
+		boolean needToUnwrap = Iterable.class.isAssignableFrom(rawType) || rawType.isArray() || supports(rawType)
+				|| Stream.class.isAssignableFrom(rawType);
+
+		return needToUnwrap ? unwrapWrapperTypes(type.getComponentType()) : type;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -144,7 +144,6 @@ public abstract class QueryExecutionConverters {
 	 * Returns whether the given type is a supported wrapper type.
 	 * 
 	 * @param type must not be {@literal null}.
-	 * @return
 	 */
 	public static boolean supports(Class<?> type) {
 
@@ -173,8 +172,6 @@ public abstract class QueryExecutionConverters {
 	/**
 	 * Returns the types that are supported on paginating query methods. Will include custom collection types of e.g.
 	 * Javaslang.
-	 * 
-	 * @return
 	 */
 	public static Set<Class<?>> getAllowedPageableTypes() {
 		return Collections.unmodifiableSet(ALLOWED_PAGEABLE_TYPES);
@@ -221,7 +218,6 @@ public abstract class QueryExecutionConverters {
 	 * Unwraps the given source value in case it's one of the currently supported wrapper types detected at runtime.
 	 * 
 	 * @param source can be {@literal null}.
-	 * @return
 	 */
 	public static Object unwrap(Object source) {
 
@@ -564,7 +560,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 1.12
 	 */
-	private static enum GuavaOptionalUnwrapper implements Converter<Object, Object> {
+	private enum GuavaOptionalUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -584,7 +580,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 1.12
 	 */
-	private static enum Jdk8OptionalUnwrapper implements Converter<Object, Object> {
+	private enum Jdk8OptionalUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -605,7 +601,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Mark Paluch
 	 * @since 1.12
 	 */
-	private static enum ScalOptionUnwrapper implements Converter<Object, Object> {
+	private enum ScalOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -637,7 +633,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 1.13
 	 */
-	private static enum JavaslangOptionUnwrapper implements Converter<Object, Object> {
+	private enum JavaslangOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -678,7 +674,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	private static enum VavrOptionUnwrapper implements Converter<Object, Object> {
+	private enum VavrOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 

--- a/src/test/java/org/springframework/data/repository/query/ParameterUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ParameterUnitTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.springframework.core.MethodParameter;
+
+/**
+ * Unit tests for {@link Parameter}.
+ *
+ * @author Jens Schauder
+ */
+public class ParameterUnitTests {
+
+	@Test // DATAJPA-1185
+	public void classParameterWithSameTypeParameterAsReturnedListIsDynamicProjectionParameter() throws Exception {
+
+		Parameter parameter = new Parameter(getMethodParameter("dynamicProjectionWithList"));
+
+		assertThat(parameter.isDynamicProjectionParameter(), is(true));
+	}
+
+	@Test // DATAJPA-1185
+	public void classParameterWithSameTypeParameterAsReturnedStreamIsDynamicProjectionParameter() throws Exception {
+
+		Parameter parameter = new Parameter(getMethodParameter("dynamicProjectionWithStream"));
+
+		assertThat(parameter.isDynamicProjectionParameter(), is(true));
+	}
+
+	private MethodParameter getMethodParameter(String methodName) throws NoSuchMethodException {
+
+		return new MethodParameter( //
+				this.getClass().getDeclaredMethod( //
+						methodName, //
+						Class.class //
+				), //
+				0);
+	}
+
+	<T> List<T> dynamicProjectionWithList(Class<T> type) {
+		return Collections.emptyList();
+	}
+
+	<T> Stream<T> dynamicProjectionWithStream(Class<T> type) {
+		return null;
+	}
+}


### PR DESCRIPTION
When trying to determine if a parameter is a dynamic projection parameter, i.e. the parameter of type Class that determines the projection to use, now the type parameter of that method parameter gets compared with the unwrapped return type.
Therefore this works now not only for Maps and Collections but also for the various wrappers defined in QueryExecutionConverters.

Moved the method for unwrapping the return type from AbstractRepositoryMetadata to QueryExecutionConverters in order to make it available to every class needing it.
This also puts it closer to the data it is working on.