### PR TITLE
DATACMNS-1580 - Fixing PersonRepository domain class

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -465,7 +465,7 @@ The query builder mechanism built into Spring Data repository infrastructure is 
 ====
 [source, java]
 ----
-interface PersonRepository extends Repository<User, Long> {
+interface PersonRepository extends Repository<Person, Long> {
 
   List<Person> findByEmailAddressAndLastname(EmailAddress emailAddress, String lastname);
 


### PR DESCRIPTION
Just a small fix in documentation declaring Person as PersonRepository's domain class.