### PR TITLE
DATACMNS-1294 - Consider java.time types as simple ones.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1294-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/SimpleTypeHolder.java
+++ b/src/main/java/org/springframework/data/mapping/model/SimpleTypeHolder.java
@@ -155,7 +155,7 @@ public class SimpleTypeHolder {
 			return isSimpleType;
 		}
 
-		if (type.getName().startsWith("java.lang")) {
+		if (type.getName().startsWith("java.lang") || type.getName().startsWith("java.time")) {
 			return true;
 		}
 

--- a/src/test/java/org/springframework/data/mapping/SimpleTypeHolderUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/SimpleTypeHolderUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.mapping;
 import static org.assertj.core.api.Assertions.*;
 
 import java.lang.reflect.Type;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.UUID;
@@ -112,6 +113,14 @@ public class SimpleTypeHolderUnitTests {
 		SimpleTypeHolder holder = SimpleTypeHolder.DEFAULT;
 
 		assertThat(holder.isSimpleType(Type.class)).isTrue();
+	}
+
+	@Test // DATACMNS-1294
+	public void considersJavaTimeTypesSimple() {
+
+		SimpleTypeHolder holder = SimpleTypeHolder.DEFAULT;
+
+		assertThat(holder.isSimpleType(Instant.class)).isTrue();
 	}
 
 	@Test // DATACMNS-1101


### PR DESCRIPTION
We now consider all types in the `java.time` package as simple types to prevent deep reflective access. We are already excluding java.lang types for the same reason.

---

Related ticket: [DATACMNS-1294](https://jira.spring.io/browse/DATACMNS-1294).