### PR TITLE
DATACMNS-1352 - Report InvalidPersistentPropertyPath on non-resolvable entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>1.13.14.BUILD-SNAPSHOT</version>
+	<version>1.13.14.DATACMNS-1352-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 by the original author(s).
+ * Copyright 2011-2018 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,7 +269,20 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			path = path.append(persistentProperty);
 
 			if (iterator.hasNext()) {
-				current = getPersistentEntity(persistentProperty.getTypeInformation().getActualType());
+
+				TypeInformation<?> actualType = persistentProperty.getTypeInformation().getActualType();
+				current = getPersistentEntity(actualType);
+
+				if (current == null) {
+
+					String source = StringUtils.collectionToDelimitedString(parts, ".");
+					String resolvedPath = path.toDotPath();
+					String unresolved = iterator.next();
+
+					throw new InvalidPersistentPropertyPath(source, persistentProperty.getTypeInformation(), unresolved,
+							resolvedPath, String.format("No entity %s found for property %s on %s !", actualType.getType().getName(),
+									segment, persistentProperty.getOwner().getName()));
+				}
 			}
 		}
 

--- a/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 the original author or authors.
+ * Copyright 2011-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 
 import org.hamcrest.Matchers;
@@ -44,7 +45,7 @@ import org.springframework.data.util.TypeInformation;
 
 /**
  * Unit test for {@link AbstractMappingContext}.
- * 
+ *
  * @author Oliver Gierke
  * @author Thomas Darimont
  */
@@ -232,6 +233,22 @@ public class AbstractMappingContextUnitTests {
 		}
 	}
 
+	@Test // DATACMNS-1352
+	public void reportsUnresolvablePropertyPathForNonEntities() {
+
+		try {
+
+			context.getPersistentPropertyPath("stringObjectMap.firstname", Sample.class);
+			fail("Expected InvalidPersistentPropertyPath!");
+
+		} catch (InvalidPersistentPropertyPath o_O) {
+
+			assertThat(o_O.getMessage(), not(isEmptyOrNullString()));
+			assertThat(o_O.getResolvedPath(), is("stringObjectMap"));
+			assertThat(o_O.getUnresolvableSegment(), is("firstname"));
+		}
+	}
+
 	@Test // DATACMNS-1214
 	public void doesNotReturnPersistentEntityForCustomSimpleTypeProperty() {
 
@@ -271,6 +288,7 @@ public class AbstractMappingContextUnitTests {
 		MetaClass metaClass;
 		List<Person> persons;
 		TreeMap<String, Person> personMap;
+		Map<String, Object> stringObjectMap;
 	}
 
 	static class Base {


### PR DESCRIPTION
We now throw `InvalidPersistentPropertyPath` during property path resolution if an intermediate path segment cannot resolve an entity to resolve the next segment. This can be caused when a non-entity typed property (e.g. `List<Object>`) is used within the property path and the path resolution attempts to resolve a property path on the non-entity typed property. Previously, the resolution failed with `NullPointerException`.

---

Related ticket: [DATACMNS-1352](https://jira.spring.io/browse/DATACMNS-1352).