### PR TITLE
DATACMNS-1177 - Parameter.isDynamicProjectionParameter uses unwrapped type instead of actual type. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATACMNS-1177-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 
@@ -163,7 +163,7 @@
 			<version>1.0.1</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>javax.interceptor</groupId>
 			<artifactId>javax.interceptor-api</artifactId>

--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
@@ -37,6 +36,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Jens Schauder
  */
 public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 
@@ -79,7 +79,7 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	 * @see org.springframework.data.repository.core.RepositoryMetadata#getReturnedDomainClass(java.lang.reflect.Method)
 	 */
 	public Class<?> getReturnedDomainClass(Method method) {
-		return unwrapWrapperTypes(typeInformation.getReturnType(method));
+		return QueryExecutionConverters.unwrapWrapperTypes(typeInformation.getReturnType(method)).getType();
 	}
 
 	/* 
@@ -127,21 +127,5 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	@Override
 	public boolean isReactiveRepository() {
 		return ReactiveWrappers.usesReactiveType(repositoryInterface);
-	}
-
-	/**
-	 * Recursively unwraps well known wrapper types from the given {@link TypeInformation}.
-	 * 
-	 * @param type must not be {@literal null}.
-	 * @return
-	 */
-	private static Class<?> unwrapWrapperTypes(TypeInformation<?> type) {
-
-		Class<?> rawType = type.getType();
-
-		boolean needToUnwrap = Iterable.class.isAssignableFrom(rawType) || rawType.isArray()
-				|| QueryExecutionConverters.supports(rawType) || Stream.class.isAssignableFrom(rawType);
-
-		return needToUnwrap ? unwrapWrapperTypes(type.getRequiredComponentType()) : rawType;
 	}
 }

--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -64,7 +64,6 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	 * 
 	 * @param repositoryInterface must not be {@literal null}.
 	 * @since 1.9
