### PR TITLE
DATACMNS-1245 - Consider Kotlin metadata annotation for Kotlin class kind retrieval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1245-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
We now inspect Kotlin's `Metadata` annotation to determine the kind of a Kotlin class.

Previously we used Kotlins internal API to introspect classes. Because this API is not public and can be changed at any time we rely on Kotlins annotations as they are supposed to not change in near future.

---

Related ticket: [DATACMNS-1245](https://jira.spring.io/browse/DATACMNS-1245).