### PR TITLE
[DATACMNS-1212] Remove unnecessary conversion

### DIFF
--- a/src/main/java/org/springframework/data/convert/Jsr310Converters.java
+++ b/src/main/java/org/springframework/data/convert/Jsr310Converters.java
@@ -174,7 +174,7 @@ public abstract class Jsr310Converters {
 		@Nonnull
 		@Override
 		public Date convert(Instant source) {
-			return Date.from(source.atZone(systemDefault()).toInstant());
+			return Date.from(source);
 		}
 	}
 


### PR DESCRIPTION
Converting from instant to ZoneDateTime and back to Instant does not seem to have a purpose as the timezone information will never be used
