### PR TITLE
DATACMNS-1803 - Convert Vavr Seq to list with `asJava` method

### DIFF
--- a/src/main/java/org/springframework/data/repository/util/VavrCollections.java
+++ b/src/main/java/org/springframework/data/repository/util/VavrCollections.java
@@ -60,7 +60,7 @@ class VavrCollections {
 		public Object convert(Object source) {
 
 			if (source instanceof io.vavr.collection.Seq) {
-				return ((io.vavr.collection.Seq<?>) source).toJavaList();
+				return ((io.vavr.collection.Seq<?>) source).asJava();
 			}
 
 			if (source instanceof io.vavr.collection.Map) {

--- a/src/main/java/org/springframework/data/repository/util/VavrCollections.java
+++ b/src/main/java/org/springframework/data/repository/util/VavrCollections.java
@@ -71,7 +71,7 @@ class VavrCollections {
 				return ((io.vavr.collection.Set<?>) source).toJavaSet();
 			}
 
-			throw new IllegalArgumentException("Unsupported Javaslang collection " + source.getClass());
+			throw new IllegalArgumentException("Unsupported Vavr collection " + source.getClass());
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:
-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
`No`
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
This case already has test in `org.springframework.data.repository.util.QueryExecutionConvertersUnitTests#unwrapsVavrCollectionsToJavaOnes`
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
`Too small changes for adding myself into authors`

Converting Vavr's `Seq` into `java.util.List` with `asJava` method is more effective because in this case will be created only simple wrapper without creating heavy class and copy data into it.
Since resulting collections will be used only for read operations than readonly nature of such view will not be problem.