### PR TITLE
DATACMNS-1208 - fixed hasPersistentEntityFor() vs getPersistentEntity…

### DIFF
--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
@@ -52,7 +51,6 @@ import org.springframework.data.mapping.model.PersistentPropertyAccessorFactory;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.ClassTypeInformation;
-import org.springframework.data.util.Optionals;
 import org.springframework.data.util.Pair;
 import org.springframework.data.util.Streamable;
 import org.springframework.data.util.TypeInformation;
@@ -73,6 +71,7 @@ import org.springframework.util.StringUtils;
  *
  * @param <E> the concrete {@link PersistentEntity} type the {@link MappingContext} implementation creates
  * @param <P> the concrete {@link PersistentProperty} type the {@link MappingContext} implementation creates
+ * @author Bartosz Kielczewski
  * @author Jon Brisbin
  * @author Oliver Gierke
  * @author Michael Hunger
@@ -85,8 +84,7 @@ import org.springframework.util.StringUtils;
 public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?, P>, P extends PersistentProperty<P>>
 		implements MappingContext<E, P>, ApplicationEventPublisherAware, InitializingBean {
 
-	private final Optional<E> NONE = Optional.empty();
-	private final Map<TypeInformation<?>, Optional<E>> persistentEntities = new HashMap<>();
+	private final Map<TypeInformation<?>, E> persistentEntities = new HashMap<>();
 	private final Map<TypeAndProperties, PersistentPropertyPath<P>> propertyPaths = new ConcurrentReferenceHashMap<>();
 	private final PersistentPropertyAccessorFactory persistentPropertyAccessorFactory = new ClassGeneratingPropertyAccessorFactory();
 
@@ -145,7 +143,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mapping.model.MappingContext#getPersistentEntities()
+	 * @see org.springframework.data.mapping.context.MappingContext#getPersistentEntities()
 	 */
 	@Override
 	public Collection<E> getPersistentEntities() {
@@ -154,9 +152,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 			read.lock();
 
-			return persistentEntities.values().stream()//
-					.flatMap(Optionals::toStream)//
-					.collect(Collectors.toSet());
+			return new HashSet<>(persistentEntities.values());
 
 		} finally {
 			read.unlock();
@@ -186,7 +182,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mapping.model.MappingContext#getPersistentEntity(org.springframework.data.util.TypeInformation)
+	 * @see org.springframework.data.mapping.context.MappingContext#getPersistentEntity(org.springframework.data.util.TypeInformation)
 	 */
 	@Nullable
 	@Override
@@ -194,37 +190,34 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 		Assert.notNull(type, "Type must not be null!");
 
+		E entity = getExistingPersistentEntity(type);
+		if (entity != null) {
+			return entity;
+		} else  if (!shouldCreatePersistentEntityFor(type)) {
+			return null;
+		} else  if (strict) {
+			throw new MappingException("Unknown persistent entity " + type);
+		} else {
+			return addPersistentEntity(type);
+		}
+	}
+
+	/**
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.context.MappingContext#getPersistentEntity(org.springframework.data.util.TypeInformation)
+	 */
+	@Nullable
+	private E getExistingPersistentEntity(TypeInformation<?> type) {
+
 		try {
 
 			read.lock();
 
-			Optional<E> entity = persistentEntities.get(type);
-
-			if (entity != null) {
-				return entity.orElse(null);
-			}
+			return persistentEntities.get(type);
 
 		} finally {
 			read.unlock();
 		}
-
-		if (!shouldCreatePersistentEntityFor(type)) {
-
-			try {
-				write.lock();
-				persistentEntities.put(type, NONE);
-			} finally {
-				write.unlock();
-			}
-
-			return null;
-		}
-
-		if (strict) {
-			throw new MappingException("Unknown persistent entity " + type);
-		}
-
-		return addPersistentEntity(type).orElse(null);
 	}
 
 	/*
@@ -339,7 +332,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
-	protected Optional<E> addPersistentEntity(Class<?> type) {
+	protected E addPersistentEntity(Class<?> type) {
 		return addPersistentEntity(ClassTypeInformation.from(type));
 	}
 
@@ -349,26 +342,16 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	 * @param typeInformation must not be {@literal null}.
 	 * @return
 	 */
-	protected Optional<E> addPersistentEntity(TypeInformation<?> typeInformation) {
+	protected E addPersistentEntity(TypeInformation<?> typeInformation) {
 
 		Assert.notNull(typeInformation, "TypeInformation must not be null!");
 
-		try {
-
-			read.lock();
-
-			Optional<E> persistentEntity = persistentEntities.get(typeInformation);
-
-			if (persistentEntity != null) {
-				return persistentEntity;
-			}
-
-		} finally {
-			read.unlock();
+		E entity = persistentEntities.get(typeInformation);
+		if (entity != null) {
+			return entity;
 		}
 
 		Class<?> type = typeInformation.getType();
-		E entity = null;
 
 		try {
 
@@ -377,7 +360,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			entity = createPersistentEntity(typeInformation);
 
 			// Eagerly cache the entity as we might have to find it during recursive lookups.
-			persistentEntities.put(typeInformation, Optional.of(entity));
+			persistentEntities.put(typeInformation, entity);
 
 			PropertyDescriptor[] pds = BeanUtils.getPropertyDescriptors(type);
 
@@ -414,7 +397,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			applicationEventPublisher.publishEvent(new MappingContextEvent<>(this, entity));
 		}
 
-		return Optional.of(entity);
+		return entity;
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
 /**
  * Unit test for {@link AbstractMappingContext}.
  *
+ * @author Bartosz Kielczewski
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -113,6 +114,14 @@ public class AbstractMappingContextUnitTests {
 
 		SampleMappingContext context = new SampleMappingContext();
 		assertThat(context.getPersistentEntity(String.class)).isNull();
+	}
+
+	@Test // DATACMNS-1208
+	public void ensureHasPersistentEntityReportsFalseForTypesThatShouldntBeCreated() {
+		SampleMappingContext context = new SampleMappingContext();
+		assertThat(context.hasPersistentEntityFor(String.class)).isFalse();
+		assertThat(context.getPersistentEntity(String.class)).isNull();
+		assertThat(context.hasPersistentEntityFor(String.class)).isFalse();
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATACMNS-214


### PR DESCRIPTION
…ForClass() inconsistency

Making call to AbstractMappingContext.getPersistentEntityForClass() created an entry in persistentEntities map for every type for which shouldCreatePersistentEntity() == false. This was causing hasPersistentEntityFor() to falsely return true after such call. This was fixed by not keeping Optionals in persistentEntities as this seem to serve no purpose.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
