### PR TITLE
DATACMNS-1255, DATACMNS-1233 - Add CDI support for repository fragments (mixins).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1255-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryBean.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryBean.java
@@ -44,7 +44,6 @@ import org.springframework.data.repository.config.CustomRepositoryImplementation
 import org.springframework.data.repository.config.DefaultRepositoryConfiguration;
 import org.springframework.data.repository.config.RepositoryBeanNameGenerator;
 import org.springframework.data.repository.config.SpringDataAnnotationBeanNameGenerator;
-import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -430,11 +429,5 @@ public abstract class CdiRepositoryBean<T> implements Bean<T>, PassivationCapabl
 		public String getRepositoryImplementationPostfix() {
 			return DefaultRepositoryConfiguration.DEFAULT_REPOSITORY_IMPLEMENTATION_POSTFIX;
 		}
-
-		@Override
-		public QueryLookupStrategy.Key getQueryLookupStrategy() {
-			return DefaultRepositoryConfiguration.DEFAULT_QUERY_LOOKUP_STRATEGY;
-		}
-
 	}
 }

--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryBean.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryBean.java
@@ -44,6 +44,7 @@ import org.springframework.data.repository.config.CustomRepositoryImplementation
 import org.springframework.data.repository.config.DefaultRepositoryConfiguration;
 import org.springframework.data.repository.config.RepositoryBeanNameGenerator;
 import org.springframework.data.repository.config.SpringDataAnnotationBeanNameGenerator;
+import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -429,5 +430,11 @@ public abstract class CdiRepositoryBean<T> implements Bean<T>, PassivationCapabl
 		public String getRepositoryImplementationPostfix() {
 			return DefaultRepositoryConfiguration.DEFAULT_REPOSITORY_IMPLEMENTATION_POSTFIX;
 		}
+
+		@Override
+		public QueryLookupStrategy.Key getQueryLookupStrategy() {
+			return DefaultRepositoryConfiguration.DEFAULT_QUERY_LOOKUP_STRATEGY;
+		}
+
 	}
 }

--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryConfiguration.java
@@ -16,12 +16,14 @@
 
 package org.springframework.data.repository.cdi;
 
+import org.springframework.data.repository.config.DefaultRepositoryConfiguration;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 
 /**
  * Interface containing the configurable options for the Spring Data repository subsystem using CDI.
  *
  * @author Mark Paluch
+ * @author Fabian Henniges
  */
 public interface CdiRepositoryConfiguration {
 
@@ -32,12 +34,13 @@ public interface CdiRepositoryConfiguration {
 	 */
 	String getRepositoryImplementationPostfix();
 
-
 	/**
-	 * Return the strategy to lookup queries
+	 * Return the strategy to lookup queries.
 	 *
-	 * @return the lookup strategy to use
+	 * @return the lookup strategy to use.
+	 * @since 2.1
 	 */
-	QueryLookupStrategy.Key getQueryLookupStrategy();
-
+	default QueryLookupStrategy.Key getQueryLookupStrategy() {
+		return DefaultRepositoryConfiguration.DEFAULT_QUERY_LOOKUP_STRATEGY;
+	}
 }

--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.data.repository.cdi;
 
+import org.springframework.data.repository.query.QueryLookupStrategy;
+
 /**
  * Interface containing the configurable options for the Spring Data repository subsystem using CDI.
  *
@@ -29,4 +31,13 @@ public interface CdiRepositoryConfiguration {
 	 * @return the postfix to use, must not be {@literal null}.
 	 */
 	String getRepositoryImplementationPostfix();
+
+
+	/**
+	 * Return the strategy to lookup queries
+	 *
+	 * @return the lookup strategy to use
+	 */
+	QueryLookupStrategy.Key getQueryLookupStrategy();
+
 }

--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryConfiguration.java
@@ -16,7 +16,10 @@
 
 package org.springframework.data.repository.cdi;
 
