### PR TITLE
DATACMNS-1275 - Introduced MappingContext.findPersistentPropertyPaths(Class<?>, Predicate<P>).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1275-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/PersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentProperty.java
@@ -21,9 +21,11 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * @author Graeme Rocher
@@ -67,21 +69,9 @@ public interface PersistentProperty<P extends PersistentProperty<P>> {
 	 * {@literal null} in case it refers to a simple type. Will return {@link Collection}'s component type or the
 	 * {@link Map}'s value type transparently.
 	 *
-	 * @deprecated Use getPersistentEntityTypes instead.
-	 */
-	@Deprecated
-	Iterable<? extends TypeInformation<?>> getPersistentEntityType();
-
-	/**
-	 * Returns the {@link TypeInformation} if the property references a {@link PersistentEntity}. Will return
-	 * {@literal null} in case it refers to a simple type. Will return {@link Collection}'s component type or the
-	 * {@link Map}'s value type transparently.
-	 *
 	 * @return
 	 */
-	default Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
-		return getPersistentEntityType();
-	};
+	Iterable<? extends TypeInformation<?>> getPersistentEntityTypes();
 
 	/**
 	 * Returns the getter method to access the property value if available. Might return {@literal null} in case there is
@@ -328,4 +318,19 @@ public interface PersistentProperty<P extends PersistentProperty<P>> {
 	 * @return
 	 */
 	boolean usePropertyAccess();
+
+	/**
+	 * Returns whether the actual type of the property carries the given annotation.
+	 * 
+	 * @param annotationType must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see #getActualType()
+	 */
+	default boolean hasActualTypeAnnotation(Class<? extends Annotation> annotationType) {
+
+		Assert.notNull(annotationType, "Annotation type must not be null!");
+
+		return AnnotatedElementUtils.hasAnnotation(getActualType(), annotationType);
+	}
 }

--- a/src/main/java/org/springframework/data/mapping/PersistentPropertyAccessor.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentPropertyAccessor.java
@@ -17,6 +17,7 @@ package org.springframework.data.mapping;
 
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * Domain service to allow accessing and setting {@link PersistentProperty}s of an entity. Usually obtained through
@@ -41,6 +42,37 @@ public interface PersistentPropertyAccessor {
 	void setProperty(PersistentProperty<?> property, @Nullable Object value);
 
 	/**
+	 * Sets the given value for the {@link PersistentProperty} pointed to by the given {@link PersistentPropertyPath}. The
+	 * lookup of intermediate values must not yield {@literal null}.
+	 * 
+	 * @param path must not be {@literal null} or empty.
+	 * @param value can be {@literal null}.
+	 * @since 2.1
+	 */
+	default void setProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, @Nullable Object value) {
+
+		Assert.notNull(path, "PersistentPropertyPath must not be null!");
+		Assert.isTrue(!path.isEmpty(), "PersistentPropertyPath must not be empty!");
+
+		PersistentPropertyPath<? extends PersistentProperty<?>> parentPath = path.getParentPath();
+		PersistentProperty<?> leafProperty = path.getRequiredLeafProperty();
+
+		Object parent = parentPath.isEmpty() ? getBean() : getProperty(parentPath);
+
+		if (parent == null) {
+
+			String nullIntermediateMessage = "Cannot lookup property %s on null intermediate! Original path was: %s on %s.";
+
+			throw new MappingException(String.format(nullIntermediateMessage, parentPath.getLeafProperty(), path.toDotPath(),
+					getBean().getClass().getName()));
+		}
+
+		PersistentPropertyAccessor accessor = leafProperty.getOwner().getPropertyAccessor(parent);
+
+		accessor.setProperty(leafProperty, value);
+	}
+
+	/**
 	 * Returns the value of the given {@link PersistentProperty} of the underlying bean instance.
 	 *
 	 * @param property must not be {@literal null}.
@@ -48,6 +80,43 @@ public interface PersistentPropertyAccessor {
 	 */
 	@Nullable
 	Object getProperty(PersistentProperty<?> property);
+
+	/**
+	 * Return the value pointed to by the given {@link PersistentPropertyPath}. If the given path is empty, the wrapped
+	 * bean is returned.
+	 * 
+	 * @param path must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 */
+	@Nullable
+	default Object getProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path) {
+
+		Object bean = getBean();
+		Object current = bean;
+
+		if (path.isEmpty()) {
+			return bean;
+		}
+
+		for (PersistentProperty<?> property : path) {
+
+			if (current == null) {
+
+				String nullIntermediateMessage = "Cannot lookup property %s on null intermediate! Original path was: %s on %s.";
+
+				throw new MappingException(
+						String.format(nullIntermediateMessage, property, path.toDotPath(), bean.getClass().getName()));
+			}
+
+			PersistentEntity<?, ? extends PersistentProperty<?>> entity = property.getOwner();
+			PersistentPropertyAccessor accessor = entity.getPropertyAccessor(current);
+
+			current = accessor.getProperty(property);
+		}
+
+		return current;
+	}
 
 	/**
 	 * Returns the underlying bean.

--- a/src/main/java/org/springframework/data/mapping/PersistentPropertyPath.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentPropertyPath.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.mapping.context;
+package org.springframework.data.mapping;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 
 /**
@@ -24,7 +24,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Oliver Gierke
  */
