### PR TITLE
DATACMNS-563 - fix for returning correct page number in metadata when one indexed parameters are used

### DIFF
--- a/src/main/java/org/springframework/data/web/PagedResourcesAssembler.java
+++ b/src/main/java/org/springframework/data/web/PagedResourcesAssembler.java
@@ -290,10 +290,11 @@ public class PagedResourcesAssembler<T> implements ResourceAssembler<Page<T>, Pa
 	 * @param page must not be {@literal null}.
 	 * @return
 	 */
-	private static <T> PageMetadata asPageMetadata(Page<T> page) {
+	private <T> PageMetadata asPageMetadata(Page<T> page) {
 
 		Assert.notNull(page, "Page must not be null!");
-		return new PageMetadata(page.getSize(), page.getNumber(), page.getTotalElements(), page.getTotalPages());
+		boolean isOneIndexedParameters = pageableResolver.isOneIndexedParameters();
+		return new PageMetadata(page.getSize(), isOneIndexedParameters ? page.getNumber() + 1 : page.getNumber(), page.getTotalElements(), page.getTotalPages());
 	}
 
 	private String baseUriOrCurrentRequest() {

--- a/src/test/java/org/springframework/data/web/PagedResourcesAssemblerUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PagedResourcesAssemblerUnitTests.java
@@ -159,6 +159,9 @@ public class PagedResourcesAssemblerUnitTests {
 		assertThat(resource.hasLink("prev")).isTrue();
 		assertThat(resource.hasLink("next")).isTrue();
 
+		// We expect 2 as the created page has index 1. Pages itself are always 0 indexed, so we created page 2 above.
+		assertThat(resource.getMetadata().getNumber()).isEqualTo(2);
+
 		assertThat(getQueryParameters(resource.getLink("prev"))).containsEntry("page", "1");
 		assertThat(getQueryParameters(resource.getLink("next"))).containsEntry("page", "3");
 	}


### PR DESCRIPTION
This fix returns the correct page number when one index parameters are used.

So instead of:

```
"page": {
  "size": 10,
  "total_elements": 888,
  "total_pages": 89,
  "number": 0
}
```
 it will return:

```
"page": {
  "size": 10,
  "total_elements": 888,
  "total_pages": 89,
  "number": 1
}
```

for the first page.
