### PR TITLE
DATACMNS-1421 - Lookup most specific wither method for a Property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1421-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
We now inspect all methods that match the wither method pattern (name, accepting a single argument) to find the most specific method returning the actual entity type.

Previously, we attempted to find a method only considering name and argument properties and not the return type. This lookup strategy could find a method returning the entity supertype that isn't assignable to the entity type.

---

Related ticket: [DATACMNS-1421](https://jira.spring.io/browse/DATACMNS-1421).