### PR TITLE
DATACMNS-1451 - Consider more than 16 immutable Kotlin properties in generated PropertyAccessor.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1451-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -1115,9 +1115,7 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 					visitDefaultValue(parameterTypes[i], mv);
 				}
 
-				copyByProperty.getDefaultMask().forEach(i -> {
-					mv.visitIntInsn(Opcodes.SIPUSH, i);
-				});
+				copyByProperty.getDefaultMask().forEach(mv::visitLdcInsn);
 
 				mv.visitInsn(Opcodes.ACONST_NULL);
 

--- a/src/test/java/org/springframework/data/mapping/model/PersistentPropertyAccessorTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/PersistentPropertyAccessorTests.java
@@ -140,6 +140,19 @@ public class PersistentPropertyAccessorTests {
 		assertThatThrownBy(() -> accessor.setProperty(property, 1)).isInstanceOf(UnsupportedOperationException.class);
 	}
 
+	@Test // DATACMNS-1451
+	public void shouldSet17thImmutableNullableKotlinProperty() {
+
+		With33Args bean = new With33Args();
+		PersistentPropertyAccessor accessor = propertyAccessorFunction.apply(bean);
+		SamplePersistentProperty property = getProperty(bean, "17");
+
+		accessor.setProperty(property, "foo");
+
+		With33Args updated = (With33Args) accessor.getBean();
+		assertThat(updated.get17()).isEqualTo("foo");
+	}
+
 	@Test // DATACMNS-1322
 	public void shouldWitherProperty() {
 


### PR DESCRIPTION
We now consider more than 16 immutable and nullable Kotlin properties per bucket in generated `PropertyAccessors`.

Previously only the first 16 properties were considered due to truncation of the defaulting bitmap. We used `SIPUSH` to render the defaulting mask in bytecode which is intended for 16 bit integers (`short`). Migrating to `LDC` (runtime constants) preserves the actual constant value of 32 bits and so we're considering now full buckets.

---

Related ticket: [DATACMNS-1451](https://jira.spring.io/browse/DATACMNS-1451).