### PR TITLE
DATACMNS-1200 - Fix entity instantiation of Kotlin types using primitives with default values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1200-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiator.java
@@ -20,6 +20,7 @@ import kotlin.reflect.KParameter;
 import kotlin.reflect.jvm.ReflectJvmMapping;
 
 import java.lang.reflect.Constructor;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -27,6 +28,7 @@ import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PreferredConstructor;
 import org.springframework.data.mapping.PreferredConstructor.Parameter;
+import org.springframework.data.mapping.model.MappingInstantiationException;
 import org.springframework.data.mapping.model.ParameterValueProvider;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.lang.Nullable;
@@ -197,7 +199,17 @@ public class KotlinClassGeneratingEntityInstantiator extends ClassGeneratingEnti
 		public <T, E extends PersistentEntity<? extends T, P>, P extends PersistentProperty<P>> T createInstance(E entity,
 				ParameterValueProvider<P> provider) {
 
-			PreferredConstructor<? extends T, P> preferredConstructor = entity.getPersistenceConstructor();
+			Object[] params = extractInvocationArguments(entity.getPersistenceConstructor(), provider);
+
+			try {
+				return (T) instantiator.newInstance(params);
+			} catch (Exception e) {
+				throw new MappingInstantiationException(entity, Arrays.asList(params), e);
+			}
+		}
+
+		private <P extends PersistentProperty<P>, T> Object[] extractInvocationArguments(
+				@Nullable PreferredConstructor<? extends T, P> preferredConstructor, ParameterValueProvider<P> provider) {
 
 			if (preferredConstructor == null) {
 				throw new IllegalArgumentException("PreferredConstructor must not be null!");
@@ -237,7 +249,7 @@ public class KotlinClassGeneratingEntityInstantiator extends ClassGeneratingEnti
 				params[userParameterCount + i] = defaulting[i];
 			}
 
-			return (T) instantiator.newInstance(params);
+			return params;
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/mapping/model/MappingInstantiationException.java
+++ b/src/main/java/org/springframework/data/mapping/model/MappingInstantiationException.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.mapping.model;
 
+import kotlin.reflect.KFunction;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +25,7 @@ import java.util.Optional;
 
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PreferredConstructor;
+import org.springframework.data.util.ReflectionUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 
@@ -88,10 +92,26 @@ public class MappingInstantiationException extends RuntimeException {
 			}
 
 			return String.format(TEXT_TEMPLATE, it.getType().getName(),
-					constructor.map(c -> c.getConstructor().toString()).orElse("NO_CONSTRUCTOR"), //
+					constructor.map(c -> toString(c)).orElse("NO_CONSTRUCTOR"), //
 					String.join(",", toStringArgs));
 
 		}).orElse(defaultMessage);
+	}
+
+	private static String toString(PreferredConstructor<?, ?> preferredConstructor) {
+
+		Constructor<?> constructor = preferredConstructor.getConstructor();
+
+		if (ReflectionUtils.isSupportedKotlinClass(constructor.getDeclaringClass())) {
+
+			KFunction<?> kotlinFunction = ReflectJvmMapping.getKotlinFunction(constructor);
+
+			if (kotlinFunction != null) {
+				return kotlinFunction.toString();
+			}
+		}
+
+		return constructor.toString();
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/convert/ClassGeneratingEntityInstantiatorUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/ClassGeneratingEntityInstantiatorUnitTests.java
@@ -264,6 +264,17 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		});
 	}
 
+	@Test // DATACMNS-1200
+	public void instantiateObjectCtor1ParamIntWithoutValue() {
+
+		doReturn(ObjectCtor1ParamInt.class).when(entity).getType();
+		doReturn(PreferredConstructorDiscoverer.discover(ObjectCtor1ParamInt.class))//
+				.when(entity).getPersistenceConstructor();
+
+		assertThatThrownBy(() -> this.instance.createInstance(entity, provider)) //
+				.hasCauseInstanceOf(IllegalArgumentException.class);
+	}
+
 	@Test // DATACMNS-578, DATACMNS-1126
 	@SuppressWarnings("unchecked")
 	public void instantiateObjectCtor7ParamsString5IntsString() {

--- a/src/test/kotlin/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiatorUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/KotlinClassGeneratingEntityInstantiatorUnitTests.kt
@@ -96,6 +96,27 @@ class KotlinClassGeneratingEntityInstantiatorUnitTests {
 				.hasCauseInstanceOf(IllegalArgumentException::class.java)
 	}
 
+	@Test // DATACMNS-1200
+	fun `should apply primitive defaulting for absent parameters`() {
+
+		val entity = this.entity as PersistentEntity<WithPrimitiveDefaulting, SamplePersistentProperty>
+		val constructor = PreferredConstructorDiscoverer.discover<WithPrimitiveDefaulting, SamplePersistentProperty>(WithPrimitiveDefaulting::class.java)
+
+		doReturn(constructor).whenever(entity).persistenceConstructor
+		doReturn(constructor.constructor.declaringClass).whenever(entity).type
+
+		val instance: WithPrimitiveDefaulting = KotlinClassGeneratingEntityInstantiator().createInstance(entity, provider)
+
+		Assertions.assertThat(instance.aByte).isEqualTo(0)
+		Assertions.assertThat(instance.aShort).isEqualTo(0)
+		Assertions.assertThat(instance.anInt).isEqualTo(0)
+		Assertions.assertThat(instance.aLong).isEqualTo(0L)
+		Assertions.assertThat(instance.aFloat).isEqualTo(0.0f)
+		Assertions.assertThat(instance.aDouble).isEqualTo(0.0)
+		Assertions.assertThat(instance.aChar).isEqualTo('a')
+		Assertions.assertThat(instance.aBool).isTrue()
+	}
+
 	data class Contact(val firstname: String, val lastname: String)
 
 	data class ContactWithDefaulting(val prop0: String, val prop1: String = "White", val prop2: String,
@@ -113,5 +134,8 @@ class KotlinClassGeneratingEntityInstantiatorUnitTests {
 	)
 
 	data class WithBoolean(val state: Boolean)
+
+	data class WithPrimitiveDefaulting(val aByte: Byte = 0, val aShort: Short = 0, val anInt: Int = 0, val aLong: Long = 0L,
+									   val aFloat: Float = 0.0f, val aDouble: Double = 0.0, val aChar: Char = 'a', val aBool: Boolean = true)
 }
 


### PR DESCRIPTION
We now determine initial values for primitive parameters in Kotlin constructors that are absent (null) and defaulted. We default all Java primitive types to their initial zero value to prevent possible NullPointerExceptions. Kotlin defaulting uses a bitmask to determine which parameter should be defaulted but still requires the appropriate type.

Previously, null values were attempted to cast/unbox and caused `NullPointerException` even though they had default values through Kotlin assigned.

It might make sense to backport c5e8e62 to 1.x to improve missing parameter reporting.

---

Related ticket: [DATACMNS-1200](https://jira.spring.io/browse/DATACMNS-1200).