### PR TITLE
DATACMNS-1210 - Fix concurrency issue in BasicPersitentEntity.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1210-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
Make sure to use concurrent collection implementations for properties holding mutable state. Especially the ones making use of `computeIfAbsent()`.

Usage of `ConcurrentReferenceHashMap` allows us to move on without additional changes as it allows to store `null` values, whereas `ConcurrentHashMap` would require us to store explicit `NullValue` placeholders for such cases, potentially causing trouble in downstream store specific projects.

JMH Benchmarks (for the mapping layer in Spring Data MongoDB) comparing `ConcurrentReferenceHashMap` and `ConcurrentHashMap` did not show any significant difference between the two.