### PR TITLE
DATACMNS-1454  Support multiple sorting fields in different directions in one sort parameter

### DIFF
--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolver.java
@@ -213,56 +213,57 @@ public class SortHandlerMethodArgumentResolver implements SortArgumentResolver {
 	 */
 	Sort parseParameterIntoSort(String[] source, String delimiter) {
 
-        	List<Order> allOrders = new ArrayList<>();
+		List<Order> allOrders = new ArrayList<>();
 
-        	for (String part : source) {
+		for (String part : source) {
 
-		    if (part == null) {
-			continue;
-		    }
+			if (part == null) {
+				continue;
+			}
 
-		    for (String element : part.split(delimiter)) {
+			parseOneSortParameter(allOrders, delimiter, part);
+		}
+
+		return allOrders.isEmpty() ? Sort.unsorted() : Sort.by(allOrders);
+	}
+
+	/*package for test*/ void parseOneSortParameter(List<Order> allOrders, String delimiter, String part) {
+		String[] elements = part.split(delimiter);
+		int length = elements.length;
+		Optional<Direction> defaultDirection = Direction.fromOptionalString(elements[length - 1].trim());
+		if (defaultDirection.isPresent()) {
+			length = length - 1;
+		}
+
+		for (int i = 0; i < length; i++) {
+			String element = elements[i];
 			if (!StringUtils.hasText(element)) {
-			    continue;
+				continue;
+			} else {
+				element = element.trim();
 			}
 
 			String[] fieldAndDirection = element.split("\\s+");
-			Optional<Direction> direction = fieldAndDirection.length <= 1 ? Optional.empty()
-				: Direction.fromOptionalString(fieldAndDirection[1]);
+			Optional<Direction> direction = fieldAndDirection.length <= 1 ? defaultDirection
+					: Direction.fromOptionalString(fieldAndDirection[1]);
 			toOrder(convertToCamel(fieldAndDirection[0]), direction).ifPresent(allOrders::add);
-		    }
+		}
+	}
 
-		    /*
-		    String[] elements = part.split(delimiter);
-
-		    Optional<Direction> direction = elements.length == 0 ? Optional.empty()
-			    : Direction.fromOptionalString(elements[elements.length - 1]);
-
-		    int lastIndex = direction.map(it -> elements.length - 1).orElseGet(() -> elements.length);
-
-		    for (int i = 0; i < lastIndex; i++) {
-			toOrder(elements[i], direction).ifPresent(allOrders::add);
-		    }
-		    */
-        	}
-
-        	return allOrders.isEmpty() ? Sort.unsorted() : Sort.by(allOrders);
-    	}
-
-    	private static String convertToCamel(String str) {
+	private static String convertToCamel(String str) {
 		StringBuilder sb = new StringBuilder();
 		boolean upper = false, first = true;
 		for (char ch : str.trim().toCharArray()) {
-		    if (ch == '-' || ch == '_') {
-			upper = !first;
-		    } else {
-			sb.append(upper ? Character.toUpperCase(ch) : Character.toLowerCase(ch));
-			upper = false;
-			first = false;
-		    }
+			if (ch == '-' || ch == '_') {
+				upper = !first;
+			} else {
+				sb.append(upper ? Character.toUpperCase(ch) : Character.toLowerCase(ch));
+				upper = false;
+				first = false;
+			}
 		}
 		return sb.toString();
-    	}
+	}
 
 	private static Optional<Order> toOrder(String property, Optional<Direction> direction) {
 

--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.data.web;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.domain.Sort.Direction.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -170,6 +173,46 @@ public class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitT
 		request.addParameter("sort", ",");
 
 		assertThat(resolveSort(request, PARAMETER).isSorted()).isFalse();
+	}
+
+	/**
+	 * Unit tests for {@link SortHandlerMethodArgumentResolver#parseOneSortParameter(List, String, String)}.
+	 * 
+	 * @author andyslin
+	 */
+	@Test
+	public void testParseOneSortParameter() {
+		SortHandlerMethodArgumentResolver resolver = new SortHandlerMethodArgumentResolver();
+		List<Order> allOrders = new ArrayList<>();
+		String delimiter = ",";
+
+		// new
+		String part = "field1_name desc, field2_name asc, field3Name desc";
+		resolver.parseOneSortParameter(allOrders, delimiter, part);
+		assertThat(allOrders.size()).isEqualTo(3);
+		assertThat(allOrders.get(0).getProperty()).isEqualTo("field1Name");
+		assertThat(allOrders.get(0).getDirection()).isEqualTo(Direction.DESC);
+		assertThat(allOrders.get(1).getDirection()).isEqualTo(Direction.ASC);
+		assertThat(allOrders.get(2).getDirection()).isEqualTo(Direction.DESC);
+
+		// old
+		allOrders.clear();
+		part = "field1_name, field2_name, desc";
+		resolver.parseOneSortParameter(allOrders, delimiter, part);
+		assertThat(allOrders.size()).isEqualTo(2);
+		assertThat(allOrders.get(0).getProperty()).isEqualTo("field1Name");
+		assertThat(allOrders.get(0).getDirection()).isEqualTo(Direction.DESC);
+		assertThat(allOrders.get(1).getDirection()).isEqualTo(Direction.DESC);
+
+		// new && old
+		allOrders.clear();
+		part = "field1_name, field2_name asc, field3Name, desc";
+		resolver.parseOneSortParameter(allOrders, delimiter, part);
+		assertThat(allOrders.size()).isEqualTo(3);
+		assertThat(allOrders.get(0).getProperty()).isEqualTo("field1Name");
+		assertThat(allOrders.get(0).getDirection()).isEqualTo(Direction.DESC);
+		assertThat(allOrders.get(1).getDirection()).isEqualTo(Direction.ASC);
+		assertThat(allOrders.get(2).getDirection()).isEqualTo(Direction.DESC);
 	}
 
 	@Test // DATACMNS-753, DATACMNS-408


### PR DESCRIPTION
Add support for multiple fields and sorting in different directions, while supporting direct use of database fields. If the last string is asc|desc, it is the default sort direction:
1. `field1_name desc, field2_name asc, field3Name desc` ==>`field1Name desc, field2Name asc, field3Name desc`
1. `field1_name, field2_name, desc` ==>`field1Name desc, field2Name desc`
1. `field1_name, field2_name asc, field3Name, desc` ==>`field1Name desc, field2Name asc, field3Name desc`