### PR TITLE
DATACMNS-1366 - Performance optimizations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1366-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -105,7 +105,7 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		this.constructor = PreferredConstructorDiscoverer.discover(this);
 		this.associations = comparator == null ? new HashSet<>() : new TreeSet<>(new AssociationComparator<>(comparator));
 
-		this.propertyCache = new HashMap<>();
+		this.propertyCache = new HashMap<>(16, 1f);
 		this.annotationCache = new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK);
 		this.propertyAnnotationCache = CollectionUtils
 				.toMultiValueMap(new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK));

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -507,7 +507,21 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 	 */
 	@Override
 	public Iterator<P> iterator() {
-		return Collections.unmodifiableList(properties).iterator();
+
+		Iterator<P> iterator = properties.iterator();
+
+		return new Iterator<P>() {
+
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+
+			@Override
+			public P next() {
+				return iterator.next();
+			}
+		};
 	}
 
 	protected EvaluationContext getEvaluationContext(Object rootObject) {

--- a/src/main/java/org/springframework/data/util/ClassTypeInformation.java
+++ b/src/main/java/org/springframework/data/util/ClassTypeInformation.java
@@ -30,8 +30,8 @@ import java.util.Set;
 
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
 
 /**
  * {@link TypeInformation} for a plain {@link Class}.
@@ -48,7 +48,8 @@ public class ClassTypeInformation<S> extends TypeDiscoverer<S> {
 	public static final ClassTypeInformation<Map> MAP = new ClassTypeInformation(Map.class);
 	public static final ClassTypeInformation<Object> OBJECT = new ClassTypeInformation(Object.class);
 
-	private static final Map<Class<?>, ClassTypeInformation<?>> CACHE = new ConcurrentReferenceHashMap<>();
+	private static final Map<Class<?>, ClassTypeInformation<?>> CACHE = new ConcurrentReferenceHashMap<>(16,
+			ReferenceType.WEAK);
 
 	static {
 		Arrays.asList(COLLECTION, LIST, SET, MAP, OBJECT).forEach(it -> CACHE.put(it.getType(), it));
@@ -67,7 +68,7 @@ public class ClassTypeInformation<S> extends TypeDiscoverer<S> {
 
 		Assert.notNull(type, "Type must not be null!");
 
-		return (ClassTypeInformation<S>) CACHE.computeIfAbsent(type, it -> new ClassTypeInformation<>(type));
+		return (ClassTypeInformation<S>) CACHE.computeIfAbsent(type, ClassTypeInformation::new);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -549,7 +549,15 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 
 		TypeDiscoverer<?> that = (TypeDiscoverer<?>) obj;
 
-		return this.type.equals(that.type) && this.typeVariableMap.equals(that.typeVariableMap);
+		if (!this.type.equals(that.type)) {
+			return false;
+		}
+
+		if (this.typeVariableMap.isEmpty() && that.typeVariableMap.isEmpty()) {
+			return true;
+		}
+
+		return this.typeVariableMap.equals(that.typeVariableMap);
 	}
 
 	/*


### PR DESCRIPTION
Various optimizations to improve CPU and memory consumption.


**Baseline**

```
Benchmark                                                                                       Mode  Cnt        Score         Error  Units
TypicalEntityReaderBenchmark.kotlinDataClass                                                   thrpt   10  5899638,348 ±   53829,186  ops/s
TypicalEntityReaderBenchmark.kotlinDataClassWithDefaulting                                     thrpt   10  2690653,960 ±   12988,854  ops/s
TypicalEntityReaderBenchmark.simpleEntityConstructorArgsCreation                               thrpt   10  4741691,355 ±   20735,714  ops/s
TypicalEntityReaderBenchmark.simpleEntityGeneratedFieldAccess                                  thrpt   10  7749539,715 ± 1845318,977  ops/s
TypicalEntityReaderBenchmark.simpleEntityGeneratedPropertyAccess                               thrpt   10  7859653,071 ±  195289,752  ops/s
TypicalEntityReaderBenchmark.simpleEntityReflectiveConstructorArgsCreation                     thrpt   10  4163905,432 ±  107432,148  ops/s
TypicalEntityReaderBenchmark.simpleEntityReflectivePropertyAccess                              thrpt   10  7437671,460 ±   96405,066  ops/s
TypicalEntityReaderBenchmark.simpleEntityReflectivePropertyAccessWithCustomConversionRegistry  thrpt   10  6911496,323 ±   64707,708  ops/s
```

**After optimizations**

```
Benchmark                                                                                       Mode  Cnt        Score        Error  Units
TypicalEntityReaderBenchmark.kotlinDataClass                                                   thrpt   10  6676400,185 ±  45164,682  ops/s
TypicalEntityReaderBenchmark.kotlinDataClassWithDefaulting                                     thrpt   10  2981338,468 ±  36943,754  ops/s
TypicalEntityReaderBenchmark.simpleEntityConstructorArgsCreation                               thrpt   10  4445213,022 ±  73618,043  ops/s
TypicalEntityReaderBenchmark.simpleEntityGeneratedFieldAccess                                  thrpt   10  8814664,064 ±  70241,114  ops/s
TypicalEntityReaderBenchmark.simpleEntityGeneratedPropertyAccess                               thrpt   10  7832454,991 ± 118872,563  ops/s
TypicalEntityReaderBenchmark.simpleEntityReflectiveConstructorArgsCreation                     thrpt   10  4564509,834 ±  38466,637  ops/s
TypicalEntityReaderBenchmark.simpleEntityReflectivePropertyAccess                              thrpt   10  8281840,412 ±  58915,514  ops/s
TypicalEntityReaderBenchmark.simpleEntityReflectivePropertyAccessWithCustomConversionRegistry  thrpt   10  7326248,088 ±  33168,993  ops/s
```

---

Related tickets: [DATACMNS-1366](https://jira.spring.io/browse/DATACMNS-1366), [DATACMNS-1366](https://jira.spring.io/browse/DATAMONGO-2046).