### PR TITLE
DATACMNS-1290 - Added support for timestamp values of type long.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1290-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/history/AnnotationRevisionMetadata.java
+++ b/src/main/java/org/springframework/data/history/AnnotationRevisionMetadata.java
@@ -19,7 +19,6 @@ import java.lang.annotation.Annotation;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.temporal.TemporalAccessor;
 import java.util.Optional;
 
 import org.springframework.data.util.AnnotationDetectionFieldCallback;
@@ -39,7 +38,7 @@ public class AnnotationRevisionMetadata<N extends Number & Comparable<N>> implem
 
 	private final Object entity;
 	private final Lazy<Optional<N>> revisionNumber;
-	private final Lazy<Optional<TemporalAccessor>> revisionDate;
+	private final Lazy<Optional<Object>> revisionDate;
 
 	/**
 	 * Creates a new {@link AnnotationRevisionMetadata} inspecting the given entity for the given annotations. If no
@@ -106,29 +105,29 @@ public class AnnotationRevisionMetadata<N extends Number & Comparable<N>> implem
 		});
 	}
 
-	private static LocalDateTime convertToLocalDateTime(TemporalAccessor temporalAccessor) {
+	private static LocalDateTime convertToLocalDateTime(Object timestamp) {
 
-		if (temporalAccessor instanceof LocalDateTime) {
-			return (LocalDateTime) temporalAccessor;
+		if (timestamp instanceof LocalDateTime) {
+			return (LocalDateTime) timestamp;
 		}
 
-		if (temporalAccessor instanceof Instant) {
-			return LocalDateTime.ofInstant((Instant) temporalAccessor, ZoneOffset.systemDefault());
-		}
-
-		throw new IllegalArgumentException(String.format("Can't convert %s to LocalDateTime!", temporalAccessor));
+		return LocalDateTime.ofInstant(convertToInstant(timestamp), ZoneOffset.systemDefault());
 	}
 
-	private static Instant convertToInstant(TemporalAccessor temporalAccessor) {
+	private static Instant convertToInstant(Object timestamp) {
 
-		if (temporalAccessor instanceof Instant) {
-			return (Instant) temporalAccessor;
+		if (timestamp instanceof Instant) {
+			return (Instant) timestamp;
 		}
 
-		if (temporalAccessor instanceof LocalDateTime) {
-			return ((LocalDateTime) temporalAccessor).atZone(ZoneOffset.systemDefault()).toInstant();
+		if (timestamp instanceof LocalDateTime) {
+			return ((LocalDateTime) timestamp).atZone(ZoneOffset.systemDefault()).toInstant();
 		}
 
-		throw new IllegalArgumentException(String.format("Can't convert %s to LocalDateTime!", temporalAccessor));
+		if (timestamp instanceof Long) {
+			return Instant.ofEpochMilli((Long) timestamp);
+		}
+
+		throw new IllegalArgumentException(String.format("Can't convert %s to Instant!", timestamp));
 	}
 }

--- a/src/test/java/org/springframework/data/history/AnnotationRevisionMetadataUnitTests.java
+++ b/src/test/java/org/springframework/data/history/AnnotationRevisionMetadataUnitTests.java
@@ -106,6 +106,26 @@ public class AnnotationRevisionMetadataUnitTests {
 		softly.assertAll();
 	}
 
+	@Test // DATACMNS-1290
+	public void exposesRevisionDateAndInstantForLong() {
+
+		SampleWithLong sample = new SampleWithLong();
+		sample.revisionLong = 4711L;
+
+		Instant expectedInstant = Instant.ofEpochMilli(sample.revisionLong);
+		LocalDateTime expectedLocalDateTime = LocalDateTime.ofInstant(expectedInstant, ZoneOffset.systemDefault());
+
+		RevisionMetadata<Long> metadata = getMetadata(sample);
+
+		softly.assertThat(metadata.getRevisionDate()).hasValue(expectedLocalDateTime);
+		softly.assertThat(metadata.getRequiredRevisionDate()).isEqualTo(expectedLocalDateTime);
+
+		softly.assertThat(metadata.getRevisionInstant()).hasValue(expectedInstant);
+		softly.assertThat(metadata.getRequiredRevisionInstant()).isEqualTo(expectedInstant);
+
+		softly.assertAll();
+	}
+
 	private static RevisionMetadata<Long> getMetadata(Object sample) {
 		return new AnnotationRevisionMetadata<>(sample, Autowired.class, Reference.class);
 	}
@@ -120,5 +140,11 @@ public class AnnotationRevisionMetadataUnitTests {
 
 		@Autowired Long revisionNumber;
 		@Reference Instant revisionInstant;
+	}
+
+	static class SampleWithLong {
+
+		@Autowired Long revisionNumber;
+		@Reference long revisionLong;
 	}
 }


### PR DESCRIPTION
The type long or Long is actually required for custom revision entities by Envers.

See also: spring-projects/spring-data-envers#122