### PR TITLE
DATACMNS-1401 - Provide context class on runtime class definition.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1401-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/ClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/ClassGeneratingEntityInstantiator.java
@@ -326,7 +326,7 @@ public class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 			Class<?> type = entity.getType();
 
 			try {
-				return ReflectUtils.defineClass(className, bytecode, type.getClassLoader(), type.getProtectionDomain());
+				return ReflectUtils.defineClass(className, bytecode, type.getClassLoader(), type.getProtectionDomain(), type);
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -1037,8 +1037,9 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 				mv.visitMethodInsn(INVOKEVIRTUAL, JAVA_LANG_INVOKE_METHOD_HANDLE, "invoke", String.format("(%s%s)%s",
 						referenceName(JAVA_LANG_OBJECT), referenceName(JAVA_LANG_OBJECT), getAccessibleTypeReferenceName(entity)),
 						false);
-
-				mv.visitTypeInsn(CHECKCAST, getAccessibleTypeReferenceName(entity));
+				if (isAccessible(entity)) {
+					mv.visitTypeInsn(CHECKCAST, Type.getInternalName(entity.getType()));
+				}
 			} else {
 
 				// this. <- for later PUTFIELD

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -318,7 +318,7 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 			Class<?> type = entity.getType();
 
 			try {
-				return ReflectUtils.defineClass(className, bytecode, type.getClassLoader(), type.getProtectionDomain());
+				return ReflectUtils.defineClass(className, bytecode, type.getClassLoader(), type.getProtectionDomain(), type);
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}


### PR DESCRIPTION
We now provide the context class for private `MethodHandle` lookup in the context of the actual entity class to properly use `MethodHandles.defineClass(…)` and to avoid illegal access warnings caused by reflective access to the `defineClass(…)` method on class loaders.

We also fix the cast in generated property accessor as we now use the internal type name without adding the reference type decorator when casting the result of a wither invocation. `CHECKCAST` allowed on earlier Java runtimes (version 8 and earlier) to use the reference decorator (`L…;`) around the type name. Java 9 and newer reject this format with a `ClassFormatError`.

---

Related ticket: [DATACMNS-1401](https://jira.spring.io/browse/DATACMNS-1401).