### PR TITLE
Can't override querydslPredicateArgumentResolver

### DIFF
--- a/src/main/java/org/springframework/data/web/config/QuerydslWebConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/QuerydslWebConfiguration.java
@@ -73,6 +73,6 @@ public class QuerydslWebConfiguration implements WebMvcConfigurer {
 	 */
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
-		argumentResolvers.add(0, querydslPredicateArgumentResolver());
+		argumentResolvers.add(querydslPredicateArgumentResolver());
 	}
 }


### PR DESCRIPTION
Since @Configuration default order is LOWEST_PRECEDENCE, add querydslPredicateArgumentResolver to the head of argumentResolvers, make override querydslPredicateArgumentResolver is impossible.
I'm trying to build my own predicate resolver to support more features.
and Is there is a workaround to achieve the goal?