### PR TITLE
DATACMNS-1174 - Reject reactive repository implementation by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.0.10.BUILD-SNAPSHOT</version>
+	<version>2.0.10.DATACMNS-1174-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtensionSupport.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtensionSupport.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
 import org.springframework.util.Assert;
@@ -300,12 +301,23 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	}
 
 	/**
-	 * Return whether to use the configuration for the repository with the given metadata. Defaults to {@literal true}.
-	 * 
+	 * Return whether to use the configuration for the repository with the given metadata. Defaults to {@literal true} and
+	 * {@link InvalidDataAccessApiUsageException} for {@link RepositoryMetadata#isReactiveRepository() reactive
+	 * repositories}. Must be overridden by store modules that wish to provide reactive repositories.
+	 *
 	 * @param metadata will never be {@literal null}.
+	 * @throws InvalidDataAccessApiUsageException on {@link RepositoryMetadata#isReactiveRepository() repositories} by
+	 *           default.
 	 * @return
 	 */
 	protected boolean useRepositoryConfiguration(RepositoryMetadata metadata) {
+
+		if (metadata.isReactiveRepository()) {
+			throw new InvalidDataAccessApiUsageException(
+					String.format("Reactive Repositories are not supported by %s. Offending repository is %s!", getModuleName(),
+							metadata.getRepositoryInterface().getName()));
+		}
+
 		return true;
 	}
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtensionSupport.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtensionSupport.java
@@ -43,7 +43,7 @@ import org.springframework.util.StringUtils;
  * Base implementation of {@link RepositoryConfigurationExtension} to ease the implementation of the interface. Will
  * default the default named query location based on a module prefix provided by implementors (see
  * {@link #getModulePrefix()}). Stubs out the post-processing methods as they might not be needed by default.
- * 
+ *
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -54,7 +54,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	private static final String CLASS_LOADING_ERROR = "%s - Could not load type %s using class loader %s.";
 	private static final String MULTI_STORE_DROPPED = "Spring Data {} - Could not safely identify store assignment for repository candidate {}.";
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtension#getModuleName()
 	 */
@@ -73,7 +73,6 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	}
 
 	/*
-	 * 
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtension#getRepositoryConfigurations(org.springframework.data.repository.config.RepositoryConfigurationSource, org.springframework.core.io.ResourceLoader, boolean)
 	 */
@@ -132,7 +131,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 
 	/**
 	 * Returns the prefix of the module to be used to create the default location for Spring Data named queries.
-	 * 
+	 *
 	 * @return must not be {@literal null}.
 	 */
 	protected abstract String getModulePrefix();
@@ -158,7 +157,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	/**
 	 * Return the annotations to scan domain types for when evaluating repository interfaces for store assignment. Modules
 	 * should return the annotations that identify a domain type as managed by the store explicitly.
-	 * 
+	 *
 	 * @return
 	 * @since 1.9
 	 */
@@ -168,7 +167,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 
 	/**
 	 * Returns the types that indicate a store match when inspecting repositories for strict matches.
-	 * 
+	 *
 	 * @return
 	 * @since 1.9
 	 */
@@ -194,8 +193,8 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	 * {@link BeanDefinitionRegistry}. For {@link BeanDefinition}s to be registered once-and-only-once for all
 	 * configuration elements (annotation or XML), prefer calling
 	 * {@link #registerIfNotAlreadyRegistered(AbstractBeanDefinition, BeanDefinitionRegistry, String, Object)} with a
-	 * dedicated bean name to avoid the bead definition being registered multiple times. *
-	 * 
+	 * dedicated bean name to avoid the bead definition being registered multiple times.
+	 *
 	 * @param registry must not be {@literal null}.
 	 * @param bean must not be {@literal null}.
 	 * @param source must not be {@literal null}.
@@ -215,7 +214,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	/**
 	 * Registers the given {@link AbstractBeanDefinition} with the given registry with the given bean name unless the
 	 * registry already contains a bean with that name.
-	 * 
+	 *
 	 * @param bean must not be {@literal null}.
 	 * @param registry must not be {@literal null}.
 	 * @param beanName must not be {@literal null} or empty.
@@ -235,7 +234,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	/**
 	 * Returns whether the given {@link BeanDefinitionRegistry} already contains a bean of the given type assuming the
 	 * bean name has been auto-generated.
-	 * 
+	 *
 	 * @param type
 	 * @param registry
 	 * @return
@@ -250,7 +249,7 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	 * Creates a actual {@link RepositoryConfiguration} instance for the given {@link RepositoryConfigurationSource} and
 	 * interface name. Defaults to the {@link DefaultRepositoryConfiguration} but allows sub-classes to override this to
 	 * customize the behavior.
-	 * 
+	 *
 	 * @param definition will never be {@literal null} or empty.
 	 * @param configSource will never be {@literal null}.
 	 * @return
@@ -266,8 +265,8 @@ public abstract class RepositoryConfigurationExtensionSupport implements Reposit
 	 * (see {@link #getIdentifyingAnnotations()}). If none of them is found, the candidate is discarded. Implementations
 	 * should make sure, the only return {@literal true} if they're really sure the interface handed to the method is
 	 * really a store interface.
-	 * 
-	 * @param repositoryInterface
+	 *
+	 * @param metadata
 	 * @return
 	 * @since 1.9
 	 */


### PR DESCRIPTION
We now reject reactive repository metadata by `RepositoryConfigurationExtensionSupport.useRepositoryConfiguration(…)` assuming that Spring Data modules provide only imperative repository support by default. Reactive store modules are required to override `useRepositoryConfiguration(…)` anyway to not accidentally implement imperative repositories with a reactive Repository extension.

---

Related ticket: [DATACMNS-1174](https://jira.spring.io/browse/DATACMNS-1174).