### PR TITLE
DATACMNS-1236 - Fix inconsistent Pageable's nullability Javadoc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1236-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/domain/PageImpl.java
+++ b/src/main/java/org/springframework/data/domain/PageImpl.java
@@ -25,27 +25,26 @@ import org.springframework.lang.Nullable;
  * 
  * @param <T> the type of which the page consists.
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class PageImpl<T> extends Chunk<T> implements Page<T> {
 
 	private static final long serialVersionUID = 867755909294344406L;
 
 	private final long total;
-	private final Pageable pageable;
 
 	/**
 	 * Constructor of {@code PageImpl}.
 	 * 
 	 * @param content the content of this page, must not be {@literal null}.
-	 * @param pageable the paging information, can be {@literal null}.
+	 * @param pageable the paging information, must not be {@literal null}.
 	 * @param total the total amount of items available. The total might be adapted considering the length of the content
-	 *          given, if it is going to be the content of the last page. This is in place to mitigate inconsistencies
+	 *          given, if it is going to be the content of the last page. This is in place to mitigate inconsistencies.
 	 */
 	public PageImpl(List<T> content, Pageable pageable, long total) {
 
 		super(content, pageable);
 
-		this.pageable = pageable;
 		this.total = pageable.toOptional().filter(it -> !content.isEmpty())//
 				.filter(it -> it.getOffset() + it.getPageSize() > total)//
 				.map(it -> it.getOffset() + content.size())//
@@ -104,7 +103,7 @@ public class PageImpl<T> extends Chunk<T> implements Page<T> {
 	 */
 	@Override
 	public <U> Page<U> map(Function<? super T, ? extends U> converter) {
-		return new PageImpl<>(getConvertedContent(converter), pageable, total);
+		return new PageImpl<>(getConvertedContent(converter), getPageable(), total);
 	}
 
 	/*


### PR DESCRIPTION
Fix Javadoc to reflect Pageable's non-nullability. Also, remove `pageable` field in favor of using Chunk's `Pageable` getter.

---

Related ticket: [DATACMNNS-1246](https://jira.spring.io/browse/DATACMNNS-1246).