### PR TITLE
DATACMNS-1055 - Java 8 improvements to QuerydslBindingsFactory and QuerydslRepositoryInvokerAdapter

### DIFF
--- a/src/main/java/org/springframework/data/querydsl/QuerydslRepositoryInvokerAdapter.java
+++ b/src/main/java/org/springframework/data/querydsl/QuerydslRepositoryInvokerAdapter.java
@@ -31,6 +31,7 @@ import com.querydsl.core.types.Predicate;
  * for all flavors of {@code findAll(…)}. All other calls are forwarded to the configured delegate.
  *
  * @author Oliver Gierke
+ * @author MD Sayem Ahmed
  */
 public class QuerydslRepositoryInvokerAdapter implements RepositoryInvoker {
 
@@ -44,13 +45,14 @@ public class QuerydslRepositoryInvokerAdapter implements RepositoryInvoker {
 	 *
 	 * @param delegate must not be {@literal null}.
 	 * @param executor must not be {@literal null}.
-	 * @param predicate can be {@literal null}.
+	 * @param predicate must not be {@literal null}.
 	 */
 	public QuerydslRepositoryInvokerAdapter(RepositoryInvoker delegate, QuerydslPredicateExecutor<Object> executor,
 			Predicate predicate) {
 
 		Assert.notNull(delegate, "Delegate RepositoryInvoker must not be null!");
 		Assert.notNull(executor, "QuerydslPredicateExecutor must not be null!");
+		Assert.notNull(predicate, "Predicate must not be null!");
 
 		this.delegate = delegate;
 		this.executor = executor;

--- a/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
@@ -46,6 +46,7 @@ import com.querydsl.core.types.Predicate;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author MD Sayem Ahmed
  * @since 1.11
  */
 public class QuerydslPredicateBuilder {
@@ -81,17 +82,16 @@ public class QuerydslPredicateBuilder {
 	 * @param bindings the {@link QuerydslBindings} for the predicate.
 	 * @return
 	 */
-	@Nullable
-	public Predicate getPredicate(TypeInformation<?> type, MultiValueMap<String, String> values,
+	public Optional<Predicate> getPredicate(TypeInformation<?> type, MultiValueMap<String, String> values,
 			QuerydslBindings bindings) {
 
 		Assert.notNull(bindings, "Context must not be null!");
 
-		BooleanBuilder builder = new BooleanBuilder();
-
 		if (values.isEmpty()) {
-			return builder;
+			return Optional.empty();
 		}
+
+		BooleanBuilder builder = new BooleanBuilder();
 
 		for (Entry<String, List<String>> entry : values.entrySet()) {
 
@@ -117,7 +117,7 @@ public class QuerydslPredicateBuilder {
 			predicate.ifPresent(builder::and);
 		}
 
-		return builder.getValue();
+		return Optional.ofNullable(builder.getValue());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolver.java
@@ -24,6 +24,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.querydsl.binding.QuerydslBindingsFactory;
 import org.springframework.data.querydsl.binding.QuerydslPredicate;
 import org.springframework.data.querydsl.binding.QuerydslPredicateBuilder;
@@ -46,6 +47,7 @@ import com.querydsl.core.types.Predicate;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author MD Sayem Ahmed
  * @since 1.11
  */
 public class QuerydslPredicateArgumentResolver implements HandlerMethodArgumentResolver {
@@ -109,9 +111,12 @@ public class QuerydslPredicateArgumentResolver implements HandlerMethodArgumentR
 				.map(QuerydslPredicate::bindings)//
 				.map(CastUtils::cast);
 
-		return predicateBuilder.getPredicate(domainType, parameters,
-				bindings.map(it -> bindingsFactory.createBindingsFor(domainType, it))
-						.orElseGet(() -> bindingsFactory.createBindingsFor(domainType)));
+		QuerydslBindings queryDslBindings = bindings
+				.map(it -> bindingsFactory.createBindingsFor(domainType, it))
+				.orElseGet(() -> bindingsFactory.createBindingsFor(domainType));
+		return predicateBuilder
+				.getPredicate(domainType, parameters, queryDslBindings)
+				.orElse(null);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/querydsl/QuerydslRepositoryInvokerAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/querydsl/QuerydslRepositoryInvokerAdapterUnitTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.querydsl;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.Serializable;
@@ -34,6 +35,7 @@ import com.querydsl.core.types.Predicate;
  * Unit tests for {@link QuerydslRepositoryInvokerAdapter}.
  *
  * @author Oliver Gierke
+ * @author MD Sayem Ahmed
  * @soundtrack Emilie Nicolas - Grown Up
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -98,5 +100,11 @@ public class QuerydslRepositoryInvokerAdapterUnitTests {
 
 		adapter.invokeSave(any());
 		verify(delegate, times(1)).invokeSave(any());
+	}
+
+	@Test // DATACMNS-1055
+	public void rejectsNullPredicateDuringConstruction() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new QuerydslRepositoryInvokerAdapter(delegate, executor, null));
 	}
 }


### PR DESCRIPTION
QuerydslRepositoryInvokerAdapter now rejects null Predicate instances on construction, forcing clients to not create an instance in the first place.

QuerydslPredicateBuilder.getPredicate(...) now returns Optional<Predicate> rather than a null value. This change couldn't bubble up further than QuerydslPredicateArgumentResolver as the invoking method is an override of HandlerMethodArgumentResolver.resolveArgument(...).

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
