### PR TITLE
 DATACMNS-1259 - Fixed support for Long values in Auditables.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1259-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactory.java
@@ -19,6 +19,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
@@ -42,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Jens Schauder
  * @since 1.5
  */
 class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory {
@@ -207,8 +209,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 				return conversionService.convert(date, targetType);
 			}
 
-			throw new IllegalArgumentException(String.format("Invalid date type for member %s! Supported types are %s.",
-					source, AnnotationAuditingMetadata.SUPPORTED_DATE_TYPES));
+			throw new IllegalArgumentException(createUnsupportedTypeErrorMessage(source));
 		}
 
 		/**
@@ -228,17 +229,22 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 					return (T) it;
 				}
 
-				Class<?> typeToConvertTo = Stream.of(target, LocalDateTime.class)//
+				Class<?> typeToConvertTo = Stream.of(target, Instant.class)//
 						.filter(type -> target.isAssignableFrom(type))//
 						.filter(type -> conversionService.canConvert(it.getClass(), type))//
 						.findFirst()
 						.orElseThrow(() -> new IllegalArgumentException(
-								String.format("Invalid date type for member %s! Supported types are %s.", source,
-										AnnotationAuditingMetadata.SUPPORTED_DATE_TYPES)));
+								createUnsupportedTypeErrorMessage(((Optional<Object>)source).orElseGet(() -> source))));
 
 				return (T) conversionService.convert(it, typeToConvertTo);
 			});
 		}
+	}
+
+	private static String createUnsupportedTypeErrorMessage(Object source) {
+
+		return String.format("Invalid date type %s for member %s! Supported types are %s.", source.getClass(), source,
+				AnnotationAuditingMetadata.SUPPORTED_DATE_TYPES);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactory.java
@@ -113,7 +113,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 		public TemporalAccessor setCreatedDate(TemporalAccessor value) {
 
 			auditable.setCreatedDate(
-					getAsTemporalAccessor(Optional.of(value), type).orElseThrow(() -> new IllegalStateException()));
+					getAsTemporalAccessor(Optional.of(value), type).orElseThrow(IllegalStateException::new));
 
 			return value;
 		}
@@ -147,7 +147,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 		public TemporalAccessor setLastModifiedDate(TemporalAccessor value) {
 
 			auditable.setLastModifiedDate(
-					getAsTemporalAccessor(Optional.of(value), type).orElseThrow(() -> new IllegalStateException()));
+					getAsTemporalAccessor(Optional.of(value), type).orElseThrow(IllegalStateException::new));
 
 			return value;
 		}
@@ -220,7 +220,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 		 * @return
 		 */
 		@SuppressWarnings("unchecked")
