### PR TITLE
DATACMNS-1422 - Fall back to reflection-based PropertyAccessor/EntityInstantiator on inaccessible framework types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1422-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/ClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/convert/ClassGeneratingEntityInstantiator.java
@@ -154,6 +154,10 @@ public class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 			return true;
 		}
 
+		if (!ClassUtils.isPresent(ObjectInstantiator.class.getName(), type.getClassLoader())) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -55,6 +55,7 @@ import org.springframework.data.util.Optionals;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -139,7 +140,9 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 
 		Class<?> type = entity.getType();
 		return type.getClassLoader() != null
-				&& (type.getPackage() == null || !type.getPackage().getName().startsWith("java"));
+				&& (type.getPackage() == null || !type.getPackage().getName().startsWith("java"))
+				&& ClassUtils.isPresent(PersistentPropertyAccessor.class.getName(), type.getClassLoader())
+				&& ClassUtils.isPresent(Assert.class.getName(), type.getClassLoader());
 	}
 
 	private boolean hasUniquePropertyHashCodes(PersistentEntity<?, ?> entity) {
@@ -1079,7 +1082,6 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 			mv.visitVarInsn(ALOAD, 0);
 
 			if (kotlinCopyMethod.shouldUsePublicCopyMethod(entity)) {
-
 
 				// PersonWithId.copy$(value)
 				mv.visitVarInsn(ALOAD, 3);


### PR DESCRIPTION
We now fall back to reflection-based `PropertyAccessor`/`EntityInstantiator` strategies when framework types are not visible by the entity's ClassLoader.

Typically, we use class generation to create and load `PropertyAccessor` and `EntityInstantiator` classes to bypass reflection. Generated types are injected into the `ClassLoader` that has loaded the actual entity. Generated classes implement framework types such as ObjectInstantiator and these interfaces must be visible to the `ClassLoader` that hosts the generated class. Some arrangements, such as OSGi isolate class repositories so the OSGi class loader cannot load our own types which prevent loading the generated class.

---

Related ticket: [DATACMNS-1422](https://jira.spring.io/browse/DATACMNS-1422).