### PR TITLE
DATACMNS-1376 - Fix illegal access warning in DefaultMethodInvokingMethodInterceptor on Java 9 and higher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1376-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/asciidoc/auditing.adoc
+++ b/src/main/asciidoc/auditing.adoc
@@ -37,7 +37,7 @@ There is also a convenience base class, `AbstractAuditable`, which you can exten
 [[auditing.auditor-aware]]
 === `AuditorAware`
 
-In case you use either `@CreatedBy` or `@LastModifiedBy`, the auditing infrastructure somehow needs to become aware of the current principal. To do so, we provide an `AuditorAware<T>` SPI interface that you have to implement to tell the infrastructure who the current user or system interacting with the application is. The generic type `T` defines what type the properties annotated with `@CreatedBy` or `@LastModifiedBy` have to be.
+In case you use either `@CreatedBy` or `@LastModifiedBy`, the auditing infrastructure somehow needs to become aware of the current principal. To do so, we provide an `AuditorAware<T>` SPI interface that you have to implement to tell the infrastructure who the current user or system interacting with the application is. The generic type `T` defines what type the properties annotated with `@CreatedBy` or `@LastModifiedBy` have to be. You can register multiple implementations as Spring beans to support different auditor types.
 
 The following example shows an implementation of the interface that uses Spring Security's `Authentication` object:
 