-import org.springframework.data.repository.config.DefaultRepositoryConfiguration;
+import java.util.Optional;
+
+import org.springframework.data.repository.core.NamedQueries;
+import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 
 /**
@@ -28,19 +31,52 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
 public interface CdiRepositoryConfiguration {
 
 	/**
+	 * Return the {@link EvaluationContextProvider} to use. Can be {@link Optional#empty()} .
+	 *
+	 * @return the optional {@link EvaluationContextProvider} base to use, can be {@link Optional#empty()}, must not be
+	 *         {@literal null}.
+	 * @since 2.1
+	 */
+	default Optional<EvaluationContextProvider> getEvaluationContextProvider() {
+		return Optional.empty();
+	}
+
+	/**
+	 * Return the {@link NamedQueries} to use. Can be {@link Optional#empty()}.
+	 *
+	 * @return the optional named queries to use, can be {@link Optional#empty()}, must not be {@literal null}.
+	 * @since 2.1
+	 */
+	default Optional<NamedQueries> getNamedQueries() {
+		return Optional.empty();
+	}
+
+	/**
+	 * Return the {@link QueryLookupStrategy.Key} to lookup queries. Can be {@link Optional#empty()}.
+	 *
+	 * @return the lookup strategy to use, can be {@link Optional#empty()}, must not be {@literal null}.
+	 * @since 2.1
+	 */
+	default Optional<QueryLookupStrategy.Key> getQueryLookupStrategy() {
+		return Optional.empty();
+	}
+
+	/**
+	 * Return the {@link Class repository base class} to use. Can be {@link Optional#empty()} .
+	 *
+	 * @return the optional repository base to use, can be {@link Optional#empty()}, must not be {@literal null}.
+	 * @since 2.1
+	 */
+	default Optional<Class<?>> getRepositoryBeanClass() {
+		return Optional.empty();
+	}
+
+	/**
 	 * Returns the configured postfix to be used for looking up custom implementation classes.
 	 *
 	 * @return the postfix to use, must not be {@literal null}.
 	 */
-	String getRepositoryImplementationPostfix();
-
-	/**
-	 * Return the strategy to lookup queries.
-	 *
-	 * @return the lookup strategy to use.
-	 * @since 2.1
-	 */
-	default QueryLookupStrategy.Key getQueryLookupStrategy() {
-		return DefaultRepositoryConfiguration.DEFAULT_QUERY_LOOKUP_STRATEGY;
+	default String getRepositoryImplementationPostfix() {
+		return "Impl";
 	}
 }

