### PR TITLE
DATACMNS-1402 - Use best-effort caching in CustomConversions and DefaultTypeMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1396-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -393,7 +393,10 @@ public class CustomConversions {
 		public Class<?> computeIfAbsent(Class<?> sourceType, Class<?> targetType,
 				Function<ConvertiblePair, Class<?>> mappingFunction) {
 
-			TargetTypes targetTypes = customReadTargetTypes.computeIfAbsent(sourceType, TargetTypes::new);
+			TargetTypes targetTypes = customReadTargetTypes.get(sourceType);
+			if (targetTypes == null) {
+				targetTypes = customReadTargetTypes.computeIfAbsent(sourceType, TargetTypes::new);
+			}
 			return targetTypes.computeIfAbsent(targetType, mappingFunction);
 		}
 

--- a/src/main/java/org/springframework/data/convert/DefaultTypeMapper.java
+++ b/src/main/java/org/springframework/data/convert/DefaultTypeMapper.java
@@ -127,7 +127,14 @@ public class DefaultTypeMapper<S> implements TypeMapper<S> {
 	 */
 	@Nullable
 	private TypeInformation<?> getFromCacheOrCreate(Alias alias) {
-		return typeCache.computeIfAbsent(alias, getAlias).orElse(null);
+
+		Optional<TypeInformation<?>> typeInformation = typeCache.get(alias);
+
+		if (typeInformation == null) {
+			typeInformation = typeCache.computeIfAbsent(alias, getAlias);
+		}
+
+		return typeInformation.orElse(null);
 	}
 
 	/*


### PR DESCRIPTION
We now apply best-effort caching instead of atomic caching for custom conversions and type mapping. This change is a workaround for a Java 8 bug in `ConcurrentHashMap` where the `computeIfAbsent(…)` operation unconditionally locks nodes even when the node is already present.

The workaround is to assume the optimistic case by looking up the key and then falling back to computeIfAbsent if the value is absent.

Note: This bug was solved in Java 9 and later.

Before:
```
TypicalEntityReaderBenchmark.simpleEntityReflectivePropertyAccessWithCustomConversionRegistry  thrpt   10   6487423,969 ±  349449,326  ops/s
DefaultTypeMapperBenchmark.readTyped                                                           thrpt   10  38213392,961 ± 5080789,480  ops/s
DefaultTypeMapperBenchmark.readUntyped                                                         thrpt   10  47565238,929 ±  855200,560  ops/s
```

After:
```
TypicalEntityReaderBenchmark.simpleEntityReflectivePropertyAccessWithCustomConversionRegistry  thrpt   10    7361251,834 ±  278530,209  ops/s
DefaultTypeMapperBenchmark.readTyped                                                           thrpt   10  122523380,422 ± 3839365,439  ops/s
DefaultTypeMapperBenchmark.readUntyped                                                         thrpt   10  181767673,793 ± 3549021,260  ops/s
```

---

Related ticket: [DATACMNS-1396](https://jira.spring.io/browse/DATACMNS-1396).