-	 * @return
 	 */
 	public static RepositoryMetadata getMetadata(Class<?> repositoryInterface) {
 

--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2015 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * 
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public class Parameter {
 
@@ -207,7 +208,8 @@ public class Parameter {
 
 		TypeInformation<?> bound = parameterTypes.getTypeArguments().get(0);
 		TypeInformation<Object> returnType = ClassTypeInformation.fromReturnTypeOf(method);
-		return bound.equals(returnType.getActualType());
+
+		return bound.equals(QueryExecutionConverters.unwrapWrapperTypes(returnType));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -66,7 +66,6 @@ public class Parameter {
 	/**
 	 * Returns whether the parameter is a special parameter.
 	 * 
-	 * @return
 	 * @see #TYPES
 	 */
 	public boolean isSpecialParameter() {
@@ -75,8 +74,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the {@link Parameter} is to be bound to a query.
-	 * 
-	 * @return
 	 */
 	public boolean isBindable() {
 		return !isSpecialParameter();
@@ -84,8 +81,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the current {@link Parameter} is the one used for dynamic projections.
-	 * 
-	 * @return
 	 */
 	public boolean isDynamicProjectionParameter() {
 		return isDynamicProjectionParameter;
@@ -93,8 +88,6 @@ public class Parameter {
 
 	/**
 	 * Returns the placeholder to be used for the parameter. Can either be a named one or positional.
-	 * 
-	 * @return
 	 */
 	public String getPlaceholder() {
 
@@ -107,8 +100,6 @@ public class Parameter {
 
 	/**
 	 * Returns the position index the parameter is bound to in the context of its surrounding {@link Parameters}.
-	 * 
-	 * @return
 	 */
 	public int getIndex() {
 		return parameter.getParameterIndex();
@@ -116,8 +107,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the parameter is annotated with {@link Param}.
-	 * 
-	 * @return
 	 */
 	public boolean isNamedParameter() {
 		return !isSpecialParameter() && getName().isPresent();
@@ -125,8 +114,6 @@ public class Parameter {
 
 	/**
 	 * Returns the name of the parameter (through {@link Param} annotation).
-	 * 
-	 * @return
 	 */
 	public Optional<String> getName() {
 
@@ -146,7 +133,6 @@ public class Parameter {
 	/**
 	 * Returns whether the parameter is named explicitly, i.e. annotated with {@link Param}.
 	 * 
-	 * @return
 	 * @since 1.11
 	 */
 	public boolean isExplicitlyNamed() {
@@ -164,8 +150,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the {@link Parameter} is a {@link Pageable} parameter.
-	 * 
-	 * @return
 	 */
 	boolean isPageable() {
 		return Pageable.class.isAssignableFrom(getType());
@@ -173,8 +157,6 @@ public class Parameter {
 
 	/**
 	 * Returns whether the {@link Parameter} is a {@link Sort} parameter.
-	 * 
-	 * @return
 	 */
 	boolean isSort() {
 		return Sort.class.isAssignableFrom(getType());
@@ -189,7 +171,6 @@ public class Parameter {
 	 * </code>
 	 * 
 	 * @param parameter must not be {@literal null}.
-	 * @return
 	 */
 	private static boolean isDynamicProjectionParameter(MethodParameter parameter) {
 
@@ -216,7 +197,6 @@ public class Parameter {
 	 * Returns whether the {@link MethodParameter} is wrapped in a wrapper type.
 	 *
 	 * @param parameter must not be {@literal null}.
-	 * @return
 	 * @see QueryExecutionConverters
 	 */
 	private static boolean isWrapped(MethodParameter parameter) {
@@ -227,7 +207,6 @@ public class Parameter {
 	 * Returns whether the {@link MethodParameter} should be unwrapped.
 	 *
 	 * @param parameter must not be {@literal null}.
-	 * @return
 	 * @see QueryExecutionConverters
 	 */
 	private static boolean shouldUnwrap(MethodParameter parameter) {
@@ -239,7 +218,6 @@ public class Parameter {
 	 * unwrapped.
 	 * 
 	 * @param parameter must not be {@literal null}.
-	 * @return
 	 */
 	private static Class<?> potentiallyUnwrapParameterType(MethodParameter parameter) {
 

--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
@@ -47,6 +48,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.util.StreamUtils;
 import org.springframework.data.util.Streamable;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.util.Assert;
@@ -76,6 +78,7 @@ import com.google.common.base.Optional;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Maciek Opała
+ * @author Jens Schauder
  * @since 1.8
  * @see ReactiveWrappers
  */
@@ -283,6 +286,23 @@ public abstract class QueryExecutionConverters {
 		}
 
 		return source;
+	}
+
+	/**
+	 * Recursively unwraps well known wrapper types from the given {@link TypeInformation}.
+	 *
+	 * @param type must not be {@literal null}.
+	 */
+	public static TypeInformation<?> unwrapWrapperTypes(TypeInformation<?> type) {
+
+		Assert.notNull(type, "type must not be null");
+
+		Class<?> rawType = type.getType();
+
+		boolean needToUnwrap = Iterable.class.isAssignableFrom(rawType) || rawType.isArray() || supports(rawType)
+				|| Stream.class.isAssignableFrom(rawType);
+
+		return needToUnwrap ? unwrapWrapperTypes(type.getRequiredComponentType()) : type;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -170,7 +170,6 @@ public abstract class QueryExecutionConverters {
 	 * Returns whether the given type is a supported wrapper type.
 	 * 
 	 * @param type must not be {@literal null}.
-	 * @return
 	 */
 	public static boolean supports(Class<?> type) {
 
@@ -189,7 +188,6 @@ public abstract class QueryExecutionConverters {
 	 * Returns whether the given wrapper type supports unwrapping.
 	 *
 	 * @param type must not be {@literal null}.
-	 * @return
 	 */
 	public static boolean supportsUnwrapping(Class<?> type) {
 
@@ -218,8 +216,6 @@ public abstract class QueryExecutionConverters {
 	/**
 	 * Returns the types that are supported on paginating query methods. Will include custom collection types of e.g.
 	 * Javaslang.
-	 * 
-	 * @return
 	 */
 	public static Set<Class<?>> getAllowedPageableTypes() {
 		return Collections.unmodifiableSet(ALLOWED_PAGEABLE_TYPES);
@@ -267,7 +263,6 @@ public abstract class QueryExecutionConverters {
 	 * Unwraps the given source value in case it's one of the currently supported wrapper types detected at runtime.
 	 * 
 	 * @param source can be {@literal null}.
-	 * @return
 	 */
 	@Nullable
 	public static Object unwrap(@Nullable Object source) {
@@ -585,7 +580,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 1.12
 	 */
-	private static enum GuavaOptionalUnwrapper implements Converter<Object, Object> {
+	private enum GuavaOptionalUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -606,7 +601,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 1.12
 	 */
-	private static enum Jdk8OptionalUnwrapper implements Converter<Object, Object> {
+	private enum Jdk8OptionalUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -628,7 +623,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Mark Paluch
 	 * @since 1.12
 	 */
-	private static enum ScalOptionUnwrapper implements Converter<Object, Object> {
+	private enum ScalOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -662,7 +657,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 1.13
 	 */
-	private static enum JavaslangOptionUnwrapper implements Converter<Object, Object> {
+	private enum JavaslangOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -693,7 +688,7 @@ public abstract class QueryExecutionConverters {
 	 * @author Oliver Gierke
 	 * @since 2.0
 	 */
-	private static enum VavrOptionUnwrapper implements Converter<Object, Object> {
+	private enum VavrOptionUnwrapper implements Converter<Object, Object> {
 
 		INSTANCE;
 
@@ -718,7 +713,7 @@ public abstract class QueryExecutionConverters {
 		}
 	}
 
-	private static enum IterableToStreamableConverter implements Converter<Iterable<?>, Streamable<?>> {
+	private enum IterableToStreamableConverter implements Converter<Iterable<?>, Streamable<?>> {
 
 		INSTANCE;
 

--- a/src/test/java/org/springframework/data/repository/query/ParameterUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ParameterUnitTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.springframework.core.MethodParameter;
+
+/**
+ * Unit tests for {@link Parameter}.
+ *
+ * @author Jens Schauder
+ */
+public class ParameterUnitTests {
+
+	@Test // DATAJPA-1185
+	public void classParameterWithSameTypeParameterAsReturnedListIsDynamicProjectionParameter() throws Exception {
+
+		Parameter parameter = new Parameter(getMethodParameter("dynamicProjectionWithList"));
+
+		assertThat(parameter.isDynamicProjectionParameter()).isTrue();
+	}
+
+	@Test // DATAJPA-1185
+	public void classParameterWithSameTypeParameterAsReturnedStreamIsDynamicProjectionParameter() throws Exception {
+
+		Parameter parameter = new Parameter(getMethodParameter("dynamicProjectionWithStream"));
+
+		assertThat(parameter.isDynamicProjectionParameter()).isTrue();
+	}
+
+	@NotNull
+	private MethodParameter getMethodParameter(String methodName) throws NoSuchMethodException {
+		return new MethodParameter( //
+				this.getClass().getDeclaredMethod( //
+						methodName, //
+						Class.class //
+				), //
+				0);
+	}
+
+	<T> List<T> dynamicProjectionWithList(Class<T> type) {
+		return Collections.emptyList();
+	}
+
+	<T> Stream<T> dynamicProjectionWithStream(Class<T> type) {
+		return Stream.empty();
+	}
+}


### PR DESCRIPTION
When trying to determine if a parameter is a dynamic projection parameter, i.e. the parameter of type Class that determines the projection to use, now the type parameter of that method parameter gets compared with the unwrapped return type.
Therefore this works now not only for Maps and Collections but also for the various wrappers defined in QueryExecutionConverters.

Moved the method for unwrapping the return type from AbstractRepositoryMetadata to QueryExecutionConverters in order to make it available to every class needing it.
This also puts it closer to the data it is working on.