### PR TITLE
Add PageRequest builder

### DIFF
--- a/src/main/java/org/springframework/data/domain/PageRequest.java
+++ b/src/main/java/org/springframework/data/domain/PageRequest.java
@@ -109,6 +109,10 @@ public class PageRequest extends AbstractPageRequest {
 		return of(page, size, Sort.by(direction, properties));
 	}
 
+	public static PageRequestBuilder pageRequest() {
+		return new PageRequestBuilder();
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.domain.Pageable#getSort()
@@ -177,5 +181,31 @@ public class PageRequest extends AbstractPageRequest {
 	@Override
 	public String toString() {
 		return String.format("Page request [number: %d, size %d, sort: %s]", getPageNumber(), getPageSize(), sort);
+	}
+
+	public static final class PageRequestBuilder {
+
+		private Sort sort = Sort.unsorted();
+		private int page;
+		private int size;
+
+		public PageRequestBuilder sort(Sort sort) {
+			this.sort = sort;
+			return this;
+		}
+
+		public PageRequestBuilder page(int page) {
+			this.page = page;
+			return this;
+		}
+
+		public PageRequestBuilder size(int size) {
+			this.size = size;
+			return this;
+		}
+
+		public PageRequest build() {
+			return PageRequest.of(page, size, sort);
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/domain/PageRequestUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/PageRequestUnitTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.domain;
 
+import static org.springframework.data.domain.PageRequest.pageRequest;
 import static org.springframework.data.domain.UnitTestUtils.*;
 
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class PageRequestUnitTests extends AbstractPageRequestUnitTests {
 	public void equalsRegardsSortCorrectly() {
 
 		Sort sort = Sort.by(Direction.DESC, "foo");
-		AbstractPageRequest request = PageRequest.of(0, 10, sort);
+		AbstractPageRequest request = pageRequest().page(0).size(10).sort(sort).build();
 
 		// Equals itself
 		assertEqualsAndHashcode(request, request);


### PR DESCRIPTION
This is a proposal PR for adding builder for `PageRequest` class.
Every time I see `PageRequest.of(0, 10)` in code I need to go into `PageRequest` to make sure that parameters were not mixed up. I think that having both parameters of the same type in constructor/static initializer is error prone. In this PR I would like to show you an example of how readable `PageRequest` could be. Please take a look. Thanks