### PR TITLE
Add a findByIdOrNull extension to CrudRepository

### DIFF
--- a/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
@@ -1,0 +1,10 @@
+package org.springframework.data.repository
+
+/**
+ * Retrieves an entity by its id.
+ *
+ * @param id the entity id.
+ * @return the entity with the given id or `null` if none found
+ * @author Sebastien Deleuze
+ */
+fun <T, ID> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)

--- a/src/test/kotlin/org/springframework/data/repository/CrudRepositoryExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/repository/CrudRepositoryExtensionsTests.kt
@@ -1,0 +1,25 @@
+package org.springframework.data.repository
+
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Answers
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.springframework.data.repository.sample.User
+
+/**
+ * @author Sebastien Deleuze
+ */
+@RunWith(MockitoJUnitRunner::class)
+class CrudRepositoryExtensionsTests {
+
+	@Mock(answer = Answers.RETURNS_MOCKS)
+	lateinit var repository: CrudRepository<User, String>
+
+	@Test
+	fun `CrudRepository#findByIdOrNull() extension should call its Java counterpart`() {
+		repository.findByIdOrNull("foo")
+		verify(repository).findById("foo")
+	}
+}


### PR DESCRIPTION
In Kotlin, it is idiomatic to deal with return value that could have or not a result with nullable types since they are natively supported by the language.

This commit add a `findByIdOrNull` variant to `CrudRepository#findById` that returns `T?` instead of `Optional<T>`.