### PR TITLE
DATACMNS-1391 - Use preferred constructors to discover Kotlin's copy method.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATACMNS-1391-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/KotlinCopyMethod.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinCopyMethod.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KClass;
+import kotlin.reflect.KFunction;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.KParameter.Kind;
+import kotlin.reflect.full.KClasses;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+import lombok.Getter;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.SimplePropertyHandler;
+import org.springframework.util.Assert;
+
+/**
+ * Value object to represent a Kotlin {@code copy} method.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@Getter
+class KotlinCopyMethod {
+
+	private final Method publicCopyMethod;
+	private final Method syntheticCopyMethod;
+	private final int parameterCount;
+	private final KFunction<?> copyFunction;
+
+	/**
+	 * @param publicCopyMethod Compiler-generated public {@code copy} method accepting all properties.
+	 * @param syntheticCopyMethod Compiler-generated synthetic {@code copy$default} variant of the copy method accepting
+	 *          the original instance and defaulting masks.
+	 */
+	private KotlinCopyMethod(Method publicCopyMethod, Method syntheticCopyMethod) {
+
+		this.publicCopyMethod = publicCopyMethod;
+		this.syntheticCopyMethod = syntheticCopyMethod;
+		this.copyFunction = ReflectJvmMapping.getKotlinFunction(publicCopyMethod);
+		this.parameterCount = copyFunction.getParameters().size();
+	}
+
+	/**
+	 * Attempt to lookup the Kotlin {@code copy} method. Lookup happens in two stages: Find the synthetic copy method and
+	 * then attempt to resolve its public variant.
+	 *
+	 * @param type the class.
+	 * @return {@link Optional} {@link KotlinCopyMethod}.
+	 */
+	public static Optional<KotlinCopyMethod> findCopyMethod(Class<?> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+
+		Optional<Method> syntheticCopyMethod = findSyntheticCopyMethod(type);
+
+		if (!syntheticCopyMethod.isPresent()) {
+			return Optional.empty();
+		}
+
+		Optional<Method> publicCopyMethod = syntheticCopyMethod.flatMap(KotlinCopyMethod::findPublicCopyMethod);
+
+		return publicCopyMethod.map(method -> new KotlinCopyMethod(method, syntheticCopyMethod.get()));
+	}
+
+	/**
+	 * Check whether the {@link PersistentProperty} is accepted as part of the copy method.
+	 *
+	 * @param property
+	 * @return
+	 */
+	boolean supportsProperty(PersistentProperty<?> property) {
+		return forProperty(property).isPresent();
+	}
+
+	/**
+	 * Create metadata for {@literal copy$default} invocation.
+	 *
+	 * @param property
+	 * @return
+	 */
+	Optional<KotlinCopyByProperty> forProperty(PersistentProperty<?> property) {
+
+		int index = KotlinCopyByProperty.findIndex(copyFunction, property.getName());
+
+		if (index == -1) {
+			return Optional.empty();
+		}
+
+		return Optional.of(new KotlinCopyByProperty(copyFunction, property));
+	}
+
+	boolean shouldUsePublicCopyMethod(PersistentEntity<?, ?> entity) {
+
+		List<PersistentProperty<?>> persistentProperties = new ArrayList<>();
+		entity.doWithProperties((SimplePropertyHandler) persistentProperties::add);
+
+		if (persistentProperties.size() > 1) {
+			return false;
+		}
+
+		if (publicCopyMethod.getParameterCount() != 1) {
+			return false;
+		}
+
+		if (Modifier.isStatic(publicCopyMethod.getModifiers())) {
+			return false;
+		}
+
+		Class<?>[] parameterTypes = publicCopyMethod.getParameterTypes();
+
+		for (int i = 0; i < parameterTypes.length; i++) {
+			if (!parameterTypes[i].equals(persistentProperties.get(i).getType())) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Optional<Method> findPublicCopyMethod(Method defaultKotlinMethod) {
+
+		Class<?> type = defaultKotlinMethod.getDeclaringClass();
+		KClass<?> kotlinClass = JvmClassMappingKt.getKotlinClass(type);
+
+		KFunction<?> primaryConstructor = KClasses.getPrimaryConstructor(kotlinClass);
+
+		if (primaryConstructor == null) {
+			return Optional.empty();
+		}
+
+		List<KParameter> constructorArguments = primaryConstructor.getParameters() //
+				.stream() //
+				.filter(it -> it.getKind() == Kind.VALUE) //
+				.collect(Collectors.toList());
+
+		return Arrays.stream(type.getDeclaredMethods()).filter(it -> it.getName().equals("copy") //
+				&& !it.isSynthetic() //
+				&& !it.isBridge() //
+				&& !Modifier.isStatic(it.getModifiers()) //
+				&& it.getReturnType().equals(type) //
+				&& it.getParameterCount() == constructorArguments.size()) //
+				.filter(it -> {
+
+					KFunction<?> kotlinFunction = ReflectJvmMapping.getKotlinFunction(it);
+
+					if (kotlinFunction == null) {
+						return false;
+					}
+
+					return parameterMatches(constructorArguments, kotlinFunction);
+				}).findFirst();
+	}
+
+	private static boolean parameterMatches(List<KParameter> constructorArguments, KFunction<?> kotlinFunction) {
+
+		boolean foundInstance = false;
+		int constructorArgIndex = 0;
+
+		for (KParameter parameter : kotlinFunction.getParameters()) {
+
+			if (parameter.getKind() == Kind.INSTANCE) {
+				foundInstance = true;
+				continue;
+			}
+
+			if (constructorArguments.size() <= constructorArgIndex) {
+				return false;
+			}
+
+			KParameter constructorParameter = constructorArguments.get(constructorArgIndex);
+
+			if (!constructorParameter.getName().equals(parameter.getName())
+					|| !constructorParameter.getType().equals(parameter.getType())) {
+				return false;
+			}
+
+			constructorArgIndex++;
+		}
+
+		return foundInstance;
+	}
+
+	private static Optional<Method> findSyntheticCopyMethod(Class<?> type) {
+
+		return Arrays.stream(type.getDeclaredMethods()) //
+				.filter(it -> it.getName().equals("copy$default") //
+						&& Modifier.isStatic(it.getModifiers()) //
+						&& it.getReturnType().equals(type))
+				.filter(Method::isSynthetic) //
+				.filter(Method::isBridge) //
+				.findFirst();
+	}
+
+	/**
+	 * Value object to represent Kotlin {@literal copy$default} invocation metadata.
+	 *
+	 * @author Mark Paluch
+	 */
+	@Getter
+	static class KotlinCopyByProperty {
+
+		private final int parameterPosition;
+		private final int parameterCount;
+		private final KotlinDefaultMask defaultMask;
+
+		KotlinCopyByProperty(KFunction<?> copyFunction, PersistentProperty<?> property) {
+
+			this.parameterPosition = findIndex(copyFunction, property.getName());
+			this.parameterCount = copyFunction.getParameters().size();
+			this.defaultMask = KotlinDefaultMask.from(copyFunction, it -> property.getName().equals(it.getName()));
+		}
+
+		static int findIndex(KFunction<?> function, String parameterName) {
+
+			for (KParameter parameter : function.getParameters()) {
+				if (parameterName.equals(parameter.getName())) {
+					return parameter.getIndex();
+				}
+			}
+
+			return -1;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/mapping/model/KotlinDefaultMask.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinDefaultMask.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntConsumer;
+import java.util.function.Predicate;
+
+import kotlin.reflect.KFunction;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.KParameter.Kind;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Value object representing defaulting masks used for Kotlin methods applying parameter defaulting.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+class KotlinDefaultMask {
+
+	private final int[] defaulting;
+
+	/**
+	 * Callback method to notify {@link IntConsumer} for each defaulting mask.
+	 *
+	 * @param maskCallback must not be {@literal null}.
+	 */
+	public void forEach(IntConsumer maskCallback) {
+
+		for (int i : defaulting) {
+			maskCallback.accept(i);
+		}
+	}
+
+	/**
+	 * Creates defaulting mask(s) used to invoke Kotlin {@literal default} methods that conditionally apply parameter
+	 * values.
+	 *
+	 * @param function the {@link KFunction} that should be invoked.
+	 * @param isPresent {@link Predicate} for the presence/absence of parameters.
+	 * @return {@link KotlinDefaultMask}.
+	 */
+	public static KotlinDefaultMask from(KFunction<?> function, Predicate<KParameter> isPresent) {
+
+		List<Integer> masks = new ArrayList<>();
+		int index = 0;
+		int mask = 0;
+
+		List<KParameter> parameters = function.getParameters();
+
+		for (KParameter parameter : parameters) {
+
+			if (index != 0 && index % Integer.SIZE == 0) {
+				masks.add(mask);
+				mask = 0;
+			}
+
+			if (parameter.isOptional() && !isPresent.test(parameter)) {
+				mask = mask | (1 << (index % Integer.SIZE));
+			}
+
+			if (parameter.getKind() == Kind.VALUE) {
+				index++;
+			}
+		}
+
+		masks.add(mask);
+
+		return new KotlinDefaultMask(masks.stream().mapToInt(i -> i).toArray());
+	}
+}

--- a/src/test/kotlin/org/springframework/data/mapping/model/DataClasses.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/DataClasses.kt
@@ -15,11 +15,20 @@
  */
 package org.springframework.data.mapping.model
 
+import java.util.*
+
 /**
  * @author Mark Paluch
  */
 data class DataClassKt(val id: String) {
 }
 
-data class ExtendedDataClassKt(val id: String, val name: String) {
+data class ExtendedDataClassKt(val id: Long, val name: String) {
+	fun copy(name: String, id: Long): ExtendedDataClassKt {
+		throw UnsupportedOperationException("Wrong copy method")
+	}
+}
+
+data class SingleSettableProperty constructor(val id: UUID = UUID.randomUUID()) {
+	val version: Int? = null
 }

--- a/src/test/kotlin/org/springframework/data/mapping/model/UnusedCustomCopy.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/UnusedCustomCopy.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import java.sql.Timestamp
+
+/**
+ * @author Mark Paluch
+ */
+data class UnusedCustomCopy internal constructor(val date: Timestamp) {
+
+	fun copy(date: Long): UnusedCustomCopy {
+		return UnusedCustomCopy(Timestamp(date))
+	}
+}


### PR DESCRIPTION
We now use the primary constructor of Kotlin classes to discover the copy method. We use the primary constructor args to compare signatures and only use the copy method that takes all parameters in the constructor args order. This allows finding the appropriate copy method in case the class declares multiple copy methods.

We now also cache the copy method (`KCallable`) to reduce lookups.


---

Related ticket: [DATACMNS-1391](https://jira.spring.io/browse/DATACMNS-1391).

/cc @sdeleuze