### PR TITLE
Wrapper type in Pageable

### DIFF
--- a/src/main/java/org/springframework/data/domain/AbstractPageRequest.java
+++ b/src/main/java/org/springframework/data/domain/AbstractPageRequest.java
@@ -29,8 +29,8 @@ public abstract class AbstractPageRequest implements Pageable, Serializable {
 
 	private static final long serialVersionUID = 1232825578694716871L;
 
-	private final int page;
-	private final int size;
+	private final Integer page;
+	private final Integer size;
 
 	/**
 	 * Creates a new {@link AbstractPageRequest}. Pages are zero indexed, thus providing 0 for {@code page} will return
@@ -39,7 +39,7 @@ public abstract class AbstractPageRequest implements Pageable, Serializable {
 	 * @param page must not be less than zero.
 	 * @param size must not be less than one.
 	 */
-	public AbstractPageRequest(int page, int size) {
+	public AbstractPageRequest(Integer page, Integer size) {
 
 		if (page < 0) {
 			throw new IllegalArgumentException("Page index must not be less than zero!");
@@ -57,7 +57,7 @@ public abstract class AbstractPageRequest implements Pageable, Serializable {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.domain.Pageable#getPageSize()
 	 */
-	public int getPageSize() {
+	public Integer getPageSize() {
 		return size;
 	}
 
@@ -73,8 +73,8 @@ public abstract class AbstractPageRequest implements Pageable, Serializable {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.domain.Pageable#getOffset()
 	 */
-	public long getOffset() {
-		return page * size;
+	public Long getOffset() {
+		return Long.valueOf(page * size);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/domain/PageRequest.java
+++ b/src/main/java/org/springframework/data/domain/PageRequest.java
@@ -36,10 +36,10 @@ public class PageRequest extends AbstractPageRequest {
 	 *
 	 * @param page zero-based page index.
 	 * @param size the size of the page to be returned.
-	 * @deprecated use {@link #of(int, int)} instead.
+	 * @deprecated use {@link #of(Integer, Integer)} instead.
 	 */
 	@Deprecated
-	public PageRequest(int page, int size) {
+	public PageRequest(Integer page, Integer size) {
 		this(page, size, Sort.unsorted());
 	}
 
@@ -50,10 +50,10 @@ public class PageRequest extends AbstractPageRequest {
 	 * @param size the size of the page to be returned.
 	 * @param direction the direction of the {@link Sort} to be specified, can be {@literal null}.
 	 * @param properties the properties to sort by, must not be {@literal null} or empty.
-	 * @deprecated use {@link #of(int, int, Direction, String...)} instead.
+	 * @deprecated use {@link #of(Integer, Integer, Direction, String...)} instead.
 	 */
 	@Deprecated
-	public PageRequest(int page, int size, Direction direction, String... properties) {
+	public PageRequest(Integer page, Integer size, Direction direction, String... properties) {
 		this(page, size, Sort.by(direction, properties));
 	}
 
@@ -63,10 +63,10 @@ public class PageRequest extends AbstractPageRequest {
 	 * @param page zero-based page index.
 	 * @param size the size of the page to be returned.
 	 * @param sort can be {@literal null}.
-	 * @deprecated since 2.0, use {@link #of(int, int, Sort)} instead.
+	 * @deprecated since 2.0, use {@link #of(Integer, Integer, Sort)} instead.
 	 */
 	@Deprecated
-	public PageRequest(int page, int size, Sort sort) {
+	public PageRequest(Integer page, Integer size, Sort sort) {
 
 		super(page, size);
 
@@ -80,7 +80,7 @@ public class PageRequest extends AbstractPageRequest {
 	 * @param size the size of the page to be returned.
 	 * @since 2.0
 	 */
-	public static PageRequest of(int page, int size) {
+	public static PageRequest of(Integer page, Integer size) {
 		return of(page, size, Sort.unsorted());
 	}
 
@@ -92,7 +92,7 @@ public class PageRequest extends AbstractPageRequest {
 	 * @param sort must not be {@literal null}.
 	 * @since 2.0
 	 */
-	public static PageRequest of(int page, int size, Sort sort) {
+	public static PageRequest of(Integer page, Integer size, Sort sort) {
 		return new PageRequest(page, size, sort);
 	}
 
@@ -105,7 +105,7 @@ public class PageRequest extends AbstractPageRequest {
 	 * @param properties must not be {@literal null}.
 	 * @since 2.0
 	 */
-	public static PageRequest of(int page, int size, Direction direction, String... properties) {
+	public static PageRequest of(Integer page, Integer size, Direction direction, String... properties) {
 		return of(page, size, Sort.by(direction, properties));
 	}
 

--- a/src/main/java/org/springframework/data/domain/Pageable.java
+++ b/src/main/java/org/springframework/data/domain/Pageable.java
@@ -65,14 +65,14 @@ public interface Pageable {
 	 * 
 	 * @return the number of items of that page
 	 */
-	int getPageSize();
+	Integer getPageSize();
 
 	/**
 	 * Returns the offset to be taken according to the underlying page and page size.
 	 * 
 	 * @return the offset to be taken
 	 */
-	long getOffset();
+	Long getOffset();
 
 	/**
 	 * Returns the sorting parameters.

--- a/src/main/java/org/springframework/data/querydsl/QPageRequest.java
+++ b/src/main/java/org/springframework/data/querydsl/QPageRequest.java
@@ -39,7 +39,7 @@ public class QPageRequest extends AbstractPageRequest {
 	 * @param page
 	 * @param size
 	 */
-	public QPageRequest(int page, int size) {
+	public QPageRequest(Integer page, Integer size) {
 		this(page, size, QSort.unsorted());
 	}
 
@@ -50,7 +50,7 @@ public class QPageRequest extends AbstractPageRequest {
 	 * @param size
 	 * @param orderSpecifiers must not be {@literal null} or empty;
 	 */
-	public QPageRequest(int page, int size, OrderSpecifier<?>... orderSpecifiers) {
+	public QPageRequest(Integer page, Integer size, OrderSpecifier<?>... orderSpecifiers) {
 		this(page, size, new QSort(orderSpecifiers));
 	}
 
@@ -61,7 +61,7 @@ public class QPageRequest extends AbstractPageRequest {
 	 * @param size
 	 * @param sort
 	 */
-	public QPageRequest(int page, int size, QSort sort) {
+	public QPageRequest(Integer page, Integer size, QSort sort) {
 		super(page, size);
 
 		this.sort = sort;


### PR DESCRIPTION
Is possible to change interface Pageable to support wrapper types?

Whit this modification it's possible to support null value, for example we can write this:

`if (pageable.getOffset()!=null) { query.offset(pageable.getOffset()); }`
`if (pageable.getPageSize()!=null) { query.limit(pageable.getPageSize()); }`