-		protected <T extends TemporalAccessor> Optional<T> getAsTemporalAccessor(Optional<? extends Object> source,
+		protected <T extends TemporalAccessor> Optional<T> getAsTemporalAccessor(Optional<?> source,
 				Class<? extends T> target) {
 
 			return source.map(it -> {

--- a/src/main/java/org/springframework/data/convert/JodaTimeConverters.java
+++ b/src/main/java/org/springframework/data/convert/JodaTimeConverters.java
@@ -15,16 +15,19 @@
  */
 package org.springframework.data.convert;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import javax.annotation.Nonnull;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.springframework.core.convert.converter.Converter;
@@ -65,6 +68,9 @@ public abstract class JodaTimeConverters {
 		converters.add(LocalDateTimeToJodaLocalDateTime.INSTANCE);
 		converters.add(LocalDateTimeToJodaDateTime.INSTANCE);
 
+		converters.add(InstantToJodaLocalDateTime.INSTANCE);
+		converters.add(JodaLocalDateTimeToInstant.INSTANCE);
+
 		converters.add(LocalDateTimeToJsr310Converter.INSTANCE);
 
 		return converters;
@@ -77,7 +83,7 @@ public abstract class JodaTimeConverters {
 		@Nonnull
 		@Override
 		public java.time.LocalDateTime convert(LocalDateTime source) {
-			return java.time.LocalDateTime.ofInstant(source.toDate().toInstant(), ZoneId.of("UTC"));
+			return java.time.LocalDateTime.ofInstant(source.toDate().toInstant(), ZoneId.systemDefault());
 		}
 	}
 
@@ -155,6 +161,28 @@ public abstract class JodaTimeConverters {
 		@Override
 		public LocalDateTime convert(java.time.LocalDateTime source) {
 			return LocalDateTime.fromDateFields(Jsr310Converters.LocalDateTimeToDateConverter.INSTANCE.convert(source));
+		}
+	}
+
+	public enum InstantToJodaLocalDateTime implements Converter<java.time.Instant, LocalDateTime> {
+
+		INSTANCE;
+
+		@Nonnull
+		@Override
+		public LocalDateTime convert(java.time.Instant source) {
+			return LocalDateTime.fromDateFields(new Date(source.toEpochMilli()));
+		}
+	}
+
+	public enum JodaLocalDateTimeToInstant implements Converter<LocalDateTime, Instant> {
+
+		INSTANCE;
+
+		@Nonnull
+		@Override
+		public Instant convert(LocalDateTime source) {
+			return Instant.ofEpochMilli(source.toDateTime().getMillis());
 		}
 	}
 

--- a/src/main/java/org/springframework/data/convert/ThreeTenBackPortConverters.java
+++ b/src/main/java/org/springframework/data/convert/ThreeTenBackPortConverters.java
@@ -36,6 +36,7 @@ import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.LocalTime;
 import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZoneOffset;
 
 /**
  * Helper class to register {@link Converter} implementations for the ThreeTen Backport project in case it's present on
@@ -43,6 +44,7 @@ import org.threeten.bp.ZoneId;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Jens Schauder
  * @see <a href="http://www.threeten.org/threetenbp">http://www.threeten.org/threetenbp</a>
  * @since 1.10
  */
@@ -74,6 +76,8 @@ public abstract class ThreeTenBackPortConverters {
 		converters.add(ZoneIdToStringConverter.INSTANCE);
 		converters.add(StringToZoneIdConverter.INSTANCE);
 		converters.add(LocalDateTimeToJsr310LocalDateTimeConverter.INSTANCE);
+		converters.add(LocalDateTimeToJavaTimeInstantConverter.INSTANCE);
+		converters.add(JavaTimeInstantToLocalDateTimeConverter.INSTANCE);
 
 		return converters;
 	}
@@ -84,7 +88,7 @@ public abstract class ThreeTenBackPortConverters {
 			return false;
 		}
 
-		return Arrays.<Class<?>> asList(LocalDateTime.class, LocalDate.class, LocalTime.class, Instant.class)
+		return Arrays.<Class<?>> asList(LocalDateTime.class, LocalDate.class, LocalTime.class, Instant.class, java.time.Instant.class)
 				.contains(type);
 	}
 
@@ -192,6 +196,28 @@ public abstract class ThreeTenBackPortConverters {
 		@Override
 		public Date convert(Instant source) {
 			return toDate(source.atZone(systemDefault()).toInstant());
+		}
+	}
+
+	public static enum LocalDateTimeToJavaTimeInstantConverter implements Converter<LocalDateTime, java.time.Instant> {
+
+		INSTANCE;
+
+		@Nonnull
+		@Override
+		public java.time.Instant convert(LocalDateTime source) {
+			return java.time.Instant.ofEpochMilli(source.atZone(ZoneOffset.systemDefault()).toInstant().toEpochMilli());
+		}
+	}
+
+	public static enum JavaTimeInstantToLocalDateTimeConverter implements Converter<java.time.Instant, LocalDateTime> {
+
+		INSTANCE;
+
+		@Nonnull
+		@Override
+		public LocalDateTime convert(java.time.Instant source) {
+			return LocalDateTime.ofInstant(Instant.ofEpochMilli(source.toEpochMilli()), ZoneOffset.systemDefault());
 		}
 	}
 

--- a/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.*;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Collections;
@@ -27,6 +29,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Optional;
 
+import org.assertj.core.api.AbstractLongAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.annotation.CreatedBy;
@@ -45,6 +48,7 @@ import org.springframework.data.mapping.context.SampleMappingContext;
  * Unit tests for {@link MappingAuditableBeanWrapperFactory}.
  *
  * @author Oliver Gierke
+ * @author Jens Schauder
  * @since 1.8
  */
 public class MappingAuditableBeanWrapperFactoryUnitTests {
@@ -169,6 +173,14 @@ public class MappingAuditableBeanWrapperFactoryUnitTests {
 		assertThat(wrapper.flatMap(it -> it.getLastModifiedDate())).hasValue(sample.modified);
 	}
 
+	@Test // DATACMNS-1259
+	public void exposesLongAsModificationDate() {
+
+		Long reference = new Date().getTime();
+
+		assertLastModificationDate(reference, Instant.ofEpochMilli(reference));
+	}
+
 	private void assertLastModificationDate(Object source, TemporalAccessor expected) {
 
 		Sample sample = new Sample();
@@ -176,7 +188,27 @@ public class MappingAuditableBeanWrapperFactoryUnitTests {
 
 		Optional<AuditableBeanWrapper> wrapper = factory.getBeanWrapperFor(sample);
 
-		assertThat(wrapper.flatMap(it -> it.getLastModifiedDate())).hasValue(expected);
+		assertThat(wrapper.flatMap(it -> it.getLastModifiedDate())).hasValueSatisfying(ta -> {
+			compareTemporalAccessors(expected, ta);
+		});
+	}
+
+	private AbstractLongAssert<?> compareTemporalAccessors(TemporalAccessor expected, TemporalAccessor actual) {
+
+		long actualSeconds = getInstantSeconds(actual);
+		long expectedSeconds = getInstantSeconds(expected);
+
+		return assertThat(actualSeconds).describedAs("Difference is %s", actualSeconds - expectedSeconds)
+				.isEqualTo(expectedSeconds);
+	}
+
+	private long getInstantSeconds(TemporalAccessor actual) {
+
+		if (actual instanceof LocalDateTime) {
+			return getInstantSeconds(((LocalDateTime) actual).atZone(ZoneOffset.systemDefault()));
+		}
+
+		return actual.getLong(ChronoField.INSTANT_SECONDS);
 	}
 
 	static class Sample {

--- a/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
@@ -163,7 +163,7 @@ public class MappingAuditableBeanWrapperFactoryUnitTests {
 				ThreeTenBackPortConverters.LocalDateTimeToJsr310LocalDateTimeConverter.INSTANCE.convert(reference));
 	}
 
-	@Test
+	@Test // DATACMNS-1109
 	public void exposesInstantAsModificationDate() {
 
 		SampleWithInstant sample = new SampleWithInstant();


### PR DESCRIPTION
Using Instant as internal data type since it's a point in time without time zone which LocalDateTime isn't.
Added necessary converters.
Fixed one JodaTime converter that used UTC to use SystemDefault like other similar converters.

In case of a conversion failure, the error message now contains the source type.