### PR TITLE
DATACMNS-1201 - Support generated property accessors for types in default packages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1201-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 
@@ -163,7 +163,7 @@
 			<version>1.0.1</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>javax.interceptor</groupId>
 			<artifactId>javax.interceptor-api</artifactId>

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -133,7 +133,10 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 	}
 
 	private static boolean isTypeInjectable(PersistentEntity<?, ?> entity) {
-		return entity.getType().getClassLoader() != null && !entity.getType().getPackage().getName().startsWith("java");
+
+		Class<?> type = entity.getType();
+		return type.getClassLoader() != null
+				&& (type.getPackage() == null || !type.getPackage().getName().startsWith("java"));
 	}
 
 	private boolean hasUniquePropertyHashCodes(PersistentEntity<?, ?> entity) {


### PR DESCRIPTION
We now support generated property accessors for types that reside in the default package.

---

Related ticket: [DATACMNS-1201](https://jira.spring.io/browse/DATACMNS-1201).