--- a/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryContext.java
+++ b/src/main/java/org/springframework/data/repository/cdi/CdiRepositoryContext.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.cdi;
+
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.enterprise.inject.CreationException;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.ClassMetadata;
+import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.config.CustomRepositoryImplementationDetector;
+import org.springframework.data.repository.config.FragmentMetadata;
+import org.springframework.data.repository.config.RepositoryFragmentConfiguration;
+import org.springframework.data.repository.config.RepositoryFragmentDiscovery;
+import org.springframework.data.util.Optionals;
+import org.springframework.data.util.Streamable;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Context for CDI repositories. This class provides {@link ClassLoader} and
+ * {@link org.springframework.data.repository.core.support.RepositoryFragment detection} which are commonly used within
+ * CDI.
+ * 
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class CdiRepositoryContext {
+
+	private final ClassLoader classLoader;
+	private final CustomRepositoryImplementationDetector detector;
+	private final MetadataReaderFactory metadataReaderFactory;
+
+	/**
+	 * Create a new {@link CdiRepositoryContext} given {@link ClassLoader} and initialize
+	 * {@link CachingMetadataReaderFactory}.
+	 * 
+	 * @param classLoader must not be {@literal null}.
+	 */
+	public CdiRepositoryContext(ClassLoader classLoader) {
+
+		Assert.notNull(classLoader, "ClassLoader must not be null!");
+
+		this.classLoader = classLoader;
+
+		Environment environment = new StandardEnvironment();
+		ResourceLoader resourceLoader = new PathMatchingResourcePatternResolver(classLoader);
+
+		this.metadataReaderFactory = new CachingMetadataReaderFactory(resourceLoader);
+		this.detector = new CustomRepositoryImplementationDetector(metadataReaderFactory, environment, resourceLoader);
+	}
+
+	/**
+	 * Create a new {@link CdiRepositoryContext} given {@link ClassLoader} and
+	 * {@link CustomRepositoryImplementationDetector}.
+	 * 
+	 * @param classLoader must not be {@literal null}.
+	 * @param detector must not be {@literal null}.
+	 */
+	public CdiRepositoryContext(ClassLoader classLoader, CustomRepositoryImplementationDetector detector) {
+
+		Assert.notNull(classLoader, "ClassLoader must not be null!");
+		Assert.notNull(detector, "CustomRepositoryImplementationDetector must not be null!");
+
+		ResourceLoader resourceLoader = new PathMatchingResourcePatternResolver(classLoader);
+
+		this.classLoader = classLoader;
+		this.metadataReaderFactory = new CachingMetadataReaderFactory(resourceLoader);
+		this.detector = detector;
+	}
+
+	CustomRepositoryImplementationDetector getCustomRepositoryImplementationDetector() {
+		return detector;
+	}
+
+	/**
+	 * Load a {@link Class} using the CDI {@link ClassLoader}.
+	 * 
+	 * @param className
+	 * @return
+	 * @throws UnsatisfiedResolutionException if the class cannot be found.
+	 */
+	Class<?> loadClass(String className) {
+
+		try {
+			return ClassUtils.forName(className, classLoader);
+		} catch (ClassNotFoundException e) {
+			throw new UnsatisfiedResolutionException(String.format("Unable to resolve class for '%s'", className), e);
+		}
+	}
+
+	/**
+	 * Discover {@link RepositoryFragmentConfiguration fragment configurations} for a {@link Class repository interface}.
+	 * 
+	 * @param configuration must not be {@literal null}.
+	 * @param repositoryInterface must not be {@literal null}.
+	 * @return {@link Stream} of {@link RepositoryFragmentConfiguration fragment configurations}.
+	 */
+	Stream<RepositoryFragmentConfiguration> getRepositoryFragments(CdiRepositoryConfiguration configuration,
+			Class<?> repositoryInterface) {
+
+		ClassMetadata classMetadata = getClassMetadata(metadataReaderFactory, repositoryInterface.getName());
+
+		RepositoryFragmentDiscovery fragmentConfiguration = new CdiRepositoryFragmentDiscovery(configuration);
+
+		return Arrays.stream(classMetadata.getInterfaceNames()) //
+				.filter(it -> FragmentMetadata.isCandidate(it, metadataReaderFactory)) //
+				.map(it -> FragmentMetadata.of(it, fragmentConfiguration)) //
+				.map(this::detectRepositoryFragmentConfiguration) //
+				.flatMap(Optionals::toStream);
+	}
+
+	/**
+	 * Retrieves a custom repository interfaces from a repository type. This works for the whole class hierarchy and can
+	 * find also a custom repository which is inherited over many levels.
+	 *
+	 * @param repositoryType The class representing the repository.
+	 * @param cdiRepositoryConfiguration The configuration for CDI usage.
+	 * @return the interface class or {@literal null}.
+	 */
+	Optional<Class<?>> getCustomImplementationClass(Class<?> repositoryType,
+			CdiRepositoryConfiguration cdiRepositoryConfiguration) {
+
+		String className = getCustomImplementationClassName(repositoryType, cdiRepositoryConfiguration);
+
+		Optional<AbstractBeanDefinition> beanDefinition = detector.detectCustomImplementation( //
+				className, //
+				className, Collections.singleton(repositoryType.getPackage().getName()), //
+				Collections.emptySet(), //
+				BeanDefinition::getBeanClassName);
+
+		return beanDefinition.map(it -> loadClass(it.getBeanClassName()));
+	}
+
+	private Optional<RepositoryFragmentConfiguration> detectRepositoryFragmentConfiguration(
+			FragmentMetadata configuration) {
+
+		String className = configuration.getFragmentImplementationClassName();
+
+		Optional<AbstractBeanDefinition> beanDefinition = detector.detectCustomImplementation(className, null,
+				configuration.getBasePackages(), configuration.getExclusions(), BeanDefinition::getBeanClassName);
+
+		return beanDefinition.map(bd -> new RepositoryFragmentConfiguration(configuration.getFragmentInterfaceName(), bd));
+	}
+
+	private static ClassMetadata getClassMetadata(MetadataReaderFactory metadataReaderFactory, String className) {
+
+		try {
+			return metadataReaderFactory.getMetadataReader(className).getClassMetadata();
+		} catch (IOException e) {
+			throw new CreationException(String.format("Cannot parse %s metadata.", className), e);
+		}
+	}
+
+	private static String getCustomImplementationClassName(Class<?> repositoryType,
+			CdiRepositoryConfiguration cdiRepositoryConfiguration) {
+
+		String configuredPostfix = cdiRepositoryConfiguration.getRepositoryImplementationPostfix();
+		Assert.hasText(configuredPostfix, "Configured repository postfix must not be null or empty!");
+
+		return ClassUtils.getShortName(repositoryType) + configuredPostfix;
+	}
+
+	@RequiredArgsConstructor
+	private static class CdiRepositoryFragmentDiscovery implements RepositoryFragmentDiscovery {
+
+		private final CdiRepositoryConfiguration configuration;
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.config.RepositoryFragmentDiscovery#getExcludeFilters()
+		 */
+		@Override
+		public Streamable<TypeFilter> getExcludeFilters() {
+			return Streamable.of(new AnnotationTypeFilter(NoRepositoryBean.class));
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.config.RepositoryFragmentDiscovery#getRepositoryImplementationPostfix()
+		 */
+		@Override
+		public Optional<String> getRepositoryImplementationPostfix() {
+			return Optional.of(configuration.getRepositoryImplementationPostfix());
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -41,7 +41,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 		implements RepositoryConfiguration<T> {
 
 	public static final String DEFAULT_REPOSITORY_IMPLEMENTATION_POSTFIX = "Impl";
-	private static final Key DEFAULT_QUERY_LOOKUP_STRATEGY = Key.CREATE_IF_NOT_FOUND;
+	public static final Key DEFAULT_QUERY_LOOKUP_STRATEGY = Key.CREATE_IF_NOT_FOUND;
 
 	private final @NonNull T configurationSource;
 	private final @NonNull BeanDefinition definition;

--- a/src/main/java/org/springframework/data/repository/config/FragmentMetadata.java
+++ b/src/main/java/org/springframework/data/repository/config/FragmentMetadata.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import lombok.Value;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.util.StreamUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Value object for a discovered Repository fragment interface.
+ * 
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@Value(staticConstructor = "of")
+public class FragmentMetadata {
+
+	private String fragmentInterfaceName;
+	private RepositoryFragmentDiscovery configuration;
+
+	/**
+	 * Returns whether the given interface is a fragment candidate.
+	 *
+	 * @param interfaceName must not be {@literal null} or empty.
+	 * @param factory must not be {@literal null}.
+	 * @return
+	 */
+	public static boolean isCandidate(String interfaceName, MetadataReaderFactory factory) {
+
+		Assert.hasText(interfaceName, "Interface name must not be null or empty!");
+		Assert.notNull(factory, "MetadataReaderFactory must not be null!");
+
+		AnnotationMetadata metadata = getAnnotationMetadata(interfaceName, factory);
+
+		return !metadata.hasAnnotation(NoRepositoryBean.class.getName());
+	}
+
+	/**
+	 * Returns the exclusions to be used when scanning for fragment implementations.
+	 *
+	 * @return
+	 */
+	public List<TypeFilter> getExclusions() {
+
+		Stream<TypeFilter> configurationExcludes = configuration.getExcludeFilters().stream();
+		Stream<AnnotationTypeFilter> noRepositoryBeans = Stream.of(new AnnotationTypeFilter(NoRepositoryBean.class));
+
+		return Stream.concat(configurationExcludes, noRepositoryBeans).collect(StreamUtils.toUnmodifiableList());
+	}
+
+	/**
+	 * Returns the name of the implementation class to be detected for the fragment interface.
+	 *
+	 * @return
+	 */
+	public String getFragmentImplementationClassName() {
+
+		String postfix = configuration.getRepositoryImplementationPostfix().orElse("Impl");
+
+		return ClassUtils.getShortName(fragmentInterfaceName).concat(postfix);
+	}
+
+	/**
+	 * Returns the base packages to be scanned to find implementations of the current fragment interface.
+	 *
+	 * @return
+	 */
+	public Iterable<String> getBasePackages() {
+		return Collections.singleton(ClassUtils.getPackageName(fragmentInterfaceName));
+	}
+
+	private static AnnotationMetadata getAnnotationMetadata(String className,
+			MetadataReaderFactory metadataReaderFactory) {
+
+		try {
+			return metadataReaderFactory.getMetadataReader(className).getAnnotationMetadata();
+		} catch (IOException e) {
+			throw new BeanDefinitionStoreException(String.format("Cannot parse %s metadata.", className), e);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentDiscovery.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentDiscovery.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import java.util.Optional;
+
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.data.util.Streamable;
+
+/**
+ * Interface containing the configurable options for the Spring Data repository fragment subsystem.
+ * 
+ * @author Mark Paluch
+ * @since 2.1
+ * @see RepositoryConfigurationSource
+ */
+public interface RepositoryFragmentDiscovery {
+
+	/**
+	 * Returns the {@link TypeFilter}s to be used to exclude packages from repository scanning.
+	 *
+	 * @return
+	 */
+	Streamable<TypeFilter> getExcludeFilters();
+
+	/**
+	 * Returns the configured postfix to be used for looking up custom implementation classes.
+	 *
+	 * @return the postfix to use or {@link Optional#empty()} in case none is configured.
+	 */
+	Optional<String> getRepositoryImplementationPostfix();
+}

--- a/src/test/java/org/springframework/data/repository/cdi/AnotherFragmentInterface.java
+++ b/src/test/java/org/springframework/data/repository/cdi/AnotherFragmentInterface.java
@@ -18,10 +18,9 @@ package org.springframework.data.repository.cdi;
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+public interface AnotherFragmentInterface {
 
-	@Override
-	public int returnZero() {
-		return 0;
-	}
+	int getPriority();
+
+	int getShadowed();
 }

--- a/src/test/java/org/springframework/data/repository/cdi/AnotherFragmentInterfaceImpl.java
+++ b/src/test/java/org/springframework/data/repository/cdi/AnotherFragmentInterfaceImpl.java
@@ -18,10 +18,15 @@ package org.springframework.data.repository.cdi;
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+class AnotherFragmentInterfaceImpl implements AnotherFragmentInterface {
 
 	@Override
-	public int returnZero() {
-		return 0;
+	public int getPriority() {
+		return 2;
+	}
+
+	@Override
+	public int getShadowed() {
+		return 2;
 	}
 }

--- a/src/test/java/org/springframework/data/repository/cdi/CdiConfigurationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/cdi/CdiConfigurationIntegrationTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.cdi;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.data.repository.cdi.isolated.IsolatedComposedRepository;
+
+/**
+ * CDI integration tests for {@link CdiRepositoryConfiguration}.
+ * 
+ * @author Mark Paluch
+ */
+public class CdiConfigurationIntegrationTests {
+
+	private static SeContainer container;
+
+	@BeforeClass
+	public static void setUp() {
+
+		container = SeContainerInitializer.newInstance() //
+				.disableDiscovery() //
+				.addPackages(IsolatedComposedRepository.class) //
+				.initialize();
+	}
+
+	@Test // DATACMNS-1233
+	public void shouldApplyImplementationPostfix() {
+
+		IsolatedComposedRepository repository = container.select(IsolatedComposedRepository.class).get();
+
+		assertThat(repository.getPriority()).isEqualTo(42);
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		container.close();
+	}
+}

--- a/src/test/java/org/springframework/data/repository/cdi/CdiRepositoryBeanUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/cdi/CdiRepositoryBeanUnitTests.java
@@ -155,14 +155,14 @@ public class CdiRepositoryBeanUnitTests {
 
 		verify(detector).detectCustomImplementation( //
 				eq("CdiRepositoryBeanUnitTests.SampleRepositoryImpl"), //
-				eq("namedRepositoryImpl"), //
+				eq("CdiRepositoryBeanUnitTests.SampleRepositoryImpl"), //
 				anySet(), //
 				anySet(), //
 				Mockito.any(Function.class) //
 		);
 	}
 
-	@Test // DATACMNS-1255
+	@Test // DATACMNS-1233
 	public void appliesRepositoryConfiguration() {
 
 		DummyCdiRepositoryBean<SampleRepository> bean = new DummyCdiRepositoryBean<SampleRepository>(NO_ANNOTATIONS,

--- a/src/test/java/org/springframework/data/repository/cdi/ComposedRepository.java
+++ b/src/test/java/org/springframework/data/repository/cdi/ComposedRepository.java
@@ -15,13 +15,17 @@
  */
 package org.springframework.data.repository.cdi;
 
+import java.io.Serializable;
+
+import org.springframework.data.repository.Repository;
+
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+public interface ComposedRepository
+		extends Repository<Object, Serializable>, FragmentInterface, AnotherFragmentInterface {
 
-	@Override
-	public int returnZero() {
-		return 0;
-	}
+	// duplicate method shadowed by AnotherFragmentInterfaceImpl. The legacy custom implementation comes last, after all
+	// other fragments.
+	int getShadowed();
 }

--- a/src/test/java/org/springframework/data/repository/cdi/ComposedRepositoryCustom.java
+++ b/src/test/java/org/springframework/data/repository/cdi/ComposedRepositoryCustom.java
@@ -18,10 +18,12 @@ package org.springframework.data.repository.cdi;
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+public interface ComposedRepositoryCustom {
 
-	@Override
-	public int returnZero() {
-		return 0;
-	}
+	int returnFourtyTwo();
+
+	// duplicate method shadowed by AnotherFragmentInterfaceImpl. The legacy custom implementation comes last, after all
+	// other
+	// fragments.
+	int getShadowed();
 }

--- a/src/test/java/org/springframework/data/repository/cdi/ComposedRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/cdi/ComposedRepositoryImpl.java
@@ -18,10 +18,15 @@ package org.springframework.data.repository.cdi;
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+class ComposedRepositoryImpl implements ComposedRepositoryCustom {
 
 	@Override
-	public int returnZero() {
-		return 0;
+	public int returnFourtyTwo() {
+		return 42;
+	}
+
+	@Override
+	public int getShadowed() {
+		return 1;
 	}
 }

--- a/src/test/java/org/springframework/data/repository/cdi/DummyCdiExtension.java
+++ b/src/test/java/org/springframework/data/repository/cdi/DummyCdiExtension.java
@@ -24,16 +24,15 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.enterprise.context.NormalScope;
-import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.BeanManager;
 
 import org.apache.webbeans.context.AbstractContext;
-import org.apache.webbeans.context.creational.BeanInstanceBag;
 import org.mockito.Mockito;
 import org.springframework.data.repository.config.CustomRepositoryImplementationDetector;
+import org.springframework.data.repository.core.support.DummyRepositoryFactory;
 
 /**
  * Dummy extension of {@link CdiRepositoryExtensionSupport} to allow integration tests. Will create mocks for repository
@@ -74,9 +73,12 @@ public class DummyCdiExtension extends CdiRepositoryExtensionSupport {
 		}
 
 		@Override
-		protected T create(CreationalContext<T> creationalContext, Class<T> repositoryType,
-				Optional<Object> customImplementation) {
-			return Mockito.mock(repositoryType);
+		protected T create(CreationalContext<T> creationalContext, Class<T> repositoryType) {
+
+			T mock = Mockito.mock(repositoryType);
+			DummyRepositoryFactory repositoryFactory = new DummyRepositoryFactory(mock);
+
+			return create(repositoryFactory, repositoryType, getRepositoryFragments(repositoryType));
 		}
 	}
 

--- a/src/test/java/org/springframework/data/repository/cdi/FragmentInterface.java
+++ b/src/test/java/org/springframework/data/repository/cdi/FragmentInterface.java
@@ -18,10 +18,6 @@ package org.springframework.data.repository.cdi;
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
-
-	@Override
-	public int returnZero() {
-		return 0;
-	}
+public interface FragmentInterface {
+	int getPriority();
 }

--- a/src/test/java/org/springframework/data/repository/cdi/FragmentInterfaceImpl.java
+++ b/src/test/java/org/springframework/data/repository/cdi/FragmentInterfaceImpl.java
@@ -18,10 +18,10 @@ package org.springframework.data.repository.cdi;
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+class FragmentInterfaceImpl implements FragmentInterface {
 
 	@Override
-	public int returnZero() {
-		return 0;
+	public int getPriority() {
+		return 1;
 	}
 }

--- a/src/test/java/org/springframework/data/repository/cdi/RepositoryFragmentsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/cdi/RepositoryFragmentsIntegrationTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.cdi;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * CDI integration tests for composed repositories.
+ * 
+ * @author Mark Paluch
+ */
+public class RepositoryFragmentsIntegrationTests {
+
+	private static SeContainer container;
+
+	@BeforeClass
+	public static void setUp() {
+
+		container = SeContainerInitializer.newInstance() //
+				.disableDiscovery() //
+				.addPackages(ComposedRepository.class) //
+				.initialize();
+	}
+
+	@Test // DATACMNS-1233
+	public void shouldInvokeCustomImplementationLast() {
+
+		ComposedRepository repository = getBean(ComposedRepository.class);
+		ComposedRepositoryImpl customImplementation = getBean(ComposedRepositoryImpl.class);
+		AnotherFragmentInterfaceImpl shadowed = getBean(AnotherFragmentInterfaceImpl.class);
+
+		assertThat(repository.getShadowed()).isEqualTo(2);
+		assertThat(customImplementation.getShadowed()).isEqualTo(1);
+		assertThat(shadowed.getShadowed()).isEqualTo(2);
+	}
+
+	@Test // DATACMNS-1233
+	public void shouldRespectInterfaceOrder() {
+
+		ComposedRepository repository = getBean(ComposedRepository.class);
+		FragmentInterfaceImpl fragment = getBean(FragmentInterfaceImpl.class);
+		AnotherFragmentInterfaceImpl shadowed = getBean(AnotherFragmentInterfaceImpl.class);
+
+		assertThat(repository.getPriority()).isEqualTo(1);
+		assertThat(fragment.getPriority()).isEqualTo(1);
+		assertThat(shadowed.getPriority()).isEqualTo(2);
+	}
+
+	protected <T> T getBean(Class<T> type) {
+		return container.select(type).get();
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		container.close();
+	}
+}

--- a/src/test/java/org/springframework/data/repository/cdi/isolated/FragmentInterface.java
+++ b/src/test/java/org/springframework/data/repository/cdi/isolated/FragmentInterface.java
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.cdi;
+package org.springframework.data.repository.cdi.isolated;
 
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+public interface FragmentInterface {
 
-	@Override
-	public int returnZero() {
-		return 0;
-	}
+	int getPriority();
 }

--- a/src/test/java/org/springframework/data/repository/cdi/isolated/FragmentInterfaceFoo.java
+++ b/src/test/java/org/springframework/data/repository/cdi/isolated/FragmentInterfaceFoo.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.cdi;
+package org.springframework.data.repository.cdi.isolated;
 
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+class FragmentInterfaceFoo implements FragmentInterface {
 
 	@Override
-	public int returnZero() {
-		return 0;
+	public int getPriority() {
+		return 42;
 	}
 }

--- a/src/test/java/org/springframework/data/repository/cdi/isolated/IsolatedComposedRepository.java
+++ b/src/test/java/org/springframework/data/repository/cdi/isolated/IsolatedComposedRepository.java
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.cdi;
+package org.springframework.data.repository.cdi.isolated;
+
+import java.io.Serializable;
+
+import org.springframework.data.repository.Repository;
 
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
-
-	@Override
-	public int returnZero() {
-		return 0;
-	}
-}
+public interface IsolatedComposedRepository extends Repository<Object, Serializable>, FragmentInterface {}

--- a/src/test/java/org/springframework/data/repository/cdi/isolated/MyCdiConfiguration.java
+++ b/src/test/java/org/springframework/data/repository/cdi/isolated/MyCdiConfiguration.java
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.cdi;
+package org.springframework.data.repository.cdi.isolated;
+
+import org.springframework.data.repository.cdi.CdiRepositoryConfiguration;
 
 /**
  * @author Mark Paluch
  */
-class AnotherRepositoryImpl implements AnotherRepositoryCustom {
+public class MyCdiConfiguration implements CdiRepositoryConfiguration {
 
 	@Override
-	public int returnZero() {
-		return 0;
+	public String getRepositoryImplementationPostfix() {
+		return "Foo";
 	}
 }


### PR DESCRIPTION
We now support repository fragments for repositories exported through CDI.

This pull request picks up changes from [DATACMNS-1255](https://jira.spring.io/browse/DATACMNS-1255) via #271 as changes in `CdiRepositoryBean` are somewhat related.

---

Related tickets: [DATACMNS-1255](https://jira.spring.io/browse/DATACMNS-1255), [DATACMNS-1233](https://jira.spring.io/browse/DATACMNS-1233).