### PR TITLE
DATACMNS-1364 - Store persistent properties in ConcurrentHashMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1364-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -20,16 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -37,19 +28,7 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.data.annotation.Immutable;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.domain.Persistable;
-import org.springframework.data.mapping.Alias;
-import org.springframework.data.mapping.Association;
-import org.springframework.data.mapping.AssociationHandler;
-import org.springframework.data.mapping.IdentifierAccessor;
-import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mapping.PersistentEntity;
-import org.springframework.data.mapping.PersistentProperty;
-import org.springframework.data.mapping.PersistentPropertyAccessor;
-import org.springframework.data.mapping.PreferredConstructor;
-import org.springframework.data.mapping.PropertyHandler;
-import org.springframework.data.mapping.SimpleAssociationHandler;
-import org.springframework.data.mapping.SimplePropertyHandler;
-import org.springframework.data.mapping.TargetAwareIdentifierAccessor;
+import org.springframework.data.mapping.*;
 import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.support.IsNewStrategy;
 import org.springframework.data.support.PersistableIsNewStrategy;
@@ -60,6 +39,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
@@ -126,8 +106,9 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		this.associations = comparator == null ? new HashSet<>() : new TreeSet<>(new AssociationComparator<>(comparator));
 
 		this.propertyCache = new ConcurrentHashMap<>();
-		this.annotationCache = new ConcurrentReferenceHashMap<>();
-		this.propertyAnnotationCache = CollectionUtils.toMultiValueMap(new ConcurrentReferenceHashMap<>());
+		this.annotationCache = new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK);
+		this.propertyAnnotationCache = CollectionUtils
+				.toMultiValueMap(new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK));
 		this.propertyAccessorFactory = BeanWrapperPropertyAccessorFactory.INSTANCE;
 		this.typeAlias = Lazy.of(() -> getAliasFromAnnotation(getType()));
 		this.isNewStrategy = Lazy.of(() -> Persistable.class.isAssignableFrom(information.getType()) //
@@ -255,7 +236,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.model.MutablePersistentEntity#setEvaluationContextProvider(org.springframework.data.spel.EvaluationContextProvider)
 	 */
@@ -488,7 +469,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		return hasIdProperty() ? new IdPropertyIdentifierAccessor(this, bean) : new AbsentIdentifierAccessor(bean);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.PersistentEntity#isNew(java.lang.Object)
 	 */
@@ -500,7 +481,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		return isNewStrategy.get().isNew(bean);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.PersistentEntity#isImmutable()
 	 */
@@ -526,7 +507,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 	 * Returns the default {@link IsNewStrategy} to be used. Will be a {@link PersistentEntityIsNewStrategy} by default.
 	 * Note, that this strategy only gets used if the entity doesn't implement {@link Persistable} as this indicates the
 	 * user wants to be in control over whether an entity is new or not.
-	 * 
+	 *
 	 * @return
 	 * @since 2.1
 	 */
@@ -536,7 +517,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 
 	/**
 	 * Verifies the given bean type to no be {@literal null} and of the type of the current {@link PersistentEntity}.
-	 * 
+	 *
 	 * @param bean must not be {@literal null}.
 	 */
 	private final void verifyBeanType(Object bean) {

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -124,7 +125,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		this.constructor = PreferredConstructorDiscoverer.discover(this);
 		this.associations = comparator == null ? new HashSet<>() : new TreeSet<>(new AssociationComparator<>(comparator));
 
-		this.propertyCache = new ConcurrentReferenceHashMap<>();
+		this.propertyCache = new ConcurrentHashMap<>();
 		this.annotationCache = new ConcurrentReferenceHashMap<>();
 		this.propertyAnnotationCache = CollectionUtils.toMultiValueMap(new ConcurrentReferenceHashMap<>());
 		this.propertyAccessorFactory = BeanWrapperPropertyAccessorFactory.INSTANCE;

--- a/src/test/java/org/springframework/data/mapping/model/BasicPersistentEntityUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/BasicPersistentEntityUnitTests.java
@@ -134,24 +134,27 @@ public class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 		assertThat(entity.getPersistentProperty("ssn")).isEqualTo(iterator.next());
 	}
 
-	@Test // DATACMNS-186
+	@Test // DATACMNS-18, DATACMNS-1364
 	public void addingAndIdPropertySetsIdPropertyInternally() {
 
 		MutablePersistentEntity<Person, T> entity = createEntity(Person.class);
 		assertThat(entity.getIdProperty()).isNull();
 
+		when(property.getName()).thenReturn("id");
 		when(property.isIdProperty()).thenReturn(true);
 		entity.addPersistentProperty(property);
 		assertThat(entity.getIdProperty()).isEqualTo(property);
 	}
 
-	@Test // DATACMNS-186
+	@Test // DATACMNS-186, DATACMNS-1364
 	public void rejectsIdPropertyIfAlreadySet() {
 
 		MutablePersistentEntity<Person, T> entity = createEntity(Person.class);
 
+		when(property.getName()).thenReturn("id");
 		when(property.isIdProperty()).thenReturn(true);
 		when(anotherProperty.isIdProperty()).thenReturn(true);
+		when(anotherProperty.getName()).thenReturn("another");
 
 		entity.addPersistentProperty(property);
 		exception.expect(MappingException.class);
@@ -406,7 +409,7 @@ public class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 
 		private final Long id = 42L;
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.domain.Persistable#getId()
 		 */
@@ -415,7 +418,7 @@ public class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 			return 4711L;
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.domain.Persistable#isNew()
 		 */


### PR DESCRIPTION
We now use `ConcurrentHashMap` to store persistent properties of a `PersistentEntity` and to prevent eviction caused by GC activity. Previously, we used `ConcurrentReferenceHashMap` defaulting to soft references. Soft references can be cleared at the discretion of the GC in response to memory demand. So a default `ConcurrentReferenceHashMap` is memory-sensitive and acts like a cache with memory-based eviction rules.

Persistent properties are not subject to be cached but elements of a `PersistentEntity` and cannot be recovered once cleared.

---

Related ticket: [DATACMNS-1364](https://jira.spring.io/browse/DATACMNS-1364).