### PR TITLE
DATACMNS-1439 - Use Java Beans decapitalization for default repository implementation bean names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1439-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
@@ -27,11 +27,10 @@ import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.util.Streamable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of {@link ImplementationLookupConfiguration}.
- * 
+ *
  * @author Oliver Gierke
  * @author Mark Paluch
  * @since 2.1
@@ -45,9 +44,9 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 	/**
 	 * Creates a new {@link DefaultImplementationLookupConfiguration} for the given
 	 * {@link ImplementationDetectionConfiguration} and interface name.
-	 * 
+	 *
 	 * @param config must not be {@literal null}.
-	 * @param implementationClassName must not be {@literal null} or empty.
+	 * @param interfaceName must not be {@literal null} or empty.
 	 */
 	DefaultImplementationLookupConfiguration(ImplementationDetectionConfiguration config, String interfaceName) {
 
@@ -56,7 +55,8 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 
 		this.config = config;
 		this.interfaceName = interfaceName;
-		this.beanName = Introspector.decapitalize(ClassUtils.getShortName(interfaceName).concat(config.getImplementationPostfix()));
+		this.beanName = Introspector
+				.decapitalize(ClassUtils.getShortName(interfaceName).concat(config.getImplementationPostfix()));
 	}
 
 	/*
@@ -86,7 +86,7 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 		return config.getExcludeFilters().and(new AnnotationTypeFilter(NoRepositoryBean.class));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.ImplementationDetectionConfiguration#getMetadataReaderFactory()
 	 */
@@ -125,7 +125,7 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 		return beanName != null && beanName.equals(config.generateBeanName(definition));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.ImplementationLookupConfiguration#matches(org.springframework.beans.factory.config.BeanDefinition, org.springframework.core.type.classreading.MetadataReaderFactory)
 	 */

--- a/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.repository.config;
 
+import java.beans.Introspector;
 import java.io.IOException;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -32,6 +33,7 @@ import org.springframework.util.StringUtils;
  * Default implementation of {@link ImplementationLookupConfiguration}.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @since 2.1
  */
 class DefaultImplementationLookupConfiguration implements ImplementationLookupConfiguration {
@@ -54,11 +56,10 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 
 		this.config = config;
 		this.interfaceName = interfaceName;
-		this.beanName = StringUtils
-				.uncapitalize(ClassUtils.getShortName(interfaceName).concat(config.getImplementationPostfix()));
+		this.beanName = Introspector.decapitalize(ClassUtils.getShortName(interfaceName).concat(config.getImplementationPostfix()));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.ImplementationLookupConfiguration#getImplementationBeanName()
 	 */

--- a/src/main/java/org/springframework/data/repository/config/ImplementationDetectionConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/ImplementationDetectionConfiguration.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.data.repository.config;
 
+import java.beans.Introspector;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.util.Streamable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * Expresses configuration to be used to detect implementation classes for repositories and repository fragments.
@@ -75,7 +76,7 @@ public interface ImplementationDetectionConfiguration {
 			throw new IllegalStateException("Cannot generate bean name for BeanDefinition without bean class name!");
 		}
 
-		return StringUtils.uncapitalize(ClassUtils.getShortName(beanName));
+		return Introspector.decapitalize(ClassUtils.getShortName(beanName));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
@@ -17,13 +17,13 @@ package org.springframework.data.repository.config;
 
 import lombok.Value;
 
+import java.beans.Introspector;
 import java.util.Optional;
 
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.data.config.ConfigurationUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * Fragment configuration consisting of an interface name and the implementation class name.
@@ -76,7 +76,7 @@ public class RepositoryFragmentConfiguration {
 	 * @return name of the implementation bean.
 	 */
 	public String getImplementationBeanName() {
-		return StringUtils.uncapitalize(ClassUtils.getShortName(getClassName()));
+		return Introspector.decapitalize(ClassUtils.getShortName(getClassName()));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DefaultImplementationLookupConfigurationUnitTests}.
+ *
+ * @author Mark Paluch
+ */
+public class DefaultImplementationLookupConfigurationUnitTests {
+
+	@Test // DATACMNS-1439
+	public void shouldConsiderBeanNameDecapitalization() {
+
+		ImplementationDetectionConfiguration idcMock = mock(ImplementationDetectionConfiguration.class);
+		when(idcMock.getImplementationPostfix()).thenReturn("Impl");
+
+		assertThat(getImplementationBeanName(idcMock, "com.acme.UDPRepository")).isEqualTo("UDPRepositoryImpl");
+		assertThat(getImplementationBeanName(idcMock, "com.acme.UdpRepository")).isEqualTo("udpRepositoryImpl");
+	}
+
+	private static String getImplementationBeanName(ImplementationDetectionConfiguration idcMock, String interfaceName) {
+
+		DefaultImplementationLookupConfiguration configuration = new DefaultImplementationLookupConfiguration(idcMock,
+				interfaceName);
+		return configuration.getImplementationBeanName();
+	}
+}

--- a/src/test/java/org/springframework/data/repository/config/ImplementationDetectionConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/ImplementationDetectionConfigurationUnitTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.data.util.Streamable;
+
+/**
+ * Unit tests for {@link ImplementationDetectionConfiguration}.
+ *
+ * @author Mark Paluch
+ */
+public class ImplementationDetectionConfigurationUnitTests {
+
+	@Test // DATACMNS-1439
+	public void shouldConsiderBeanNameDecapitalization() {
+
+		assertThat(getBeanName("com.acme.UDPRepository")).isEqualTo("UDPRepository");
+		assertThat(getBeanName("com.acme.UdpRepository")).isEqualTo("udpRepository");
+	}
+
+	private static String getBeanName(String className) {
+
+		MockImplementationDetectionConfiguration configuration = new MockImplementationDetectionConfiguration();
+
+		return configuration.generateBeanName(BeanDefinitionBuilder.rootBeanDefinition(className).getBeanDefinition());
+	}
+
+	private static class MockImplementationDetectionConfiguration implements ImplementationDetectionConfiguration {
+
+		@Override
+		public String getImplementationPostfix() {
+			return null;
+		}
+
+		@Override
+		public Streamable<String> getBasePackages() {
+			return null;
+		}
+
+		@Override
+		public Streamable<TypeFilter> getExcludeFilters() {
+			return null;
+		}
+
+		@Override
+		public MetadataReaderFactory getMetadataReaderFactory() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/repository/config/RepositoryFragmentConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryFragmentConfigurationUnitTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RepositoryFragmentConfiguration}.
+ *
+ * @author Mark Paluch
+ */
+public class RepositoryFragmentConfigurationUnitTests {
+
+	@Test // DATACMNS-1439
+	public void shouldConsiderBeanNameDecapitalization() {
+
+		assertThat(getImplementationBeanName("com.acme.UDPRepository")).isEqualTo("UDPRepository");
+		assertThat(getImplementationBeanName("com.acme.UdpRepository")).isEqualTo("udpRepository");
+	}
+
+	private static String getImplementationBeanName(String className) {
+		return new RepositoryFragmentConfiguration("interface", className).getImplementationBeanName();
+	}
+}


### PR DESCRIPTION
We now use Java Beans `Introspector` during default bean name derivation from class names. Previously, we used `String.decapitalize(…)` which decapitalizes always the first character. Java Beans do not decapitalize upper case sequences so a class name `com.acme.UDPRepository` translates to a bean name with `UDPRepository` instead of `uDPRepository`.

---

Related ticket: [DATACMNS-1439](https://jira.spring.io/browse/DATACMNS-1439).