-public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends Iterable<T> {
+public interface PersistentPropertyPath<P extends PersistentProperty<P>> extends Streamable<P> {
 
 	/**
 	 * Returns the dot based path notation using {@link PersistentProperty#getName()}.
@@ -42,7 +42,7 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @return
 	 */
 	@Nullable
-	String toDotPath(Converter<? super T, String> converter);
+	String toDotPath(Converter<? super P, String> converter);
 
 	/**
 	 * Returns a {@link String} path with the given delimiter based on the {@link PersistentProperty#getName()}.
@@ -62,7 +62,7 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @return
 	 */
 	@Nullable
-	String toPath(String delimiter, Converter<? super T, String> converter);
+	String toPath(String delimiter, Converter<? super P, String> converter);
 
 	/**
 	 * Returns the last property in the {@link PersistentPropertyPath}. So for {@code foo.bar} it will return the
@@ -72,7 +72,18 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @return
 	 */
 	@Nullable
-	T getLeafProperty();
+	P getLeafProperty();
+
+	default P getRequiredLeafProperty() {
+
+		P property = getLeafProperty();
+
+		if (property == null) {
+			throw new IllegalStateException("No leaf property found!");
+		}
+
+		return property;
+	}
 
 	/**
 	 * Returns the first property in the {@link PersistentPropertyPath}. So for {@code foo.bar} it will return the
@@ -82,7 +93,7 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @return
 	 */
 	@Nullable
-	T getBaseProperty();
+	P getBaseProperty();
 
 	/**
 	 * Returns whether the given {@link PersistentPropertyPath} is a base path of the current one. This means that the
@@ -91,7 +102,7 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @param path must not be {@literal null}.
 	 * @return
 	 */
-	boolean isBasePathOf(PersistentPropertyPath<T> path);
+	boolean isBasePathOf(PersistentPropertyPath<P> path);
 
 	/**
 	 * Returns the sub-path of the current one as if it was based on the given base path. So for a current path
@@ -101,7 +112,7 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @param base must not be {@literal null}.
 	 * @return
 	 */
-	PersistentPropertyPath<T> getExtensionForBaseOf(PersistentPropertyPath<T> base);
+	PersistentPropertyPath<P> getExtensionForBaseOf(PersistentPropertyPath<P> base);
 
 	/**
 	 * Returns the parent path of the current {@link PersistentPropertyPath}, i.e. the path without the leaf property.
@@ -110,7 +121,7 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 *
 	 * @return
 	 */
-	PersistentPropertyPath<T> getParentPath();
+	PersistentPropertyPath<P> getParentPath();
 
 	/**
 	 * Returns the length of the {@link PersistentPropertyPath}.
@@ -118,12 +129,4 @@ public interface PersistentPropertyPath<T extends PersistentProperty<T>> extends
 	 * @return
 	 */
 	int getLength();
-
-	/**
-	 * Returns whether the path is empty.
-	 *
-	 * @return
-	 * @since 1.11
-	 */
-	boolean isEmpty();
 }

--- a/src/main/java/org/springframework/data/mapping/PersistentPropertyPaths.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentPropertyPaths.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping;
+
+import java.util.Optional;
+
+import org.springframework.data.util.Streamable;
+
+/**
+ * A wrapper for a collection of {@link PersistentPropertyPath}s.
+ * 
+ * @author Oliver Gierke
+ * @since 2.1
+ * @soundtrack Stuart McCallum - North Star (City)
+ */
+public interface PersistentPropertyPaths<T, P extends PersistentProperty<P>>
+		extends Streamable<PersistentPropertyPath<P>> {
+
+	/**
+	 * Returns the first {@link PersistentPropertyPath}.
+	 * 
+	 * @return
+	 */
+	Optional<PersistentPropertyPath<P>> getFirst();
+
+	/**
+	 * Returns whether the given path is contained in the current {@link PersistentPropertyPaths}.
+	 * 
+	 * @param path must not be {@literal null}.
+	 * @return
+	 */
+	boolean contains(String path);
+
+	/**
+	 * Returns whether the given {@link PropertyPath} is contained in the current {@link PersistentPropertyPaths}.
+	 * 
+	 * @param path must not be {@literal null}.
+	 * @return
+	 */
+	boolean contains(PropertyPath path);
+}

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -18,23 +18,20 @@ package org.springframework.data.mapping.context;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.BeanUtils;
@@ -45,6 +42,8 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.model.ClassGeneratingPropertyAccessorFactory;
 import org.springframework.data.mapping.model.MutablePersistentEntity;
@@ -53,16 +52,13 @@ import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.Optionals;
-import org.springframework.data.util.Pair;
 import org.springframework.data.util.Streamable;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ConcurrentReferenceHashMap;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ReflectionUtils.FieldCallback;
 import org.springframework.util.ReflectionUtils.FieldFilter;
-import org.springframework.util.StringUtils;
 
 /**
  * Base class to build mapping metadata and thus create instances of {@link PersistentEntity} and
@@ -87,8 +83,8 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 	private final Optional<E> NONE = Optional.empty();
 	private final Map<TypeInformation<?>, Optional<E>> persistentEntities = new HashMap<>();
-	private final Map<TypeAndProperties, PersistentPropertyPath<P>> propertyPaths = new ConcurrentReferenceHashMap<>();
 	private final PersistentPropertyAccessorFactory persistentPropertyAccessorFactory = new ClassGeneratingPropertyAccessorFactory();
+	private final PersistentPropertyPathFactory<E, P> persistentPropertyPathFactory;
 
 	private @Nullable ApplicationEventPublisher applicationEventPublisher;
 
@@ -99,6 +95,10 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 	private final Lock read = lock.readLock();
 	private final Lock write = lock.writeLock();
+
+	protected AbstractMappingContext() {
+		this.persistentPropertyPathFactory = new PersistentPropertyPathFactory<>(this);
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -253,10 +253,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	 */
 	@Override
 	public PersistentPropertyPath<P> getPersistentPropertyPath(PropertyPath propertyPath) {
-
-		Assert.notNull(propertyPath, "Property path must not be null!");
-
-		return getPersistentPropertyPath(propertyPath.toDotPath(), propertyPath.getOwningType());
+		return persistentPropertyPathFactory.from(propertyPath);
 	}
 
 	/*
@@ -265,11 +262,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	 */
 	@Override
 	public PersistentPropertyPath<P> getPersistentPropertyPath(String propertyPath, Class<?> type) {
-
-		Assert.notNull(propertyPath, "Property path must not be null!");
-		Assert.notNull(type, "Type must not be null!");
-
-		return getPersistentPropertyPath(propertyPath, ClassTypeInformation.from(type));
+		return persistentPropertyPathFactory.from(type, propertyPath);
 	}
 
 	/*
@@ -278,65 +271,36 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	 */
 	@Override
 	public PersistentPropertyPath<P> getPersistentPropertyPath(InvalidPersistentPropertyPath invalidPath) {
-		return getPersistentPropertyPath(invalidPath.getResolvedPath(), invalidPath.getType());
+		return persistentPropertyPathFactory.from(invalidPath.getType(), invalidPath.getResolvedPath());
 	}
 
-	private PersistentPropertyPath<P> getPersistentPropertyPath(String propertyPath, TypeInformation<?> type) {
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.context.MappingContext#findPersistentPropertyPath(java.lang.Class, java.util.function.Predicate)
+	 */
+	@Override
+	public <T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate) {
 
-		return propertyPaths.computeIfAbsent(TypeAndProperties.of(type, propertyPath),
-				it -> createPersistentPropertyPath(it.getPath(), it.getType()));
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(predicate, "Selection predicate must not be null!");
+
+		return doFindPersistentPropertyPaths(type, predicate, it -> !it.isAssociation());
 	}
 
 	/**
-	 * Creates a {@link PersistentPropertyPath} for the given parts and {@link TypeInformation}.
-	 *
-	 * @param propertyPath must not be {@literal null}.
-	 * @param type must not be {@literal null}.
-	 * @return
+	 * Actually looks up the {@link PersistentPropertyPaths} for the given type, selection predicate and traversal guard.
+	 * Primary purpose is to allow sub-types to alter the default traversal guard, e.g. used by
+	 * {@link #findPersistentPropertyPaths(Class, Predicate)}.
+	 * 
+	 * @param type will never be {@literal null}.
+	 * @param predicate will never be {@literal null}.
+	 * @param traversalGuard will never be {@literal null}.
+	 * @return will never be {@literal null}.
+	 * @see #findPersistentPropertyPaths(Class, Predicate)
 	 */
-	private PersistentPropertyPath<P> createPersistentPropertyPath(String propertyPath, TypeInformation<?> type) {
-
-		List<String> parts = Arrays.asList(propertyPath.split("\\."));
-		DefaultPersistentPropertyPath<P> path = DefaultPersistentPropertyPath.empty();
-		Iterator<String> iterator = parts.iterator();
-		E current = getRequiredPersistentEntity(type);
-
-		while (iterator.hasNext()) {
-
-			String segment = iterator.next();
-			final DefaultPersistentPropertyPath<P> foo = path;
-			final E bar = current;
-
-			Pair<DefaultPersistentPropertyPath<P>, E> pair = getPair(path, iterator, segment, current);
-
-			if (pair == null) {
-
-				String source = StringUtils.collectionToDelimitedString(parts, ".");
-				String resolvedPath = foo.toDotPath();
-
-				throw new InvalidPersistentPropertyPath(source, type, segment, resolvedPath,
-						String.format("No property %s found on %s!", segment, bar.getName()));
-			}
-
-			path = pair.getFirst();
-			current = pair.getSecond();
-		}
-
-		return path;
-	}
-
-	@Nullable
-	private Pair<DefaultPersistentPropertyPath<P>, E> getPair(DefaultPersistentPropertyPath<P> path,
-			Iterator<String> iterator, String segment, E entity) {
-
-		P property = entity.getPersistentProperty(segment);
-
-		if (property == null) {
-			return null;
-		}
-
-		TypeInformation<?> type = property.getTypeInformation().getRequiredActualType();
-		return Pair.of(path.append(property), iterator.hasNext() ? getRequiredPersistentEntity(type) : entity);
+	protected final <T> PersistentPropertyPaths<T, P> doFindPersistentPropertyPaths(Class<T> type,
+			Predicate<? super P> predicate, Predicate<P> traversalGuard) {
+		return persistentPropertyPathFactory.from(ClassTypeInformation.from(type), predicate, traversalGuard);
 	}
 
 	/**
@@ -571,13 +535,6 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 			property.getPersistentEntityTypes().forEach(AbstractMappingContext.this::addPersistentEntity);
 		}
-	}
-
-	@Value(staticConstructor = "of")
-	static class TypeAndProperties {
-
-		TypeInformation<?> type;
-		String path;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/mapping/context/InvalidPersistentPropertyPath.java
+++ b/src/main/java/org/springframework/data/mapping/context/InvalidPersistentPropertyPath.java
@@ -15,10 +15,18 @@
  */
 package org.springframework.data.mapping.context;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.beans.PropertyMatches;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Exception to indicate a source path couldn't be resolved into a {@link PersistentPropertyPath} completely.
@@ -29,6 +37,7 @@ import org.springframework.util.Assert;
 public class InvalidPersistentPropertyPath extends MappingException {
 
 	private static final long serialVersionUID = 2805815643641094488L;
+	private static final String DEFAULT_MESSAGE = "No property '%s' found on %s! Did you mean: %s?";
 
 	private final String source, unresolvableSegment, resolvedPath;
 	private final TypeInformation<?> type;
@@ -41,10 +50,11 @@ public class InvalidPersistentPropertyPath extends MappingException {
 	 * @param resolvedPath
 	 * @param message must not be {@literal null} or empty.
 	 */
-	InvalidPersistentPropertyPath(String source, TypeInformation<?> type, String unresolvableSegment,
-			@Nullable String resolvedPath, String message) {
+	public InvalidPersistentPropertyPath(String source, TypeInformation<?> type, String unresolvableSegment,
+			PersistentPropertyPath<? extends PersistentProperty<?>> resolvedPath) {
 
-		super(message);
+		super(createMessage(resolvedPath.isEmpty() ? type : resolvedPath.getRequiredLeafProperty().getTypeInformation(),
+				unresolvableSegment));
 
 		Assert.notNull(source, "Source property path must not be null!");
 		Assert.notNull(type, "Type must not be null!");
@@ -53,7 +63,7 @@ public class InvalidPersistentPropertyPath extends MappingException {
 		this.source = source;
 		this.type = type;
 		this.unresolvableSegment = unresolvableSegment;
-		this.resolvedPath = resolvedPath == null ? "" : resolvedPath;
+		this.resolvedPath = toDotPathOrEmpty(resolvedPath);
 	}
 
 	/**
@@ -90,5 +100,33 @@ public class InvalidPersistentPropertyPath extends MappingException {
 	 */
 	public String getResolvedPath() {
 		return resolvedPath;
+	}
+
+	private static String toDotPathOrEmpty(@Nullable PersistentPropertyPath<? extends PersistentProperty<?>> path) {
+
+		if (path == null) {
+			return "";
+		}
+
+		String dotPath = path.toDotPath();
+
+		return dotPath == null ? "" : dotPath;
+	}
+
+	private static String createMessage(TypeInformation<?> type, String unresolvableSegment) {
+
+		Set<String> potentialMatches = detectPotentialMatches(unresolvableSegment, type.getType());
+		Object match = StringUtils.collectionToCommaDelimitedString(potentialMatches);
+
+		return String.format(DEFAULT_MESSAGE, unresolvableSegment, type.getType(), match);
+	}
+
+	private static Set<String> detectPotentialMatches(String propertyName, Class<?> type) {
+
+		Set<String> result = new HashSet<>();
+		result.addAll(Arrays.asList(PropertyMatches.forField(propertyName, type).getPossibleMatches()));
+		result.addAll(Arrays.asList(PropertyMatches.forProperty(propertyName, type).getPossibleMatches()));
+
+		return result;
 	}
 }

--- a/src/main/java/org/springframework/data/mapping/context/MappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/MappingContext.java
@@ -16,10 +16,13 @@
 package org.springframework.data.mapping.context;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
@@ -183,6 +186,19 @@ public interface MappingContext<E extends PersistentEntity<?, P>, P extends Pers
 	 */
 	@Deprecated
 	PersistentPropertyPath<P> getPersistentPropertyPath(InvalidPersistentPropertyPath invalidPath);
+
+	/**
+	 * Returns all {@link PersistentPropertyPath}s pointing to properties on the given type that match the given
+	 * {@link Predicate}. In case of circular references the detection will stop at the property that references a type
+	 * that's already included in the path. Note, that is is a potentially expensive operation as results cannot be
+	 * cached.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param predicate must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 */
+	<T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate);
 
 	/**
 	 * Returns the {@link TypeInformation}s for all {@link PersistentEntity}s in the {@link MappingContext}.

--- a/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.context;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.springframework.data.mapping.AssociationHandler;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPaths;
+import org.springframework.data.mapping.PropertyHandler;
+import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.data.util.Pair;
+import org.springframework.data.util.StreamUtils;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.StringUtils;
+
+/**
+ * A factory implementation to create {@link PersistentPropertyPath} instances in various ways.
+ * 
+ * @author Oliver Gierke
+ * @since 2.1
+ * @soundtrack Cypress Hill - Boom Biddy Bye Bye (Fugees Remix, Unreleased & Revamped)
+ */
+@RequiredArgsConstructor
+class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends PersistentProperty<P>> {
+
+	private static final Predicate<PersistentProperty<?>> IS_ENTITY = it -> it.isEntity();
+
+	private final Map<TypeAndPath, PersistentPropertyPath<P>> propertyPaths = new ConcurrentReferenceHashMap<>();
+	private final MappingContext<E, P> context;
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} for the given property path on the given type.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param propertyPath must not be {@literal null}.
+	 * @return
+	 */
+	public PersistentPropertyPath<P> from(Class<?> type, String propertyPath) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(propertyPath, "Property path must not be null!");
+
+		return getPersistentPropertyPath(ClassTypeInformation.from(type), propertyPath);
+	}
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} for the given property path on the given type.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param propertyPath must not be {@literal null}.
+	 * @return
+	 */
+	public PersistentPropertyPath<P> from(TypeInformation<?> type, String propertyPath) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(propertyPath, "Property path must not be null!");
+
+		return getPersistentPropertyPath(type, propertyPath);
+	}
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} for the given {@link PropertyPath}.
+	 * 
+	 * @param path must not be {@literal null}.
+	 * @return
+	 */
+	public PersistentPropertyPath<P> from(PropertyPath path) {
+
+		Assert.notNull(path, "Property path must not be null!");
+
+		return from(path.getOwningType(), path.toDotPath());
+	}
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} based on a given type and {@link Predicate} to select properties
+	 * matching it.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param propertyFilter must not be {@literal null}.
+	 * @return
+	 */
+	public <T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(propertyFilter, "Property filter must not be null!");
+
+		return from(ClassTypeInformation.from(type), propertyFilter);
+	}
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} based on a given type and {@link Predicate} to select properties
+	 * matching it.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param propertyFilter must not be {@literal null}.
+	 * @param traversalGuard must not be {@literal null}.
+	 * @return
+	 */
+	public <T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter,
+			Predicate<P> traversalGuard) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(propertyFilter, "Property filter must not be null!");
+		Assert.notNull(traversalGuard, "Traversal guard must not be null!");
+
+		return from(ClassTypeInformation.from(type), propertyFilter, traversalGuard);
+	}
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} based on a given type and {@link Predicate} to select properties
+	 * matching it.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param propertyFilter must not be {@literal null}.
+	 * @return
+	 */
+	public <T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter) {
+		return from(type, propertyFilter, it -> !it.isAssociation());
+	}
+
+	/**
+	 * Creates a new {@link PersistentPropertyPath} based on a given type and {@link Predicate} to select properties
+	 * matching it.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param propertyFilter must not be {@literal null}.
+	 * @param traversalGuard must not be {@literal null}.
+	 * @return
+	 */
+	public <T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter,
+			Predicate<P> traversalGuard) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.notNull(propertyFilter, "Property filter must not be null!");
+		Assert.notNull(traversalGuard, "Traversal guard must not be null!");
+
+		return DefaultPersistentPropertyPaths.of(type,
+				from(type, propertyFilter, traversalGuard, DefaultPersistentPropertyPath.empty()));
+	}
+
+	private PersistentPropertyPath<P> getPersistentPropertyPath(TypeInformation<?> type, String propertyPath) {
+
+		return propertyPaths.computeIfAbsent(TypeAndPath.of(type, propertyPath),
+				it -> createPersistentPropertyPath(it.getPath(), it.getType()));
+	}
+
+	/**
+	 * Creates a {@link PersistentPropertyPath} for the given parts and {@link TypeInformation}.
+	 *
+	 * @param propertyPath must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @return
+	 */
+	private PersistentPropertyPath<P> createPersistentPropertyPath(String propertyPath, TypeInformation<?> type) {
+
+		String trimmedPath = propertyPath.trim();
+
+		List<String> parts = trimmedPath.isEmpty() //
+				? Collections.emptyList() //
+				: Arrays.asList(trimmedPath.split("\\."));
+
+		DefaultPersistentPropertyPath<P> path = DefaultPersistentPropertyPath.empty();
+		Iterator<String> iterator = parts.iterator();
+		E current = context.getRequiredPersistentEntity(type);
+
+		while (iterator.hasNext()) {
+
+			String segment = iterator.next();
+			final DefaultPersistentPropertyPath<P> currentPath = path;
+
+			Pair<DefaultPersistentPropertyPath<P>, E> pair = getPair(path, iterator, segment, current);
+
+			if (pair == null) {
+
+				String source = StringUtils.collectionToDelimitedString(parts, ".");
+
+				throw new InvalidPersistentPropertyPath(source, type, segment, currentPath);
+			}
+
+			path = pair.getFirst();
+			current = pair.getSecond();
+		}
+
+		return path;
+	}
+
+	@Nullable
+	private Pair<DefaultPersistentPropertyPath<P>, E> getPair(DefaultPersistentPropertyPath<P> path,
+			Iterator<String> iterator, String segment, E entity) {
+
+		P property = entity.getPersistentProperty(segment);
+
+		if (property == null) {
+			return null;
+		}
+
+		TypeInformation<?> type = property.getTypeInformation().getRequiredActualType();
+		return Pair.of(path.append(property), iterator.hasNext() ? context.getRequiredPersistentEntity(type) : entity);
+	}
+
+	private <T> Collection<PersistentPropertyPath<P>> from(TypeInformation<T> type, Predicate<? super P> filter,
+			Predicate<P> traversalGuard, DefaultPersistentPropertyPath<P> basePath) {
+
+		TypeInformation<?> actualType = type.getActualType();
+
+		if (actualType == null) {
+			return Collections.emptyList();
+		}
+
+		E entity = context.getRequiredPersistentEntity(actualType);
+		Set<PersistentPropertyPath<P>> properties = new HashSet<>();
+
+		PropertyHandler<P> propertyTester = persistentProperty -> {
+
+			TypeInformation<?> typeInformation = persistentProperty.getTypeInformation();
+			TypeInformation<?> actualPropertyType = typeInformation.getActualType();
+
+			if (basePath.containsPropertyOfType(actualPropertyType)) {
+				return;
+			}
+
+			DefaultPersistentPropertyPath<P> currentPath = basePath.append(persistentProperty);
+
+			if (filter.test(persistentProperty)) {
+				properties.add(currentPath);
+			}
+
+			if (traversalGuard.and(IS_ENTITY).test(persistentProperty)) {
+				properties.addAll(from(typeInformation, filter, traversalGuard, currentPath));
+			}
+		};
+
+		entity.doWithProperties(propertyTester);
+		entity.doWithAssociations((AssociationHandler<P>) association -> {
+
+			P inverse = association.getInverse();
+
+			if (traversalGuard.test(inverse)) {
+				propertyTester.doWithPersistentProperty(inverse);
+			}
+		});
+
+		return properties;
+	}
+
+	@Value(staticConstructor = "of")
+	static class TypeAndPath {
+
+		TypeInformation<?> type;
+		String path;
+	}
+
+	@ToString
+	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+	static class DefaultPersistentPropertyPaths<T, P extends PersistentProperty<P>>
+			implements PersistentPropertyPaths<T, P> {
+
+		private static final Comparator<PersistentPropertyPath<?>> SHORTEST_PATH = Comparator
+				.comparingInt(PersistentPropertyPath::getLength);
+
+		private final TypeInformation<T> type;
+		private final Iterable<PersistentPropertyPath<P>> paths;
+
+		/**
+		 * Creates a new {@link DefaultPersistentPropertyPaths} instance
+		 * 
+		 * @param type
+		 * @param paths
+		 * @return
+		 */
+		static <T, P extends PersistentProperty<P>> PersistentPropertyPaths<T, P> of(TypeInformation<T> type,
+				Collection<PersistentPropertyPath<P>> paths) {
+
+			List<PersistentPropertyPath<P>> sorted = new ArrayList<>(paths);
+
+			Collections.sort(sorted, SHORTEST_PATH.thenComparing(ShortestSegmentFirst.INSTANCE));
+
+			return new DefaultPersistentPropertyPaths<>(type, sorted);
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mapping.PersistentPropertyPaths#getFirst()
+		 */
+		@Override
+		public Optional<PersistentPropertyPath<P>> getFirst() {
+			return isEmpty() ? Optional.empty() : Optional.of(iterator().next());
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mapping.PersistentPropertyPaths#contains(java.lang.String)
+		 */
+		@Override
+		public boolean contains(String path) {
+			return contains(PropertyPath.from(path, type));
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.mapping.PersistentPropertyPaths#contains(org.springframework.data.mapping.PropertyPath)
+		 */
+		@Override
+		public boolean contains(PropertyPath path) {
+
+			Assert.notNull(path, "PropertyPath must not be null!");
+
+			if (!path.getOwningType().equals(type)) {
+				return false;
+			}
+
+			String dotPath = path.toDotPath();
+
+			return stream().anyMatch(it -> dotPath.equals(it.toDotPath()));
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see java.lang.Iterable#iterator()
+		 */
+		@Override
+		public Iterator<PersistentPropertyPath<P>> iterator() {
+			return paths.iterator();
+		}
+
+		/**
+		 * Simple {@link Comparator} to sort {@link PersistentPropertyPath} instances by their property segment's name
+		 * length.
+		 * 
+		 * @author Oliver Gierke
+		 * @since 2.1
+		 */
+		private static enum ShortestSegmentFirst
+				implements Comparator<PersistentPropertyPath<? extends PersistentProperty<?>>> {
+
+			INSTANCE;
+
+			@Override
+			@SuppressWarnings("null")
+			public int compare(PersistentPropertyPath<?> left, PersistentPropertyPath<?> right) {
+
+				Function<PersistentProperty<?>, Integer> mapper = it -> it.getName().length();
+
+				Stream<Integer> leftNames = left.stream().map(mapper);
+				Stream<Integer> rightNames = right.stream().map(mapper);
+
+				return StreamUtils.zip(leftNames, rightNames, (l, r) -> l - r) //
+						.filter(it -> it != 0) //
+						.findFirst() //
+						.orElse(0);
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
@@ -130,13 +130,12 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 		return information;
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mapping.PersistentProperty#getPersistentEntityType()
+	 * @see org.springframework.data.mapping.PersistentProperty#getPersistentEntityTypes()
 	 */
-	@Deprecated
 	@Override
-	public Iterable<? extends TypeInformation<?>> getPersistentEntityType() {
+	public Iterable<? extends TypeInformation<?>> getPersistentEntityTypes() {
 
 		if (!isEntity()) {
 			return Collections.emptySet();

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
@@ -217,10 +217,9 @@ public class RepositoryComposition {
 	 */
 	public void validateImplementation() {
 
-		fragments.stream()
-				.forEach(it -> it.getImplementation() //
-						.orElseThrow(() -> new IllegalStateException(String.format("Fragment %s has no implementation.",
-								ClassUtils.getQualifiedName(it.getSignatureContributor())))));
+		fragments.stream().forEach(it -> it.getImplementation() //
+				.orElseThrow(() -> new IllegalStateException(String.format("Fragment %s has no implementation.",
+						ClassUtils.getQualifiedName(it.getSignatureContributor())))));
 	}
 
 	/**
@@ -320,15 +319,6 @@ public class RepositoryComposition {
 			return from(Stream.concat(left, right).collect(Collectors.toList()));
 		}
 
-		/**
-		 * Return {@literal true} if this {@link RepositoryFragments} contains no {@link RepositoryFragment fragments}.
-		 *
-		 * @return {@literal true} if this {@link RepositoryFragments} contains no {@link RepositoryFragment fragments}.
-		 */
-		public boolean isEmpty() {
-			return fragments.isEmpty();
-		}
-
 		/*
 		 * (non-Javadoc)
 		 * @see java.lang.Iterable#iterator()
@@ -336,14 +326,6 @@ public class RepositoryComposition {
 		@Override
 		public Iterator<RepositoryFragment<?>> iterator() {
 			return fragments.iterator();
-		}
-
-		/**
-		 * @return {@link Stream} of {@link RepositoryFragment fragments}.
-		 */
-		@Override
-		public Stream<RepositoryFragment<?>> stream() {
-			return fragments.stream();
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/util/Streamable.java
+++ b/src/main/java/org/springframework/data/util/Streamable.java
@@ -121,4 +121,13 @@ public interface Streamable<T> extends Iterable<T> {
 
 		return Streamable.of(() -> stream().filter(predicate));
 	}
+
+	/**
+	 * Returns whether the current {@link Streamable} is empty.
+	 * 
+	 * @return
+	 */
+	default boolean isEmpty() {
+		return !iterator().hasNext();
+	}
 }

--- a/src/test/java/org/springframework/data/mapping/PersistentPropertyAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PersistentPropertyAccessorUnitTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Value;
+
+import org.junit.Test;
+import org.springframework.data.mapping.context.SampleMappingContext;
+
+/**
+ * @author Oliver Gierke
+ */
+public class PersistentPropertyAccessorUnitTests {
+
+	SampleMappingContext context = new SampleMappingContext();
+
+	PersistentPropertyPath<? extends PersistentProperty<?>> path;
+	PersistentPropertyAccessor accessor;
+
+	private void setUp(Order order, String path) {
+
+		this.accessor = context.getPersistentEntity(Order.class).getPropertyAccessor(order);
+		this.path = context.getPersistentPropertyPath(path, Order.class);
+	}
+
+	@Test // DATACMNS-1275
+	public void looksUpValueForPropertyPath() {
+
+		Order order = new Order(new Customer("Dave"));
+
+		setUp(order, "customer.firstname");
+
+		assertThat(accessor.getProperty(path)).isEqualTo("Dave");
+	}
+
+	@Test // DATACMNS-1275
+	public void setsPropertyOnNestedPath() {
+
+		Customer customer = new Customer("Dave");
+		Order order = new Order(customer);
+
+		setUp(order, "customer.firstname");
+
+		accessor.setProperty(path, "Oliver August");
+
+		assertThat(customer.firstname).isEqualTo("Oliver August");
+	}
+
+	@Test // DATACMNS-1275
+	public void rejectsEmptyPathToSetValues() {
+
+		setUp(new Order(null), "");
+
+		assertThatExceptionOfType(IllegalArgumentException.class) //
+				.isThrownBy(() -> accessor.setProperty(path, "Oliver August"));
+	}
+
+	@Test // DATACMNS-1275
+	public void rejectsIntermediateNullValuesForRead() {
+
+		setUp(new Order(null), "customer.firstname");
+
+		assertThatExceptionOfType(MappingException.class)//
+				.isThrownBy(() -> accessor.getProperty(path));
+	}
+
+	@Test // DATACMNS-1275
+	public void rejectsIntermediateNullValuesForWrite() {
+
+		setUp(new Order(null), "customer.firstname");
+
+		assertThatExceptionOfType(MappingException.class)//
+				.isThrownBy(() -> accessor.setProperty(path, "Oliver August"));
+	}
+
+	@Value
+	static class Order {
+		Customer customer;
+	}
+
+	@Value
+	static class Customer {
+		String firstname;
+	}
+}

--- a/src/test/java/org/springframework/data/mapping/context/DefaultPersistentPropertyPathUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/DefaultPersistentPropertyPathUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mapping.context;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -28,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
 
 /**
  * Unit tests for {@link DefaultPersistentPropertyPath}.
@@ -35,14 +37,14 @@ import org.springframework.data.mapping.PersistentProperty;
  * @author Oliver Gierke
  */
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultPersistenPropertyPathUnitTests<T extends PersistentProperty<T>> {
+public class DefaultPersistentPropertyPathUnitTests<P extends PersistentProperty<P>> {
 
-	@Mock T first, second;
+	@Mock P first, second;
 
-	@Mock Converter<T, String> converter;
+	@Mock Converter<P, String> converter;
 
-	PersistentPropertyPath<T> oneLeg;
-	PersistentPropertyPath<T> twoLegs;
+	PersistentPropertyPath<P> oneLeg;
+	PersistentPropertyPath<P> twoLegs;
 
 	@Before
 	public void setUp() {
@@ -96,7 +98,7 @@ public class DefaultPersistenPropertyPathUnitTests<T extends PersistentProperty<
 	@Test
 	public void calculatesExtensionCorrectly() {
 
-		PersistentPropertyPath<T> extension = twoLegs.getExtensionForBaseOf(oneLeg);
+		PersistentPropertyPath<P> extension = twoLegs.getExtensionForBaseOf(oneLeg);
 
 		assertThat(extension).isEqualTo(new DefaultPersistentPropertyPath<>(Collections.singletonList(second)));
 	}
@@ -107,8 +109,18 @@ public class DefaultPersistenPropertyPathUnitTests<T extends PersistentProperty<
 	}
 
 	@Test
-	public void returnsItselfAsParentPathIfSizeOne() {
-		assertThat(oneLeg.getParentPath()).isEqualTo(oneLeg);
+	public void returnsEmptyPathForRootLevelProperty() {
+		assertThat(oneLeg.getParentPath()).isEmpty();
+	}
+
+	@Test
+	public void returnItselfForEmptyPath() {
+
+		PersistentPropertyPath<P> parent = oneLeg.getParentPath();
+		PersistentPropertyPath<P> parentsParent = parent.getParentPath();
+
+		assertThat(parentsParent).isEmpty();
+		assertThat(parentsParent).isSameAs(parent);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/mapping/context/PersistentPropertyPathFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/PersistentPropertyPathFactoryUnitTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.context;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.springframework.data.annotation.Reference;
+import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPaths;
+import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.mapping.model.BasicPersistentEntity;
+import org.springframework.data.util.Streamable;
+import org.springframework.util.StringUtils;
+
+/**
+ * Unit tests for {@link PersistentPropertyPathFactory}.
+ * 
+ * @author Oliver Gierke
+ * @soundtrack Cypress Hill - Illusions (Q-Tip Remix, Unreleased & Revamped)
+ */
+public class PersistentPropertyPathFactoryUnitTests {
+
+	PersistentPropertyPathFactory<BasicPersistentEntity<Object, SamplePersistentProperty>, SamplePersistentProperty> factory = //
+			new PersistentPropertyPathFactory<>(new SampleMappingContext());
+
+	@Test
+	public void doesNotTryToLookupPersistentEntityForLeafProperty() {
+		assertThat(factory.from(Person.class, "name")).isNotNull();
+	}
+
+	@Test // DATACMNS-380
+	public void returnsPersistentPropertyPathForDotPath() {
+
+		PersistentPropertyPath<SamplePersistentProperty> path = factory.from(PersonSample.class, "persons.name");
+
+		assertThat(path.getLength()).isEqualTo(2);
+		assertThat(path.getBaseProperty().getName()).isEqualTo("persons");
+		assertThat(path.getLeafProperty().getName()).isEqualTo("name");
+	}
+
+	@Test(expected = MappingException.class) // DATACMNS-380
+	public void rejectsInvalidPropertyReferenceWithMappingException() {
+		factory.from(PersonSample.class, "foo");
+	}
+
+	@Test // DATACMNS-695
+	public void persistentPropertyPathTraversesGenericTypesCorrectly() {
+		assertThat(factory.from(Outer.class, "field.wrapped.field")).hasSize(3);
+	}
+
+	@Test // DATACMNS-727
+	public void exposesContextForFailingPropertyPathLookup() {
+
+		assertThatExceptionOfType(InvalidPersistentPropertyPath.class)//
+				.isThrownBy(() -> factory.from(PersonSample.class, "persons.firstname"))//
+				.matches(e -> StringUtils.hasText(e.getMessage()))//
+				.matches(e -> e.getResolvedPath().equals("persons"))//
+				.matches(e -> e.getUnresolvableSegment().equals("firstname"))//
+				.matches(e -> factory.from(PersonSample.class, e.getResolvedPath()) != null);
+	}
+
+	@Test // DATACMNS-1116
+	public void cachesPersistentPropertyPaths() {
+
+		assertThat(factory.from(PersonSample.class, "persons.name")) //
+				.isSameAs(factory.from(PersonSample.class, "persons.name"));
+	}
+
+	@Test // DATACMNS-1275
+	public void findsNestedPropertyByFilter() {
+
+		PersistentPropertyPaths<?, SamplePersistentProperty> paths = factory.from(Sample.class,
+				property -> property.findAnnotation(Inject.class) != null);
+
+		assertThat(paths).hasSize(1).anySatisfy(it -> it.toDotPath().equals("inner.annotatedField"));
+	}
+
+	@Test // DATACMNS-1275
+	public void findsNestedPropertiesByFilter() {
+
+		PersistentPropertyPaths<?, SamplePersistentProperty> paths = factory.from(Wrapper.class,
+				property -> property.findAnnotation(Inject.class) != null);
+
+		assertThat(paths).hasSize(2);//
+		assertThat(paths).element(0).satisfies(it -> it.toDotPath().equals("first.inner.annotatedField"));
+		assertThat(paths).element(1).satisfies(it -> it.toDotPath().equals("second.inner.annotatedField"));
+	}
+
+	@Test // DATACMNS-1275
+	public void createsEmptyPropertyPathCorrectly() {
+		assertThat(factory.from(Wrapper.class, "")).isEmpty();
+	}
+
+	@Test // DATACMNS-1275
+	public void returnsShortestsPathsFirst() {
+
+		Streamable<String> paths = factory.from(First.class, it -> true, it -> true) //
+				.map(PersistentPropertyPath::toDotPath);
+
+		assertThat(paths).containsExactly("third", "second", "third.lastname", "second.firstname");
+	}
+
+	@Test // DATACMNS-1275
+	public void doesNotTraverseAssociationsByDefault() {
+
+		Streamable<String> paths = factory.from(First.class, it -> true) //
+				.map(PersistentPropertyPath::toDotPath);
+
+		assertThat(paths) //
+				.contains("second", "second.firstname")//
+				.doesNotContain("third", "third.lastname");
+	}
+
+	@Test // DATACMNS-1275
+	public void traversesAssociationsIfTraversalGuardAllowsIt() {
+
+		PersistentPropertyPaths<First, SamplePersistentProperty> paths = //
+				factory.from(First.class, it -> true, it -> true);
+
+		assertThat(paths.contains("third.lastname")).isTrue();
+		assertThat(paths.contains(PropertyPath.from("third.lastname", First.class)));
+	}
+
+	@Test // DATACMNS-1275
+	public void returnsEmptyPropertyPathsIfNoneSelected() {
+
+		PersistentPropertyPaths<Third, SamplePersistentProperty> paths = factory.from(Third.class, it -> false);
+
+		assertThat(paths).isEmpty();
+		assertThat(paths.getFirst()).isEmpty();
+	}
+
+	@Test // DATACMNS-1275
+	public void returnsShortestPathFirst() {
+
+		PersistentPropertyPaths<First, SamplePersistentProperty> paths = factory.from(First.class, it -> !it.isEntity(),
+				it -> true);
+
+		assertThat(paths.contains("second.firstname")).isTrue();
+		assertThat(paths.getFirst()) //
+				.hasValueSatisfying(it -> assertThat(it.toDotPath()).isEqualTo("third.lastname"));
+	}
+
+	static class PersonSample {
+		List<Person> persons;
+	}
+
+	class Person {
+		String name;
+	}
+
+	static class Wrapper {
+		Sample first;
+		Sample second;
+	}
+
+	static class Sample {
+		Inner inner;
+	}
+
+	static class Inner {
+		@Inject String annotatedField;
+		Sample cyclic;
+	}
+
+	static class Outer {
+		Generic<Nested> field;
+	}
+
+	static class Generic<T> {
+		T wrapped;
+	}
+
+	static class Nested {
+		String field;
+	}
+
+	static class First {
+		Second second;
+		@Reference Third third;
+	}
+
+	static class Second {
+		String firstname;
+	}
+
+	static class Third {
+		String lastname;
+	}
+}

--- a/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
@@ -72,7 +72,6 @@ public class AbstractPersistentPropertyUnitTests {
 	@Test // DATACMNS-101
 	public void returnsNestedEntityTypeCorrectly() {
 		assertThat(getProperty(TestClassComplex.class, "testClassSet").getPersistentEntityTypes()).isEmpty();
-		assertThat(getProperty(TestClassComplex.class, "testClassSet").getPersistentEntityType()).isEmpty();
 	}
 
 	@Test // DATACMNS-132
@@ -198,7 +197,6 @@ public class AbstractPersistentPropertyUnitTests {
 
 		SamplePersistentProperty property = getProperty(TreeMapWrapper.class, "map");
 		assertThat(property.getPersistentEntityTypes()).isEmpty();
-		assertThat(property.getPersistentEntityType()).isEmpty();
 		assertThat(property.isEntity()).isFalse();
 	}
 


### PR DESCRIPTION
MappingContext now exposes a method to detect all property paths pointing to properties matching a given predicate.

Extracted PersistentPropertyPath creation into a dedicated factory class so that it can be tested individually. DefaultPersistentPropertyPath now exposes a ….containsPropertyOfType(…) to detect whether we've already processed a particular type in the path. Also applied a bit of Java 8 and Lombok polish.