### PR TITLE
DATACMNS-1228 - Allow custom bean name generator

### DIFF
--- a/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSourceUnitTests.java
@@ -41,6 +41,7 @@ import org.springframework.data.util.Streamable;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Sascha Woo
  */
 public class AnnotationRepositoryConfigurationSourceUnitTests {
 
@@ -165,6 +166,8 @@ public class AnnotationRepositoryConfigurationSourceUnitTests {
 		Filter[] includeFilters() default {};
 
 		Filter[] excludeFilters() default {};
+
+		Class<? extends RepositoryBeanNameGenerator> nameGenerator() default RepositoryBeanNameGenerator.class;
 	}
 
 	@SampleAnnotation

--- a/src/test/java/org/springframework/data/repository/config/EnableRepositories.java
+++ b/src/test/java/org/springframework/data/repository/config/EnableRepositories.java
@@ -51,4 +51,6 @@ public @interface EnableRepositories {
 	boolean considerNestedRepositories() default false;
 
 	boolean limitImplementationBasePackages() default true;
+
+	Class<? extends RepositoryBeanNameGenerator> nameGenerator() default RepositoryBeanNameGenerator.class;
 }


### PR DESCRIPTION
This adds a new annotation attribute `nameGenerator` and XML attribute `name-generator` to specify a custom bean name generator in the same way it's done in `@ComponentScan`.

```java
@EnableRepository(nameGenerator = XYZRepositoryBeanNameGenerator.class)
```

```xml
<repositories name-generator="com.acme.repositories.XYZRepositoryBeanNameGenerator" />
```

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