@@ -61,4 +61,4 @@ class SpringSecurityAuditorAware implements AuditorAware<User> {
 ----
 ====
 
-The implementation accesses the `Authentication` object provided by Spring Security and looks up the custom `UserDetails` instance that you have created in your `UserDetailsService` implementation. We assume here that you are exposing the domain user through the `UserDetails` implementation but that, based on the `Authentication` found, you could also look it up from anywhere.
+The implementation accesses the `Authentication` object provided by Spring Security and looks up the custom `UserDetails` instance that you have created in your `UserDetailsService` implementation. Here we assume that you are exposing the domain user through the `UserDetails` implementation but that, based on the `Authentication` found, you could also look it up from anywhere.

--- a/src/main/java/org/springframework/data/auditing/AuditableBeanWrapper.java
+++ b/src/main/java/org/springframework/data/auditing/AuditableBeanWrapper.java
@@ -70,4 +70,20 @@ public interface AuditableBeanWrapper<T> {
 	 * @since 2.1
 	 */
 	T getBean();
+
+	/**
+	 * Return the type used as creator.
+	 * 
+	 * @return
+	 * @since 2.1
+	 */
+	Optional<Class<?>> getCreatorType();
+
+	/**
+	 * Return the used as modifier.
+	 * 
+	 * @return
+	 * @since 2.1
+	 */
+	Optional<Class<?>> getModifierType();
 }

--- a/src/main/java/org/springframework/data/auditing/AuditingHandler.java
+++ b/src/main/java/org/springframework/data/auditing/AuditingHandler.java
@@ -15,20 +15,37 @@
  */
 package org.springframework.data.auditing;
 
+import lombok.RequiredArgsConstructor;
+
 import java.time.temporal.TemporalAccessor;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.support.AopUtils;
-import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.core.ResolvableType;
 import org.springframework.data.domain.Auditable;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.util.BeanLookup;
+import org.springframework.data.util.Lazy;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -38,14 +55,14 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @since 1.5
  */
-public class AuditingHandler implements InitializingBean {
+public class AuditingHandler implements BeanFactoryAware {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AuditingHandler.class);
 
 	private final DefaultAuditableBeanWrapperFactory factory;
 
 	private DateTimeProvider dateTimeProvider = CurrentDateTimeProvider.INSTANCE;
-	private Optional<AuditorAware<?>> auditorAware;
+	private @Nullable Lazy<AuditorAwareAdapter> auditorAware;
 	private boolean dateTimeForNow = true;
 	private boolean modifyOnCreation = true;
 
@@ -75,7 +92,6 @@ public class AuditingHandler implements InitializingBean {
 		Assert.notNull(entities, "PersistentEntities must not be null!");
 
 		this.factory = new MappingAuditableBeanWrapperFactory(entities);
-		this.auditorAware = Optional.empty();
 	}
 
 	/**
@@ -86,7 +102,7 @@ public class AuditingHandler implements InitializingBean {
 	public void setAuditorAware(AuditorAware<?> auditorAware) {
 
 		Assert.notNull(auditorAware, "AuditorAware must not be null!");
-		this.auditorAware = Optional.of(auditorAware);
+		this.auditorAware = Lazy.of(new AuditorAwareAdapter(Collections.singleton(auditorAware)));
 	}
 
 	/**
@@ -117,6 +133,26 @@ public class AuditingHandler implements InitializingBean {
 	 */
 	public void setDateTimeProvider(DateTimeProvider dateTimeProvider) {
 		this.dateTimeProvider = dateTimeProvider == null ? CurrentDateTimeProvider.INSTANCE : dateTimeProvider;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org.springframework.beans.factory.BeanFactory)
+	 */
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+
+		if (!ListableBeanFactory.class.isInstance(beanFactory) || auditorAware != null) {
+			return;
+		}
+
+		Supplier<Collection<? extends AuditorAware>> orderedBeansOfType = () -> BeanLookup
+				.orderedBeansOfType(AuditorAware.class, beanFactory);
+
+		this.auditorAware = Lazy.of(orderedBeansOfType) //
+				.map(Collection.class::cast) // weird but needed as the compiler doesn't allow the following cast
+				.map(it -> new AuditorAwareAdapter((Collection<? extends AuditorAware<?>>) it));
 	}
 
 	/**
@@ -162,20 +198,20 @@ public class AuditingHandler implements InitializingBean {
 
 		return wrapper.map(it -> {
 
-			Optional<Object> auditor = touchAuditor(it, isNew);
 			Optional<TemporalAccessor> now = dateTimeForNow ? touchDate(it, isNew) : Optional.empty();
 
-			if (LOGGER.isDebugEnabled()) {
-
-				Object defaultedNow = now.map(Object::toString).orElse("not set");
-				Object defaultedAuditor = auditor.map(Object::toString).orElse("unknown");
-
-				LOGGER.debug("Touched {} - Last modification at {} by {}", target, defaultedNow, defaultedAuditor);
-			}
+			touchAuditor(target, it, isNew, now);
 
 			return it.getBean();
 
 		}).orElse(target);
+	}
+
+	private AuditorAwareAdapter getAuditorAware() {
+
+		Lazy<AuditorAwareAdapter> toUse = auditorAware;
+
+		return toUse == null ? AuditorAwareAdapter.EMPTY : toUse.get();
 	}
 
 	/**
@@ -184,22 +220,30 @@ public class AuditingHandler implements InitializingBean {
 	 * @param auditable
 	 * @return
 	 */
-	private Optional<Object> touchAuditor(AuditableBeanWrapper<?> wrapper, boolean isNew) {
+	private void touchAuditor(Object target, AuditableBeanWrapper<?> wrapper, boolean isNew,
+			Optional<TemporalAccessor> time) {
 
 		Assert.notNull(wrapper, "AuditableBeanWrapper must not be null!");
 
-		return auditorAware.map(it -> {
+		AuditorLookup lookup = new AuditorLookup(getAuditorAware());
 
-			Optional<?> auditor = it.getCurrentAuditor();
+		if (isNew) {
 
-			Assert.notNull(auditor,
-					() -> String.format("Auditor must not be null! Returned by: %s!", AopUtils.getTargetClass(it)));
+			Optional<?> creator = wrapper.getCreatorType() //
+					.flatMap(lookup::getTypedAuditor) //
+					.map(wrapper::setCreatedBy);
 
-			auditor.filter(__ -> isNew).ifPresent(foo -> wrapper.setCreatedBy(foo));
-			auditor.filter(__ -> !isNew || modifyOnCreation).ifPresent(foo -> wrapper.setLastModifiedBy(foo));
+			logModification(target, time, creator, "Touched {} for creation by {} at {}!");
+		}
 
-			return auditor;
-		});
+		if (!isNew || modifyOnCreation) {
+
+			Optional<?> modifier = wrapper.getModifierType() //
+					.flatMap(lookup::getTypedAuditor) //
+					.map(wrapper::setLastModifiedBy);
+
+			logModification(target, time, modifier, "Touched {} for modification by {} at {}!");
+		}
 	}
 
 	/**
@@ -222,14 +266,97 @@ public class AuditingHandler implements InitializingBean {
 		return now;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
-	 */
-	public void afterPropertiesSet() {
+	private static void logModification(Object target, Optional<TemporalAccessor> time, Optional<?> auditor,
+			String template) {
 
-		if (!auditorAware.isPresent()) {
-			LOGGER.debug("No AuditorAware set! Auditing will not be applied!");
+		if (!LOGGER.isDebugEnabled()) {
+			return;
+		}
+
+		Object defaultedNow = time.map(Object::toString).orElse("not set");
+		Object defaultedAuditor = auditor.map(Object::toString).orElse("unknown");
+
+		LOGGER.debug(template, target, defaultedAuditor, defaultedNow);
+	}
+
+	/**
+	 * Simple value object to cache auditor lookups by type so that we don't unnecessarily invoke {@link AuditorAware}
+	 * instances for the same type multiple times.
+	 *
+	 * @author Oliver Gierke
+	 */
+	@RequiredArgsConstructor
+	private static class AuditorLookup {
+
+		private final AuditorAwareAdapter adapter;
+		private final Map<Class<?>, Optional<?>> resolvedAuditors = new HashMap<>(2);
+
+		/**
+		 * Returns the auditor of the given type.
+		 * 
+		 * @param type must not be {@literal null}.
+		 * @return
+		 */
+		public Optional<?> getTypedAuditor(Class<?> type) {
+
+			return resolvedAuditors.computeIfAbsent(type,
+					it -> adapter.getAuditorAwareFor(it).flatMap(AuditorLookup::lookupAuditor));
+		}
+
+		private static Optional<?> lookupAuditor(AuditorAware<?> auditorAware) {
+
+			Optional<?> auditor = auditorAware.getCurrentAuditor();
+
+			Assert.notNull(auditor,
+					() -> String.format("Auditor must not be null! Returned by: %s!", AopUtils.getTargetClass(auditorAware)));
+
+			return auditor;
+		}
+	}
+
+	/**
+	 * Simple registry that allows per auditor type lookups of {@link AuditorAware} instances.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.1
+	 */
+	private static class AuditorAwareAdapter {
+
+		private static final AuditorAwareAdapter EMPTY = new AuditorAwareAdapter(Collections.emptyList());
+
+		private final Map<Class<?>, AuditorAware<?>> delegates;
+
+		public AuditorAwareAdapter(Collection<? extends AuditorAware<?>> delegates) {
+
+			this.delegates = delegates.stream()
+					.collect(Collectors.toMap(AuditorAwareAdapter::determineGenericArgument, Function.identity()));
+		}
+
+		/**
+		 * Returns the {@link AuditorAware} for the given auditor type.
+		 * 
+		 * @param auditorType must not be {@literal null}.
+		 * @return
+		 */
+		public Optional<AuditorAware<?>> getAuditorAwareFor(Class<?> auditorType) {
+
+			return delegates.entrySet().stream()//
+					.filter(it -> it.getKey().isAssignableFrom(auditorType))//
+					.findFirst()//
+					.map(Entry::getValue);
+		}
+
+		private static Class<?> determineGenericArgument(AuditorAware<?> auditorAware) {
+
+			Class<?> resolvedType = ResolvableType.forClass(AuditorAware.class, auditorAware.getClass()) //
+					.getGeneric(0).resolve();
+
+			if (resolvedType == null) {
+				throw new IllegalStateException(
+						String.format("Cannot determine auditor type for AuditorAware %s!", auditorAware.getClass()));
+			}
+
+			return resolvedType;
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -229,6 +229,29 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 			return accessor.getBean();
 		}
 
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.auditing.AuditableBeanWrapper#getCreatorType()
+		 */
+		@Override
+		public Optional<Class<?>> getCreatorType() {
+
+			return metadata.createdByPaths.getFirst() //
+					.map(path -> path.getLeafProperty()) //
+					.map(PersistentProperty::getType);
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.auditing.AuditableBeanWrapper#getModifierType()
+		 */
+		@Override
+		public Optional<Class<?>> getModifierType() {
+			return metadata.lastModifiedByPaths.getFirst() //
+					.map(path -> path.getLeafProperty()) //
+					.map(PersistentProperty::getType);
+		}
+
 		private <S, P extends PersistentProperty<?>> S setProperty(
 				PersistentPropertyPaths<?, ? extends PersistentProperty<?>> paths, S value) {
 

--- a/src/main/java/org/springframework/data/projection/DefaultMethodInvokingMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/projection/DefaultMethodInvokingMethodInterceptor.java
@@ -21,13 +21,13 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.lang.reflect.Modifier;
 import java.util.Map;
-import java.util.Optional;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.aop.ProxyMethodInvocation;
+import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ConcurrentReferenceHashMap;
 import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
@@ -86,37 +86,6 @@ public class DefaultMethodInvokingMethodInterceptor implements MethodInterceptor
 	enum MethodHandleLookup {
 
 		/**
-		 * Open (via reflection construction of {@link MethodHandles.Lookup}) method handle lookup. Works with Java 8 and
-		 * with Java 9 permitting illegal access.
-		 */
-		OPEN {
-
-			private final Optional<Constructor<Lookup>> constructor = getLookupConstructor();
-
-			/*
-			 * (non-Javadoc)
-			 * @see org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup#lookup(java.lang.reflect.Method)
-			 */
-			@Override
-			MethodHandle lookup(Method method) throws ReflectiveOperationException {
-
-				Constructor<Lookup> constructor = this.constructor
-						.orElseThrow(() -> new IllegalStateException("Could not obtain MethodHandles.lookup constructor"));
-
-				return constructor.newInstance(method.getDeclaringClass()).unreflectSpecial(method, method.getDeclaringClass());
-			}
-
-			/*
-			 * (non-Javadoc)
-			 * @see org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup#isAvailable()
-			 */
-			@Override
-			boolean isAvailable() {
-				return constructor.isPresent();
-			}
-		},
-
-		/**
 		 * Encapsulated {@link MethodHandle} lookup working on Java 9.
 		 */
 		ENCAPSULATED {
@@ -131,10 +100,82 @@ public class DefaultMethodInvokingMethodInterceptor implements MethodInterceptor
 			@Override
 			MethodHandle lookup(Method method) throws ReflectiveOperationException {
 
-				MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
+				if (privateLookupIn == null) {
+					throw new IllegalStateException("Could not obtain MethodHandles.privateLookupIn!");
+				}
 
-				return getLookup(method.getDeclaringClass(), privateLookupIn).findSpecial(method.getDeclaringClass(),
-						method.getName(), methodType, method.getDeclaringClass());
+				return doLookup(method, getLookup(method.getDeclaringClass(), privateLookupIn));
+			}
+
+			/*
+			 * (non-Javadoc)
+			 * @see org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup#isAvailable()
+			 */
+			@Override
+			boolean isAvailable() {
+				return privateLookupIn != null;
+			}
+
+			private Lookup getLookup(Class<?> declaringClass, Method privateLookupIn) {
+
+				Lookup lookup = MethodHandles.lookup();
+
+				try {
+					return (Lookup) privateLookupIn.invoke(MethodHandles.class, declaringClass, lookup);
+				} catch (ReflectiveOperationException e) {
+					return lookup;
+				}
+			}
+		},
+
+		/**
+		 * Open (via reflection construction of {@link MethodHandles.Lookup}) method handle lookup. Works with Java 8 and
+		 * with Java 9 permitting illegal access.
+		 */
+		OPEN {
+
+			private final Lazy<Constructor<Lookup>> constructor = Lazy.of(MethodHandleLookup::getLookupConstructor);
+
+			/*
+			 * (non-Javadoc)
+			 * @see org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup#lookup(java.lang.reflect.Method)
+			 */
+			@Override
+			MethodHandle lookup(Method method) throws ReflectiveOperationException {
+
+				if (!isAvailable()) {
+					throw new IllegalStateException("Could not obtain MethodHandles.lookup constructor!");
+				}
+
+				Constructor<Lookup> constructor = this.constructor.get();
+
+				return constructor.newInstance(method.getDeclaringClass()).unreflectSpecial(method, method.getDeclaringClass());
+			}
+
+			/*
+			 * (non-Javadoc)
+			 * @see org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup#isAvailable()
+			 */
+			@Override
+			boolean isAvailable() {
+				return constructor.orElse(null) != null;
+			}
+		},
+
+		/**
+		 * Fallback {@link MethodHandle} lookup using {@link MethodHandles#lookup() public lookup}.
+		 *
+		 * @since 2.1
+		 */
+		FALLBACK {
+
+			/*
+			 * (non-Javadoc)
+			 * @see org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup#lookup(java.lang.reflect.Method)
+			 */
+			@Override
+			MethodHandle lookup(Method method) throws ReflectiveOperationException {
+				return doLookup(method, MethodHandles.lookup());
 			}
 
 			/*
@@ -145,22 +186,19 @@ public class DefaultMethodInvokingMethodInterceptor implements MethodInterceptor
 			boolean isAvailable() {
 				return true;
 			}
-
-			private Lookup getLookup(Class<?> declaringClass, @Nullable Method privateLookupIn) {
-
-				if (privateLookupIn == null) {
-					return MethodHandles.lookup();
-				}
-
-				Lookup lookup = MethodHandles.lookup();
-
-				try {
-					return (Lookup) privateLookupIn.invoke(MethodHandles.class, declaringClass, lookup);
-				} catch (ReflectiveOperationException e) {
-					return lookup;
-				}
-			}
 		};
+
+		private static MethodHandle doLookup(Method method, Lookup lookup)
+				throws NoSuchMethodException, IllegalAccessException {
+
+			MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
+
+			if (Modifier.isStatic(method.getModifiers())) {
+				return lookup.findStatic(method.getDeclaringClass(), method.getName(), methodType);
+			}
+
+			return lookup.findSpecial(method.getDeclaringClass(), method.getName(), methodType, method.getDeclaringClass());
+		}
 
 		/**
 		 * Lookup a {@link MethodHandle} given {@link Method} to look up.
@@ -184,26 +222,30 @@ public class DefaultMethodInvokingMethodInterceptor implements MethodInterceptor
 		 */
 		public static MethodHandleLookup getMethodHandleLookup() {
 
-			return Arrays.stream(MethodHandleLookup.values()) //
-					.filter(it -> it.isAvailable()) //
-					.findFirst() //
-					.orElseThrow(() -> new IllegalStateException("No MethodHandleLookup available!"));
+			for (MethodHandleLookup it : MethodHandleLookup.values()) {
+
+				if (it.isAvailable()) {
+					return it;
+				}
+			}
+
+			throw new IllegalStateException("No MethodHandleLookup available!");
 		}
 
-		private static Optional<Constructor<Lookup>> getLookupConstructor() {
+		@Nullable
+		private static Constructor<Lookup> getLookupConstructor() {
 
 			try {
 
 				Constructor<Lookup> constructor = Lookup.class.getDeclaredConstructor(Class.class);
 				ReflectionUtils.makeAccessible(constructor);
 
-				return Optional.of(constructor);
-
+				return constructor;
 			} catch (Exception ex) {
 
 				// this is the signal that we are on Java 9 (encapsulated) and can't use the accessible constructor approach.
 				if (ex.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
-					return Optional.empty();
+					return null;
 				}
 
 				throw new IllegalStateException(ex);

--- a/src/main/java/org/springframework/data/util/BeanLookup.java
+++ b/src/main/java/org/springframework/data/util/BeanLookup.java
@@ -17,6 +17,7 @@ package org.springframework.data.util;
 
 import lombok.experimental.UtilityClass;
 
+import java.util.Collection;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -24,6 +25,9 @@ import javax.annotation.Nullable;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.Order;
 import org.springframework.util.Assert;
 
 /**
@@ -53,6 +57,26 @@ public class BeanLookup {
 		Assert.isInstanceOf(ListableBeanFactory.class, beanFactory);
 
 		return Lazy.of(() -> lookupBean(type, (ListableBeanFactory) beanFactory));
+	}
+
+	/**
+	 * Returns all beans of the given type ordered (i.e. sorted by what they expressed via {@link Order} or
+	 * {@link Ordered}.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param beanFactory must not be {@literal null} but an instance of {@link ListableBeanFactory}.
+	 * @return
+	 */
+	public static <T> Collection<? extends T> orderedBeansOfType(Class<T> type, BeanFactory beanFactory) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.isInstanceOf(ListableBeanFactory.class, beanFactory);
+
+		Collection<T> result = ((ListableBeanFactory) beanFactory).getBeansOfType(type, false, false).values();
+
+		AnnotationAwareOrderComparator.sortIfNecessary(result);
+
+		return result;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/auditing/AuditingHandlerUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/AuditingHandlerUnitTests.java
@@ -22,8 +22,15 @@ import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.mapping.context.SampleMappingContext;
 
 /**
  * Unit test for {@code AuditingHandler}.
@@ -32,10 +39,23 @@ import org.springframework.data.mapping.context.PersistentEntities;
  * @since 1.5
  */
 @SuppressWarnings("unchecked")
+@RunWith(MockitoJUnitRunner.class)
 public class AuditingHandlerUnitTests {
 
+	static class AuditedUserAuditorAware implements AuditorAware<AuditedUser> {
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.domain.AuditorAware#getCurrentAuditor()
+		 */
+		@Override
+		public Optional<AuditedUser> getCurrentAuditor() {
+			return Optional.empty();
+		}
+	}
+
 	AuditingHandler handler;
-	AuditorAware<AuditedUser> auditorAware;
+	@Mock AuditedUserAuditorAware auditorAware;
 
 	AuditedUser user;
 
@@ -45,12 +65,16 @@ public class AuditingHandlerUnitTests {
 		handler = getHandler();
 		user = new AuditedUser();
 
-		auditorAware = mock(AuditorAware.class);
 		when(auditorAware.getCurrentAuditor()).thenReturn(Optional.of(user));
 	}
 
 	protected AuditingHandler getHandler() {
-		return new AuditingHandler(PersistentEntities.of());
+
+		SampleMappingContext context = new SampleMappingContext();
+		context.getPersistentEntity(MixedAuditors.class);
+		context.afterPropertiesSet();
+
+		return new AuditingHandler(PersistentEntities.of(context));
 	}
 
 	/**
@@ -151,5 +175,73 @@ public class AuditingHandlerUnitTests {
 		handler.markCreated(user);
 
 		verify(provider, times(1)).getNow();
+	}
+
+	@Test // DATACMNS-1269
+	public void detectsAuditorAwareBeansFromBeanFactory() {
+
+		DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+		factory.registerSingleton("first", new LongAuditorAware());
+		factory.registerSingleton("second", new StringAuditorAware());
+
+		handler.setBeanFactory(factory);
+
+		MixedAuditors probe = new MixedAuditors();
+
+		handler.markCreated(probe);
+
+		assertThat(probe.creator).isEqualTo(1L);
+		assertThat(probe.modifier).isEqualTo("foo");
+	}
+
+	@Test // DATACMNS-1269
+	public void manuallyConfiguredAuditorAwareTrumpsBeanFactory() {
+
+		// Given a manually configured AuditorAware
+		handler.setAuditorAware(auditorAware);
+
+		// and other implementations present in a BeanFactory
+		DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+		factory.registerSingleton("first", new LongAuditorAware());
+		factory.registerSingleton("second", new StringAuditorAware());
+
+		handler.setBeanFactory(factory);
+
+		MixedAuditors probe = new MixedAuditors();
+
+		// when auditing is triggered
+		handler.markCreated(probe);
+
+		// the beans in the BeanFactory do not get applied
+		assertThat(probe.creator).isNull();
+		assertThat(probe.modifier).isNull();
+
+		handler.markCreated(user);
+
+		// but only the configured instance
+		assertThat(user.createdBy).isEqualTo(user);
+		assertThat(user.modifiedBy).isEqualTo(user);
+	}
+
+	static class LongAuditorAware implements AuditorAware<Long> {
+
+		@Override
+		public Optional<Long> getCurrentAuditor() {
+			return Optional.of(1L);
+		}
+	}
+
+	static class StringAuditorAware implements AuditorAware<String> {
+
+		@Override
+		public Optional<String> getCurrentAuditor() {
+			return Optional.of("foo");
+		}
+	}
+
+	static class MixedAuditors {
+
+		@CreatedBy Long creator;
+		@LastModifiedBy String modifier;
 	}
 }

--- a/src/test/java/org/springframework/data/auditing/IsNewAwareAuditingHandlerUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/IsNewAwareAuditingHandlerUnitTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -36,18 +35,15 @@ import org.springframework.data.mapping.context.SampleMappingContext;
 @RunWith(MockitoJUnitRunner.class)
 public class IsNewAwareAuditingHandlerUnitTests extends AuditingHandlerUnitTests {
 
-	SampleMappingContext mappingContext;
-
-	@Before
-	public void init() {
-
-		this.mappingContext = new SampleMappingContext();
-		this.mappingContext.getPersistentEntity(AuditedUser.class);
-		this.mappingContext.afterPropertiesSet();
-	}
-
 	@Override
 	protected IsNewAwareAuditingHandler getHandler() {
+
+		SampleMappingContext mappingContext = new SampleMappingContext();
+
+		mappingContext.getPersistentEntity(AuditedUser.class);
+		mappingContext.getPersistentEntity(MixedAuditors.class);
+		mappingContext.afterPropertiesSet();
+
 		return new IsNewAwareAuditingHandler(PersistentEntities.of(mappingContext));
 	}
 

--- a/src/test/java/org/springframework/data/projection/DefaultMethodInvokingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/DefaultMethodInvokingMethodInterceptorUnitTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.projection;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assume.*;
+
+import org.junit.Test;
+import org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.MethodHandleLookup;
+import org.springframework.data.util.Version;
+
+/**
+ * Unit tests for {@link DefaultMethodInvokingMethodInterceptor}.
+ *
+ * @author Mark Paluch
+ */
+public class DefaultMethodInvokingMethodInterceptorUnitTests {
+
+	@Test // DATACMNS-1376
+	public void shouldApplyEncapsulatedLookupOnJava9AndHigher() {
+
+		Version version = Version.parse(System.getProperty("java.version"));
+
+		assumeTrue(version.isGreaterThanOrEqualTo(Version.parse("9.0")));
+
+		assertThat(MethodHandleLookup.getMethodHandleLookup()).isEqualTo(MethodHandleLookup.ENCAPSULATED);
+		assertThat(MethodHandleLookup.ENCAPSULATED.isAvailable()).isTrue();
+	}
+
+	@Test // DATACMNS-1376
+	public void shouldApplyOpenLookupOnJava8() {
+
+		Version version = Version.parse(System.getProperty("java.version"));
+
+		assumeTrue(version.isLessThan(Version.parse("1.8.9999")));
+
+		assertThat(MethodHandleLookup.getMethodHandleLookup()).isEqualTo(MethodHandleLookup.OPEN);
+		assertThat(MethodHandleLookup.OPEN.isAvailable()).isTrue();
+		assertThat(MethodHandleLookup.ENCAPSULATED.isAvailable()).isFalse();
+	}
+}


### PR DESCRIPTION
We now attempt to use private `MethodHandles` lookup as the first mechanism to resolve a MethodHandle for default interface methods and fall back to reflection-based Lookup construction if private lookup is not available. Reflective availability is checked lazily to prevent illegal access on enum constant construction. This approach prevents an illegal access which was logged by attempting a reflection-based lookup first.

We also introduced a `FALLBACK` mechanism to split encapsulated access from a fallback mechanism.

---

Related ticket: [DATACMNS-1376](https://jira.spring.io/browse/DATACMNS-1376).