### PR TITLE
DATAJPA-1003 - Modifying the method that create a Projection for a interface to also create a projection for a non final Class using CGLIB proxy.

### DIFF
--- a/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
+++ b/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
@@ -41,6 +41,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Bernardo Maia
  * @see SpelAwareProxyProjectionFactory
  * @since 1.10
  */

--- a/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
+++ b/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
@@ -96,7 +96,6 @@ class ProxyProjectionFactory implements ProjectionFactory, BeanClassLoaderAware 
 
 		Assert.notNull(projectionType, "Projection type must not be null!");
 		Assert.notNull(source, "Source must not be null!");
-		Assert.isTrue(projectionType.isInterface(), "Projection type must be an interface!");
 
 		if (projectionType.isInstance(source)) {
 			return (T) source;
@@ -105,7 +104,13 @@ class ProxyProjectionFactory implements ProjectionFactory, BeanClassLoaderAware 
 		ProxyFactory factory = new ProxyFactory();
 		factory.setTarget(source);
 		factory.setOpaque(true);
-		factory.setInterfaces(projectionType, TargetAware.class);
+
+		if (projectionType.isInterface()) {
+			factory.setInterfaces(projectionType, TargetAware.class);
+		} else {
+			factory.setTargetClass(projectionType);
+			factory.setProxyTargetClass(true);
+		}
 
 		factory.addAdvice(new DefaultMethodInvokingMethodInterceptor());
 		factory.addAdvice(new TargetAwareMethodInterceptor(source.getClass()));

--- a/src/main/java/org/springframework/data/repository/query/ResultProcessor.java
+++ b/src/main/java/org/springframework/data/repository/query/ResultProcessor.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import org.springframework.cglib.core.TypeUtils;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
@@ -286,7 +287,7 @@ public class ResultProcessor {
 
 			Class<?> targetType = type.getReturnedType();
 
-			if (targetType.isInterface()) {
+			if (targetType.isInterface() || !TypeUtils.isFinal(targetType.getModifiers())) {
 				return factory.createProjection(targetType, getProjectionTarget(source));
 			}
 

--- a/src/main/java/org/springframework/data/repository/query/ResultProcessor.java
+++ b/src/main/java/org/springframework/data/repository/query/ResultProcessor.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author John Blum
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Bernardo Maia
  * @since 1.12
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import lombok.Data;
 import org.junit.Test;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.TargetClassAware;
@@ -80,11 +81,6 @@ public class ProxyProjectionFactoryUnitTests {
 
 		assertThat(proxy).isInstanceOf(TargetClassAware.class);
 		assertThat(((TargetClassAware) proxy).getTargetClass()).isEqualTo(HashMap.class);
-	}
-
-	@Test(expected = IllegalArgumentException.class) // DATAREST-221, DATACMNS-630
-	public void rejectsNonInterfacesAsProjectionTarget() {
-		factory.createProjection(Object.class, new Object());
 	}
 
 	@Test // DATACMNS-630
@@ -216,6 +212,24 @@ public class ProxyProjectionFactoryUnitTests {
 		assertThat(factory.createProjection(Contact.class, customer)).isSameAs(customer);
 	}
 
+	@Test // DATAJPA-1003
+	public void createsProjectingClassProxy() {
+
+		Employeer employeer = new Employeer();
+		employeer.setName("Company x");
+
+		Employee employee = new Employee();
+		employee.firstname = "Dave";
+		employee.lastname = "Matthews";
+
+		employeer.setEmployee(employee);
+
+		EmployeerExpect employeerExpect = factory.createProjection(EmployeerExpect.class, employeer);
+
+		assertThat(employeerExpect.getName()).isEqualTo("Company x");
+		assertThat(employeerExpect.getEmployee().getFirstname()).isEqualTo("Dave");
+	}
+
 	interface Contact {}
 
 	static class Customer implements Contact {
@@ -258,5 +272,27 @@ public class ProxyProjectionFactoryUnitTests {
 		String getFirstname();
 
 		void setFirstname(String firstname);
+	}
+
+	@Data
+	public class Employee {
+		String firstname, lastname;
+	}
+
+	@Data
+	public class EmployeeExpect {
+		String firstname, lastname;
+	}
+
+	@Data
+	public class Employeer {
+		String name;
+		Employee employee;
+	}
+
+	@Data
+	public class EmployeerExpect {
+		String name;
+		Employee employee;
 	}
 }

--- a/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
@@ -35,6 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * Unit tests for {@link ProxyProjectionFactory}.
  *
  * @author Oliver Gierke
+ * @author Bernardo Maia
  */
 public class ProxyProjectionFactoryUnitTests {
 

--- a/src/test/java/org/springframework/data/repository/query/ResultProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ResultProcessorUnitTests.java
@@ -51,6 +51,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Bernardo Maia
  */
 public class ResultProcessorUnitTests {
 

--- a/src/test/java/org/springframework/data/repository/query/ResultProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ResultProcessorUnitTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import io.reactivex.Flowable;
+import lombok.Data;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import rx.Observable;
@@ -308,6 +309,18 @@ public class ResultProcessorUnitTests {
 		assertThat(content.get(0)).isInstanceOf(SampleProjection.class);
 	}
 
+	@Test // DATAJPA-1003
+	public void createsListOfProjectionsClassFromEntity() throws Exception {
+
+		ResultProcessor information = getProcessor("findAllProjectionClass");
+
+		List<Sample> source = new ArrayList<>(Collections.singletonList(new Sample("Dave", "Matthews")));
+		List<SampleProjectionClass> result = information.processResult(source);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).getLastname()).isEqualTo("Matthews");
+	}
+
 	private static ResultProcessor getProcessor(String methodName, Class<?>... parameters) throws Exception {
 		return getQueryMethod(methodName, parameters).getResultProcessor();
 	}
@@ -326,6 +339,8 @@ public class ResultProcessorUnitTests {
 		List<SampleDto> findAllDtos();
 
 		List<SampleProjection> findAllProjection();
+
+		List<SampleProjectionClass> findAllProjectionClass();
 
 		Sample findOne();
 
@@ -385,6 +400,11 @@ public class ResultProcessorUnitTests {
 
 		@Value("#{target.firstname + ' ' + target.lastname}")
 		String getFullName();
+	}
+
+	@Data
+	public class SampleProjectionClass {
+		String firstname, lastname;
 	}
 
 	static class SpecialList<E> extends ArrayList<E> {


### PR DESCRIPTION
Hi,

I´ve made some changes that will allow work with projection using Class instead of only Interface. The bug was reported for query annoted with @Query but Native queries using @Query was not working as well.

With these changes If the class is not a interface and a non final class, the createProjection method going to use CGLIB-based proxy. Otherwise will continue using the default converters.

thanks.


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
