### PR TITLE
DATACMNS-1314 save the synchronizations before the commit / rollback …

### DIFF
--- a/src/main/java/org/springframework/data/transaction/SpringTransactionSynchronizationManager.java
+++ b/src/main/java/org/springframework/data/transaction/SpringTransactionSynchronizationManager.java
@@ -15,7 +15,10 @@
  */
 package org.springframework.data.transaction;
 
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
 
 /**
  * {@link SynchronizationManager} delegating calls to Spring's {@link TransactionSynchronizationManager}.
@@ -50,5 +53,15 @@ enum SpringTransactionSynchronizationManager implements SynchronizationManager {
 	 */
 	public void clearSynchronization() {
 		TransactionSynchronizationManager.clear();
+	}
+
+	@Override
+	public List<TransactionSynchronization> getSynchronizations () {
+		return TransactionSynchronizationManager.getSynchronizations();
+	}
+
+	@Override
+	public void registerSynchronization (TransactionSynchronization synchronization) {
+		TransactionSynchronizationManager.registerSynchronization(synchronization);
 	}
 }

--- a/src/main/java/org/springframework/data/transaction/SynchronizationManager.java
+++ b/src/main/java/org/springframework/data/transaction/SynchronizationManager.java
@@ -16,6 +16,10 @@
 
 package org.springframework.data.transaction;
 
+import org.springframework.transaction.support.TransactionSynchronization;
+
+import java.util.List;
+
 /**
  * Strategy interface to allow providing a dedicated synchronization mechanism.
  *
@@ -31,4 +35,8 @@ interface SynchronizationManager {
 	boolean isSynchronizationActive();
 
 	void clearSynchronization();
+
+	List<TransactionSynchronization> getSynchronizations();
+
+	void registerSynchronization (TransactionSynchronization synchronization);
 }

--- a/src/test/java/org/springframework/data/transaction/ChainedTransactionManagerTests.java
+++ b/src/test/java/org/springframework/data/transaction/ChainedTransactionManagerTests.java
@@ -27,6 +27,10 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.TransactionSynchronization;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Integration tests for {@link ChainedTransactionManager}.
@@ -134,20 +138,30 @@ public class ChainedTransactionManagerTests {
 
 	static class TestSynchronizationManager implements SynchronizationManager {
 
-		private boolean synchronizationActive;
+	    private List<TransactionSynchronization> synchronizations;
 
 		public void initSynchronization() {
-			synchronizationActive = true;
+		    synchronizations = new ArrayList<>();
 		}
 
 		public boolean isSynchronizationActive() {
-			return synchronizationActive;
+			return synchronizations != null;
 		}
 
 		public void clearSynchronization() {
-			synchronizationActive = false;
+		    synchronizations.clear();
+            synchronizations = null;
 		}
-	}
+
+		public List<TransactionSynchronization> getSynchronizations () {
+			return new ArrayList<>(synchronizations);
+		}
+
+        @Override
+        public void registerSynchronization (TransactionSynchronization synchronization) {
+            synchronizations.add(synchronization);
+        }
+    }
 
 	static class TestPlatformTransactionManager implements org.springframework.transaction.PlatformTransactionManager {
 


### PR DESCRIPTION
stored the synchronizations before the "for" and then restoring back just before the last iteration.

This way, the last AbstractPlatformTransactionManager will take care of the Synchronizations.

Sorry I messed up a bit with the formatting style.