### PR TITLE
DATACMNS-1373 - Use ReflectUtils.defineClass(…) to load generated EntityInstantiators.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1373-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/test/java/org/springframework/data/convert/ClassGeneratingEntityInstantiatorUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/ClassGeneratingEntityInstantiatorUnitTests.java
@@ -303,6 +303,66 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 		});
 	}
 
+	@Test // DATACMNS-1373
+	public void shouldInstantiateProtectedInnerClass() {
+
+		prepareMocks(ProtectedInnerClass.class);
+
+		assertThat(this.instance.shouldUseReflectionEntityInstantiator(entity)).isFalse();
+		assertThat(this.instance.createInstance(entity, provider)).isInstanceOf(ProtectedInnerClass.class);
+	}
+
+	@Test // DATACMNS-1373
+	public void shouldInstantiatePackagePrivateInnerClass() {
+
+		prepareMocks(PackagePrivateInnerClass.class);
+
+		assertThat(this.instance.shouldUseReflectionEntityInstantiator(entity)).isFalse();
+		assertThat(this.instance.createInstance(entity, provider)).isInstanceOf(PackagePrivateInnerClass.class);
+	}
+
+	@Test // DATACMNS-1373
+	public void shouldNotInstantiatePrivateInnerClass() {
+
+		prepareMocks(PrivateInnerClass.class);
+
+		assertThat(this.instance.shouldUseReflectionEntityInstantiator(entity)).isTrue();
+	}
+
+	@Test // DATACMNS-1373
+	public void shouldInstantiateClassWithPackagePrivateConstructor() {
+
+		prepareMocks(ClassWithPackagePrivateConstructor.class);
+
+		assertThat(this.instance.shouldUseReflectionEntityInstantiator(entity)).isFalse();
+		assertThat(this.instance.createInstance(entity, provider)).isInstanceOf(ClassWithPackagePrivateConstructor.class);
+	}
+
+	@Test // DATACMNS-1373
+	public void shouldInstantiateClassInDefaultPackage() throws ClassNotFoundException {
+
+		Class<?> typeInDefaultPackage = Class.forName("TypeInDefaultPackage");
+		prepareMocks(typeInDefaultPackage);
+
+		assertThat(this.instance.shouldUseReflectionEntityInstantiator(entity)).isFalse();
+		assertThat(this.instance.createInstance(entity, provider)).isInstanceOf(typeInDefaultPackage);
+	}
+
+	@Test // DATACMNS-1373
+	public void shouldNotInstantiateClassWithPrivateConstructor() {
+
+		prepareMocks(ClassWithPrivateConstructor.class);
+
+		assertThat(this.instance.shouldUseReflectionEntityInstantiator(entity)).isTrue();
+	}
+
+	private void prepareMocks(Class<?> type) {
+
+		doReturn(type).when(entity).getType();
+		doReturn(PreferredConstructorDiscoverer.discover(type))//
+				.when(entity).getPersistenceConstructor();
+	}
+
 	static class Foo {
 
 		Foo(String foo) {
@@ -424,4 +484,21 @@ public class ClassGeneratingEntityInstantiatorUnitTests<P extends PersistentProp
 			this.param7 = param7;
 		}
 	}
+
+	protected static class ProtectedInnerClass {}
+
+	static class PackagePrivateInnerClass {}
+
+	private static class PrivateInnerClass {}
+
+	static class ClassWithPrivateConstructor {
+
+		private ClassWithPrivateConstructor() {}
+	}
+
+	static class ClassWithPackagePrivateConstructor {
+
+		ClassWithPackagePrivateConstructor() {}
+	}
+
 }


### PR DESCRIPTION
We now use `ReflectUtils.defineClass(…)` to load generated EntityInstantiators which uses internally either `MethodHandles.Lookup.defineClass(…)`(on Java 9 and higher) or reflective `defineClass` invocation on the entity `ClassLoader`. Class injection into the originating `ClassLoader` assigns the `ClassLoader` of the entity to the generated class which allows optimized instantiation of package-protected classes and constructors.

---

Related ticket: [DATACMNS-1373](https://jira.spring.io/browse/DATACMNS-1373).