### PR TITLE
DATACMNS-1400 - Do not consider bridge modifier in Kotlin default-method discovery.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1400-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 
@@ -20,6 +20,7 @@
 		<vavr>0.9.2</vavr>
 		<scala>2.11.7</scala>
 		<xmlbeam>1.4.15</xmlbeam>
+		<kotlin>1.3.0-rc-80</kotlin>
 
 		<java-module-name>spring.data.commons</java-module-name>
 	</properties>
@@ -405,12 +406,20 @@
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
+		<repository>
+			<id>kotlin-eap</id>
+			<url>http://dl.bintray.com/kotlin/kotlin-eap</url>
+		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-plugins-release</id>
 			<url>https://repo.spring.io/plugins-release</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>kotlin-eap</id>
+			<url>http://dl.bintray.com/kotlin/kotlin-eap</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/src/main/java/org/springframework/data/mapping/model/KotlinCopyMethod.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinCopyMethod.java
@@ -160,7 +160,6 @@ class KotlinCopyMethod {
 
 		return Arrays.stream(type.getDeclaredMethods()).filter(it -> it.getName().equals("copy") //
 				&& !it.isSynthetic() //
-				&& !it.isBridge() //
 				&& !Modifier.isStatic(it.getModifiers()) //
 				&& it.getReturnType().equals(type) //
 				&& it.getParameterCount() == constructorArguments.size()) //
@@ -212,7 +211,6 @@ class KotlinCopyMethod {
 						&& Modifier.isStatic(it.getModifiers()) //
 						&& it.getReturnType().equals(type))
 				.filter(Method::isSynthetic) //
-				.filter(Method::isBridge) //
 				.findFirst();
 	}
 


### PR DESCRIPTION
We now no longer consider bridge modifiers when looking up Kotlin default methods. We previously included checks whether a synthetic default method is also a bridge method to take all specifics of synthetic methods into account. With Kotlin 1.3, the compiler no longer sets the bridge flag. This behavior change would previously prevent usage of the copy method with classes compiled with Kotlin 1.3.

Default method discovery is still guesswork and Kotlin compiler reverse engineering as there is no documentation on how to look up this kind of methods.

Further references:
* https://youtrack.jetbrains.net/issue/KT-24415 - Remove bridge flag from default methods.
* https://youtrack.jetbrains.net/issue/KT-27317 - No documented rules for discoverability of generated methods.
f1e75bc

---

Related ticket: [DATACMNS-1400](https://jira.spring.io/browse/DATACMNS-1400).