### PR TITLE
 DATACMNS-1251 - Added methods returning Instant to Revision.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1251-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/history/Revision.java
+++ b/src/main/java/org/springframework/data/history/Revision.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -33,6 +34,7 @@ import org.springframework.lang.Nullable;
  * @author Oliver Gierke
  * @author Philipp Huegelmeyer
  * @author Christoph Strobl
+ * @author Jens Schauder
  */
 @Value
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -80,19 +82,41 @@ public final class Revision<N extends Number & Comparable<N>, T> implements Comp
 	/**
 	 * Returns the revision date of the revision.
 	 *
-	 * @return
+	 * @return Guaranteed to be not {@literal null}.
+	 * @deprecated Use {@link #getRevisionInstant()} instead.
 	 */
+	@Deprecated
 	public Optional<LocalDateTime> getRevisionDate() {
 		return metadata.getRevisionDate();
+	}
+
+	/**
+	 * Returns the timestamp of the revision.
+	 *
+	 * @return Guaranteed to be not {@literal null}.
+	 */
+	public Optional<Instant> getRevisionInstant() {
+		return metadata.getRevisionInstant();
 	}
 
 	/**
 	 * Returns the revision date of the revision, immediately failing on absence.
 	 *
 	 * @return the revision date.
+	 * @deprecated Use {@link #getRequiredRevisionInstant()} instead.
 	 */
+	@Deprecated
 	public LocalDateTime getRequiredRevisionDate() {
 		return metadata.getRequiredRevisionDate();
+	}
+
+	/**
+	 * Returns the timestamp of the revision, immediately failing on absence.
+	 *
+	 * @return the revision {@link Instant}. May be {@literal null}.
+	 */
+	public Instant getRequiredRevisionInstant() {
+		return metadata.getRequiredRevisionInstant();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/history/RevisionMetadata.java
+++ b/src/main/java/org/springframework/data/history/RevisionMetadata.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.history;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -23,6 +24,7 @@ import java.util.Optional;
  *
  * @author Philipp Huegelmeyer
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 public interface RevisionMetadata<N extends Number & Comparable<N>> {
 
@@ -48,17 +50,40 @@ public interface RevisionMetadata<N extends Number & Comparable<N>> {
 	 * Returns the date of the revision.
 	 *
 	 * @return will never be {@literal null}.
+	 * @deprecated use {@link #getRevisionInstant()} instead.
 	 */
+	@Deprecated
 	Optional<LocalDateTime> getRevisionDate();
+
+	/**
+	 * Returns the timestamp of the revision.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	Optional<Instant> getRevisionInstant();
 
 	/**
 	 * Returns the revision date of the revision, immediately failing on absence.
 	 *
 	 * @return will never be {@literal null}.
-	 * @throw IllegalStateException if no revision date is available.
+	 * @throws IllegalStateException if no revision date is available.
+	 * @deprecated Use {@link #getRevisionInstant()} instead.
 	 */
+	@Deprecated
 	default LocalDateTime getRequiredRevisionDate() {
 		return getRevisionDate().orElseThrow(
+				() -> new IllegalStateException(String.format("No revision date found on %s!", (Object) getDelegate())));
+	}
+
+
+	/**
+	 * Returns the timestamp of the revision, immediately failing on absence.
+	 *
+	 * @return will never be {@literal null}.
+	 * @throws IllegalStateException if no revision date is available.
+	 */
+	default Instant getRequiredRevisionInstant() {
+		return getRevisionInstant().orElseThrow(
 				() -> new IllegalStateException(String.format("No revision date found on %s!", (Object) getDelegate())));
 	}
 

--- a/src/test/java/org/springframework/data/history/RevisionUnitTests.java
+++ b/src/test/java/org/springframework/data/history/RevisionUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.history;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Unit tests for {@link RevisionMetadata}.
  *
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RevisionUnitTests {
@@ -70,6 +72,15 @@ public class RevisionUnitTests {
 		when(firstMetadata.getRevisionDate()).thenReturn(reference);
 
 		assertThat(Revision.of(firstMetadata, new Object()).getRevisionDate()).isEqualTo(reference);
+	}
+
+	@Test // DATACMNS-1251
+	public void returnsRevisionInstant() {
+
+		Optional<Instant> reference = Optional.of(Instant.now());
+		when(firstMetadata.getRevisionInstant()).thenReturn(reference);
+
+		assertThat(Revision.of(firstMetadata, new Object()).getRevisionInstant()).isEqualTo(reference);
 	}
 
 	@Test // DATACMNS-218


### PR DESCRIPTION
Revision and RevisionMetadata now have methods returning Instant instead of LocalDateTime.
The existing methods returning LocalDateTime are now deprecated.