### PR TITLE
DATACMNS-1438, DATACMNS-1461 - Improved property path access.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1438-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -224,7 +224,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 			return setDateProperty(metadata.lastModifiedDatePaths, value);
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.auditing.AuditableBeanWrapper#getBean()
 		 */

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -27,9 +27,12 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.domain.Auditable;
+import org.springframework.data.mapping.AccessOptions;
+import org.springframework.data.mapping.AccessOptions.Propagation;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PersistentPropertyPathAccessor;
 import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.context.PersistentEntities;
@@ -83,7 +86,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 						key -> new MappingAuditingMetadata(context, it.getClass()));
 
 				return Optional.<AuditableBeanWrapper<T>> ofNullable(metadata.isAuditable() //
-						? new MappingMetadataAuditableBeanWrapper<T>(entity.getPropertyAccessor(it), metadata)
+						? new MappingMetadataAuditableBeanWrapper<T>(entity.getPropertyPathAccessor(it), metadata)
 						: null);
 
 			}).orElseGet(() -> super.getBeanWrapperFor(source));
@@ -148,7 +151,11 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 	 */
 	static class MappingMetadataAuditableBeanWrapper<T> extends DateConvertingAuditableBeanWrapper<T> {
 
-		private final PersistentPropertyAccessor<T> accessor;
+		private static final AccessOptions OPTIONS = AccessOptions.DEFAULT //
+				.skipNulls() // ;
+				.withCollectionAndMapPropagation(Propagation.SKIP);
+
+		private final PersistentPropertyPathAccessor<T> accessor;
 		private final MappingAuditingMetadata metadata;
 
 		/**
@@ -158,7 +165,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		 * @param accessor must not be {@literal null}.
 		 * @param metadata must not be {@literal null}.
 		 */
-		public MappingMetadataAuditableBeanWrapper(PersistentPropertyAccessor<T> accessor,
+		public MappingMetadataAuditableBeanWrapper(PersistentPropertyPathAccessor<T> accessor,
 				MappingAuditingMetadata metadata) {
 
 			Assert.notNull(accessor, "PersistentPropertyAccessor must not be null!");
@@ -174,10 +181,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		 */
 		@Override
 		public Object setCreatedBy(Object value) {
-
-			metadata.createdByPaths.forEach(it -> this.accessor.setProperty(it, value));
-
-			return value;
+			return setProperty(metadata.createdByPaths, value);
 		}
 
 		/*
@@ -232,7 +236,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		private <S, P extends PersistentProperty<?>> S setProperty(
 				PersistentPropertyPaths<?, ? extends PersistentProperty<?>> paths, S value) {
 
-			paths.forEach(it -> this.accessor.setProperty(it, value));
+			paths.forEach(it -> this.accessor.setProperty(it, value, OPTIONS));
 
 			return value;
 		}
@@ -240,8 +244,12 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		private <P extends PersistentProperty<?>> TemporalAccessor setDateProperty(
 				PersistentPropertyPaths<?, ? extends PersistentProperty<?>> property, TemporalAccessor value) {
 
-			property.forEach(it -> this.accessor.setProperty(it,
-					getDateValueToSet(value, it.getRequiredLeafProperty().getType(), accessor.getBean())));
+			property.forEach(it -> {
+
+				Class<?> type = it.getRequiredLeafProperty().getType();
+
+				this.accessor.setProperty(it, getDateValueToSet(value, type, accessor.getBean()), OPTIONS);
+			});
 
 			return value;
 		}

--- a/src/main/java/org/springframework/data/mapping/AccessOptions.java
+++ b/src/main/java/org/springframework/data/mapping/AccessOptions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Wither;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Options to be used for access of properties via {@link PersistentPropertyPathAccessor}. They define how to handle
+ * intermediate {@literal null} values contained in a path for set operations as well as how to deal with collection or
+ * map properties.
+ *
+ * @author Oliver Gierke
+ * @since 2.2
+ * @soundtrack The Intersphere - Linger (The Grand Delusion)
+ */
+@Wither
+@AllArgsConstructor
+public class AccessOptions {
+
+	/**
+	 * How to handle null values
+	 *
+	 * @author Oliver Gierke
+	 */
+	public enum NullHandling {
+
+	/**
+	 * Reject {@literal null} values detected when traversing a path to eventually set the leaf property. This will cause
+	 * a {@link MappingException} being thrown in that case.
+	 */
+	REJECT,
+
+	/**
+	 * Skip setting the value but log an info message to leave a trace why the value wasn't actually set.
+	 */
+	LOG,
+
+	/**
+	 * Silently skip the attempt to set the value.
+	 */
+	SKIP;
+	}
+
+	public enum Propagation {
+
+		/**
+		 * Skip the setting of values when encountering a collection or map value within the path to traverse.
+		 */
+		SKIP,
+
+		/**
+		 * Propagate the setting of values when encountering a collection or map value and set it on all collection or map
+		 * members.
+		 */
+		PROPAGATE;
+	}
+
+	public static final AccessOptions DEFAULT = new AccessOptions();
+
+	private final @Getter NullHandling nullHandling;
+	private final Propagation collectionPropagation, mapPropagation;
+
+	private AccessOptions() {
+
+		this.nullHandling = NullHandling.REJECT;
+		this.collectionPropagation = Propagation.PROPAGATE;
+		this.mapPropagation = Propagation.PROPAGATE;
+	}
+
+	/**
+	 * Returns a new {@link AccessOptions} that will cause paths that contain {@literal null} values to be skipped when
+	 * setting a property.
+	 *
+	 * @return
+	 */
+	public AccessOptions skipNulls() {
+		return withNullHandling(NullHandling.SKIP);
+	}
+
+	/**
+	 * Shortcut to configure the same {@link Propagation} for both collection and map property path segments.
+	 *
+	 * @param propagation must not be {@literal null}.
+	 * @return
+	 */
+	public AccessOptions withCollectionAndMapPropagation(Propagation propagation) {
+
+		Assert.notNull(propagation, "Propagation must not be null!");
+
+		return withCollectionPropagation(propagation) //
+				.withMapPropagation(propagation);
+	}
+
+	/**
+	 * Returns whether the given property is supposed to be propagated, i.e. if values for it are supposed to be set at
+	 * all.
+	 *
+	 * @param property can be {@literal null}.
+	 * @return
+	 */
+	public boolean propagate(@Nullable PersistentProperty<?> property) {
+
+		if (property == null) {
+			return true;
+		}
+
+		if (property.isCollectionLike() && collectionPropagation.equals(Propagation.SKIP)) {
+			return false;
+		}
+
+		if (property.isMap() && mapPropagation.equals(Propagation.SKIP)) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/org/springframework/data/mapping/PersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentEntity.java
@@ -289,6 +289,15 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	<B> PersistentPropertyAccessor<B> getPropertyAccessor(B bean);
 
 	/**
+	 * Returns a {@link PersistentPropertyPathAccessor} to access property values of the given bean.
+	 *
+	 * @param bean must not be {@literal null}.
+	 * @return a new {@link PersistentPropertyPathAccessor}
+	 * @since 2.2
+	 */
+	<B> PersistentPropertyPathAccessor<B> getPropertyPathAccessor(B bean);
+
+	/**
 	 * Returns the {@link IdentifierAccessor} for the given bean.
 	 *
 	 * @param bean must not be {@literal null}.

--- a/src/main/java/org/springframework/data/mapping/PersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentEntity.java
@@ -308,7 +308,7 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 
 	/**
 	 * Returns whether the given bean is considered new according to the static metadata.
-	 * 
+	 *
 	 * @param bean must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given bean is not an instance of the typ represented by the
 	 *           {@link PersistentEntity}.
@@ -319,7 +319,7 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	/**
 	 * Returns whether the entity is considered immutable, i.e. clients shouldn't attempt to change instances via the
 	 * {@link PersistentPropertyAccessor} obtained via {@link #getPropertyAccessor(Object)}.
-	 * 
+	 *
 	 * @return
 	 * @see Immutable
 	 * @since 2.1
@@ -329,7 +329,7 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	/**
 	 * Returns whether the entity needs properties to be populated, i.e. if any property exists that's not initialized by
 	 * the constructor.
-	 * 
+	 *
 	 * @return
 	 * @since 2.1
 	 */

--- a/src/main/java/org/springframework/data/mapping/PersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentProperty.java
@@ -392,4 +392,18 @@ public interface PersistentProperty<P extends PersistentProperty<P>> {
 	 */
 	@Nullable
 	Class<?> getAssociationTargetType();
+
+	/**
+	 * Returns a {@link PersistentPropertyAccessor} for the current property's owning value.
+	 * 
+	 * @param owner must not be {@literal null}.
+	 * @return will never be {@literal null}.
+	 * @since 2.2
+	 */
+	default <T> PersistentPropertyAccessor<T> getAccessorForOwner(T owner) {
+
+		Assert.notNull(owner, "Owner must not be null!");
+
+		return getOwner().getPropertyAccessor(owner);
+	}
 }

--- a/src/main/java/org/springframework/data/mapping/PersistentPropertyAccessor.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentPropertyAccessor.java
@@ -52,7 +52,10 @@ public interface PersistentPropertyAccessor<T> {
 	 * @param path must not be {@literal null} or empty.
 	 * @param value can be {@literal null}.
 	 * @since 2.1
+	 * @deprecated since 2.2, use {@link PersistentPropertyPathAccessor#setProperty(PersistentPropertyPath, Object)}
+	 *             instead.
 	 */
+	@Deprecated
 	default void setProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, @Nullable Object value) {
 
 		Assert.notNull(path, "PersistentPropertyPath must not be null!");
@@ -60,6 +63,12 @@ public interface PersistentPropertyAccessor<T> {
 
 		PersistentPropertyPath<? extends PersistentProperty<?>> parentPath = path.getParentPath();
 		PersistentProperty<?> leafProperty = path.getRequiredLeafProperty();
+		PersistentProperty<?> parentProperty = parentPath.isEmpty() ? null : parentPath.getLeafProperty();
+
+		if (parentProperty != null && (parentProperty.isCollectionLike() || parentProperty.isMap())) {
+			throw new MappingException(
+					String.format("Cannot traverse collection or map intermediate %s", parentPath.toDotPath()));
+		}
 
 		Object parent = parentPath.isEmpty() ? getBean() : getProperty(parentPath);
 
@@ -67,8 +76,8 @@ public interface PersistentPropertyAccessor<T> {
 
 			String nullIntermediateMessage = "Cannot lookup property %s on null intermediate! Original path was: %s on %s.";
 
-			throw new MappingException(String.format(nullIntermediateMessage, parentPath.getLeafProperty(), path.toDotPath(),
-					getBean().getClass().getName()));
+			throw new MappingException(
+					String.format(nullIntermediateMessage, parentProperty, path.toDotPath(), getBean().getClass().getName()));
 		}
 
 		PersistentPropertyAccessor<?> accessor = parent == getBean() //
@@ -104,7 +113,9 @@ public interface PersistentPropertyAccessor<T> {
 	 * @param path must not be {@literal null}.
 	 * @return
 	 * @since 2.1
+	 * @deprecated since 2.2, use {@link PersistentPropertyPathAccessor#getProperty(PersistentPropertyPath)} instead
 	 */
+	@Deprecated
 	@Nullable
 	default Object getProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path) {
 

--- a/src/main/java/org/springframework/data/mapping/PersistentPropertyPathAccessor.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentPropertyPathAccessor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping;
+
+import org.springframework.data.mapping.AccessOptions.NullHandling;
+import org.springframework.lang.Nullable;
+
+/**
+ * Extension of {@link PersistentPropertyAccessor} that is also able to obtain and set values for
+ * {@link PersistentPropertyPath}s.
+ *
+ * @author Oliver Gierke
+ * @since 2.2
+ * @soundtrack Sophia Wahnschaffe - Leuchten (Live Session) https://www.youtube.com/watch?v=izZxWiPto5Q
+ */
+public interface PersistentPropertyPathAccessor<T> extends PersistentPropertyAccessor<T> {
+
+	/**
+	 * @author Oliver Gierke
+	 */
+	public enum NullValues {
+
+	REJECT, EARLY_RETURN;
+
+		public AccessOptions.NullHandling toNullHandling() {
+			return REJECT == this ? NullHandling.REJECT : NullHandling.SKIP;
+		}
+	}
+
+	/**
+	 * Return the value pointed to by the given {@link PersistentPropertyPath}. If the given path is empty, the wrapped
+	 * bean is returned.
+	 *
+	 * @param path must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 */
+	@Nullable
+	@SuppressWarnings("deprecation")
+	default Object getProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path) {
+		return PersistentPropertyAccessor.super.getProperty(path);
+	}
+
+	/**
+	 * Return the value pointed to by the given {@link PersistentPropertyPath} considering the given lookup options.
+	 *
+	 * @param path
+	 * @param options
+	 * @return
+	 * @since 2.2
+	 */
+	@Nullable
+	Object getProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, NullValues values);
+
+	/**
+	 * Sets the given value for the {@link PersistentProperty} pointed to by the given {@link PersistentPropertyPath}. The
+	 * lookup of intermediate values must not yield {@literal null}.
+	 *
+	 * @param path must not be {@literal null} or empty.
+	 * @param value can be {@literal null}.
+	 * @see AccessOptions#DEFAULT
+	 */
+	void setProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, @Nullable Object value);
+
+	/**
+	 * Sets the given value for the {@link PersistentProperty} pointed to by the given {@link PersistentPropertyPath}
+	 * considering the given {@link AccessOptions}.
+	 *
+	 * @param path must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 */
+	void setProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, @Nullable Object value,
+			AccessOptions options);
+}

--- a/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/model/BasicPersistentEntity.java
@@ -455,6 +455,15 @@ public class BasicPersistentEntity<T, P extends PersistentProperty<P>> implement
 		return propertyAccessorFactory.getPropertyAccessor(this, bean);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentEntity#getPropertyPathAccessor(java.lang.Object)
+	 */
+	@Override
+	public <B> PersistentPropertyPathAccessor<B> getPropertyPathAccessor(B bean) {
+		return new SimplePersistentPropertyPathAccessor<>(getPropertyAccessor(bean));
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.mapping.PersistentEntity#getIdentifierAccessor(java.lang.Object)

--- a/src/main/java/org/springframework/data/mapping/model/SimplePersistentPropertyPathAccessor.java
+++ b/src/main/java/org/springframework/data/mapping/model/SimplePersistentPropertyPathAccessor.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import static org.springframework.data.mapping.AccessOptions.NullHandling.*;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.springframework.core.CollectionFactory;
+import org.springframework.data.mapping.AccessOptions;
+import org.springframework.data.mapping.AccessOptions.NullHandling;
+import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPathAccessor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * {@link PersistentPropertyPathAccessor} that propagates attempts to set property values through collections and map
+ * values. I.e. if a {@link PersistentPropertyPath} contains a path segment pointing to a collection or map based
+ * property, the nested property will be set on all collection elements and map values.
+ *
+ * @author Oliver Gierke
+ * @since 2.2
+ * @soundtrack Ron Spielman - Nineth Song (Tip of My Tongue)
+ */
+@Slf4j
+@RequiredArgsConstructor
+class SimplePersistentPropertyPathAccessor<T> implements PersistentPropertyPathAccessor<T> {
+
+	private final @NonNull PersistentPropertyAccessor<T> delegate;
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentPropertyAccessor#getBean()
+	 */
+	@Override
+	public T getBean() {
+		return delegate.getBean();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentPropertyAccessor#getProperty(org.springframework.data.mapping.PersistentProperty)
+	 */
+	@Nullable
+	@Override
+	public Object getProperty(PersistentProperty<?> property) {
+		return delegate.getProperty(property);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentPropertyPathAccessor#getProperty(org.springframework.data.mapping.PersistentPropertyPath)
+	 */
+	@Nullable
+	@Override
+	public Object getProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path) {
+		return getProperty(path, NullValues.REJECT);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentPropertyPathAccessor#getProperty(org.springframework.data.mapping.PersistentPropertyPath, org.springframework.data.mapping.PersistentPropertyPathAccessor.Options)
+	 */
+	@Nullable
+	@Override
+	public Object getProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, NullValues options) {
+
+		Object bean = getBean();
+		Object current = bean;
+
+		if (path.isEmpty()) {
+			return bean;
+		}
+
+		for (PersistentProperty<?> property : path) {
+
+			if (current == null) {
+				return handleNull(path, options.toNullHandling());
+			}
+
+			PersistentEntity<?, ? extends PersistentProperty<?>> entity = property.getOwner();
+			PersistentPropertyAccessor<Object> accessor = entity.getPropertyAccessor(current);
+
+			current = accessor.getProperty(property);
+		}
+
+		return current;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentPropertyAccessor#setProperty(org.springframework.data.mapping.PersistentProperty, java.lang.Object)
+	 */
+	@Override
+	public void setProperty(PersistentProperty<?> property, @Nullable Object value) {
+		delegate.setProperty(property, value);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.PersistentPropertyPathAccessor#setProperty(org.springframework.data.mapping.PersistentPropertyPath, java.lang.Object)
+	 */
+	@Override
+	public void setProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, @Nullable Object value) {
+		setProperty(path, value, AccessOptions.DEFAULT);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.model.ConvertingPropertyAccessor#setProperty(org.springframework.data.mapping.PersistentPropertyPath, java.lang.Object)
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public void setProperty(PersistentPropertyPath<? extends PersistentProperty<?>> path, @Nullable Object value,
+			AccessOptions options) {
+
+		Assert.notNull(path, "PersistentPropertyPath must not be null!");
+		Assert.isTrue(!path.isEmpty(), "PersistentPropertyPath must not be empty!");
+
+		PersistentPropertyPath<? extends PersistentProperty<?>> parentPath = path.getParentPath();
+		PersistentProperty<?> leafProperty = path.getRequiredLeafProperty();
+
+		if (!options.propagate(parentPath.getLeafProperty())) {
+			return;
+		}
+
+		Object parent = parentPath.isEmpty() ? getBean() : getProperty(parentPath);
+
+		if (parent == null) {
+			handleNull(path, options.getNullHandling());
+			return;
+		}
+
+		if (parent == getBean()) {
+
+			setProperty(leafProperty, value);
+			return;
+		}
+
+		PersistentProperty<?> parentProperty = parentPath.getRequiredLeafProperty();
+
+		Object newValue;
+
+		if (parentProperty.isCollectionLike()) {
+
+			Collection<Object> source = getTypedProperty(parentProperty, Collection.class);
+
+			if (source == null) {
+				return;
+			}
+
+			newValue = source.stream() //
+					.map(it -> setValue(it, leafProperty, value)) //
+					.collect(Collectors.toCollection(() -> CollectionFactory.createApproximateCollection(source, source.size())));
+
+		} else if (Map.class.isInstance(parent)) {
+
+			Map<Object, Object> source = getTypedProperty(parentProperty, Map.class);
+
+			if (source == null) {
+				return;
+			}
+
+			Map<Object, Object> result = CollectionFactory.createApproximateMap(source, source.size());
+
+			for (Entry<?, Object> entry : source.entrySet()) {
+				result.put(entry.getKey(), setValue(entry.getValue(), leafProperty, value));
+			}
+
+			newValue = result;
+
+		} else {
+
+			newValue = setValue(parent, leafProperty, value);
+		}
+
+		if (newValue != parent) {
+			setProperty(parentPath, newValue);
+		}
+	}
+
+	/**
+	 * @param path
+	 * @param options
+	 * @param parentPath
+	 */
+	@Nullable
+	private Object handleNull(PersistentPropertyPath<? extends PersistentProperty<?>> path, NullHandling handling) {
+
+		if (SKIP.equals(handling)) {
+			return null;
+		}
+
+		String nullIntermediateMessage = "Cannot lookup property %s on null intermediate! Original path was: %s on %s.";
+
+		if (NullHandling.LOG.equals(handling)) {
+			LOG.info(nullIntermediateMessage);
+			return null;
+		}
+
+		PersistentPropertyPath<? extends PersistentProperty<?>> parentPath = path.getParentPath();
+
+		throw new MappingException(String.format(nullIntermediateMessage, parentPath.getLeafProperty(), path.toDotPath(),
+				getBean().getClass().getName()));
+	}
+
+	/**
+	 * Sets the value for the given {@link PersistentProperty} on the given parent object and returns the potentially
+	 * newly created instance.
+	 *
+	 * @param parent must not be {@literal null}.
+	 * @param property must not be {@literal null}.
+	 * @param newValue can be {@literal null}.
+	 * @return will never be {@literal null}.
+	 */
+	private Object setValue(Object parent, PersistentProperty<?> property, @Nullable Object newValue) {
+
+		PersistentPropertyAccessor<Object> accessor = property.getAccessorForOwner(parent);
+		accessor.setProperty(property, newValue);
+		return accessor.getBean();
+	}
+
+	/**
+	 * Returns the value of the given {@link PersistentProperty} potentially applying type conversion to the given target
+	 * type. The default implementation will not attempt any conversion and reject a type mismatch with a
+	 * {@link MappingException}.
+	 *
+	 * @param property will never be {@literal null}.
+	 * @param type will never be {@literal null}.
+	 * @return can be {@literal null}.
+	 */
+	@Nullable
+	protected <S> S getTypedProperty(PersistentProperty<?> property, Class<S> type) {
+
+		Assert.notNull(property, "Property must not be null!");
+		Assert.notNull(type, "Type must not be null!");
+
+		Object value = getProperty(property);
+
+		if (value == null) {
+			return null;
+		}
+
+		if (!type.isInstance(value)) {
+			throw new MappingException(String.format("Invalid property value type! Need %s but got %s!", //
+					type.getName(), value.getClass().getName()));
+		}
+
+		return type.cast(value);
+	}
+}

--- a/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
@@ -23,9 +23,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.assertj.core.api.AbstractLongAssert;
@@ -212,6 +216,51 @@ public class MappingAuditableBeanWrapperFactoryUnitTests {
 		});
 	}
 
+	@Test // DATACMNS-1461
+	public void skipsNullIntermediatesWhenSettingProperties() {
+
+		WithEmbedded withEmbedded = new WithEmbedded();
+
+		assertThat(factory.getBeanWrapperFor(withEmbedded)).hasValueSatisfying(it -> {
+			assertThatCode(() -> it.setCreatedBy("user")).doesNotThrowAnyException();
+		});
+	}
+
+	@Test // DATACMNS-1438
+	public void skipsCollectionPropertiesWhenSettingProperties() {
+
+		WithEmbedded withEmbedded = new WithEmbedded();
+		withEmbedded.embedded = new Embedded();
+		withEmbedded.embeddeds = Arrays.asList(new Embedded());
+		withEmbedded.embeddedMap = new HashMap<>();
+		withEmbedded.embeddedMap.put("key", new Embedded());
+
+		assertThat(factory.getBeanWrapperFor(withEmbedded)).hasValueSatisfying(it -> {
+
+			String user = "user";
+			Instant now = Instant.now();
+
+			it.setCreatedBy(user);
+			it.setLastModifiedBy(user);
+			it.setLastModifiedDate(now);
+			it.setCreatedDate(now);
+
+			Embedded embedded = withEmbedded.embeddeds.iterator().next();
+
+			assertThat(embedded.created).isNull();
+			assertThat(embedded.creator).isNull();
+			assertThat(embedded.modified).isNull();
+			assertThat(embedded.modifier).isNull();
+
+			embedded = withEmbedded.embeddedMap.get("key");
+
+			assertThat(embedded.created).isNull();
+			assertThat(embedded.creator).isNull();
+			assertThat(embedded.modified).isNull();
+			assertThat(embedded.modifier).isNull();
+		});
+	}
+
 	private void assertLastModificationDate(Object source, TemporalAccessor expected) {
 
 		Sample sample = new Sample();
@@ -274,5 +323,7 @@ public class MappingAuditableBeanWrapperFactoryUnitTests {
 
 	static class WithEmbedded {
 		Embedded embedded;
+		Collection<Embedded> embeddeds;
+		Map<String, Embedded> embeddedMap;
 	}
 }

--- a/src/test/java/org/springframework/data/mapping/PersistentPropertyAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PersistentPropertyAccessorUnitTests.java
@@ -24,10 +24,8 @@ import lombok.Value;
 import lombok.experimental.Wither;
 
 import org.junit.Test;
-import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.mapping.context.SampleMappingContext;
 import org.springframework.data.mapping.context.SamplePersistentProperty;
-import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 
 /**
  * @author Oliver Gierke
@@ -114,23 +112,6 @@ public class PersistentPropertyAccessorUnitTests {
 			assertThat(it.immutable).isNotSameAs(immutable);
 			assertThat(it).isNotSameAs(outer);
 		});
-	}
-
-	@Test // DATACMNS-1377
-	public void shouldConvertToPropertyPathLeafType() {
-
-		Order order = new Order(new Customer("1"));
-
-		PersistentPropertyAccessor<Order> accessor = context.getPersistentEntity(Order.class).getPropertyAccessor(order);
-		ConvertingPropertyAccessor<Order> convertingAccessor = new ConvertingPropertyAccessor<>(accessor,
-				new DefaultConversionService());
-
-		PersistentPropertyPath<SamplePersistentProperty> path = context.getPersistentPropertyPath("customer.firstname",
-				Order.class);
-
-		convertingAccessor.setProperty(path, 2);
-
-		assertThat(convertingAccessor.getBean().getCustomer().getFirstname()).isEqualTo("2");
 	}
 
 	@Value

--- a/src/test/java/org/springframework/data/mapping/model/ConvertingPropertyAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ConvertingPropertyAccessorUnitTests.java
@@ -18,9 +18,15 @@ package org.springframework.data.mapping.model;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Value;
+
 import org.junit.Test;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.SampleMappingContext;
 import org.springframework.data.mapping.context.SamplePersistentProperty;
 import org.springframework.format.support.DefaultFormattingConversionService;
@@ -107,6 +113,25 @@ public class ConvertingPropertyAccessorUnitTests {
 		});
 	}
 
+	@Test // DATACMNS-1377
+	public void shouldConvertToPropertyPathLeafType() {
+
+		Order order = new Order(new Customer("1"));
+
+		SampleMappingContext context = new SampleMappingContext();
+
+		PersistentPropertyAccessor<Order> accessor = context.getPersistentEntity(Order.class).getPropertyAccessor(order);
+		ConvertingPropertyAccessor<Order> convertingAccessor = new ConvertingPropertyAccessor<>(accessor,
+				new DefaultConversionService());
+
+		PersistentPropertyPath<SamplePersistentProperty> path = context.getPersistentPropertyPath("customer.firstname",
+				Order.class);
+
+		convertingAccessor.setProperty(path, 2);
+
+		assertThat(convertingAccessor.getBean().getCustomer().getFirstname()).isEqualTo("2");
+	}
+
 	private static ConvertingPropertyAccessor getAccessor(Object entity, ConversionService conversionService) {
 
 		PersistentPropertyAccessor wrapper = new BeanWrapper<>(entity);
@@ -123,5 +148,16 @@ public class ConvertingPropertyAccessorUnitTests {
 
 	static class Entity {
 		Long id;
+	}
+
+	@Value
+	static class Order {
+		Customer customer;
+	}
+
+	@Data
+	@AllArgsConstructor
+	static class Customer {
+		String firstname;
 	}
 }

--- a/src/test/java/org/springframework/data/mapping/model/SimplePersistentPropertyPathAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/SimplePersistentPropertyPathAccessorUnitTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Value;
+import lombok.experimental.Wither;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.springframework.data.mapping.AccessOptions;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPathAccessor;
+import org.springframework.data.mapping.context.SampleMappingContext;
+import org.springframework.data.mapping.context.SamplePersistentProperty;
+
+/**
+ * Unit tests for {@link SimplePersistentPropertyPathAccessor}.
+ *
+ * @author Oliver Gierke
+ * @since 2.2
+ * @soundtrack Ron Spielman Trio - Raindrops (Electric Tales)
+ */
+public class SimplePersistentPropertyPathAccessorUnitTests {
+
+	SampleMappingContext context = new SampleMappingContext();
+
+	Customer first = new Customer("1");
+	Customer second = new Customer("2");
+
+	@Test // DATACMNS-1438
+	public void setsPropertyContainingCollectionPathForAllElements() {
+
+		Customers customers = new Customers(Arrays.asList(first, second), Collections.emptyMap());
+
+		assertFirstnamesSetFor(customers, "customers.firstname");
+	}
+
+	@Test // DATACMNS-1438
+	public void setsPropertyContainingMapPathForAllValues() {
+
+		Map<String, Customer> map = new HashMap<>();
+		map.put("1", first);
+		map.put("2", second);
+
+		Customers customers = new Customers(Collections.emptyList(), map);
+
+		assertFirstnamesSetFor(customers, "customerMap.firstname");
+	}
+
+	@Test // DATACMNS-1461
+	public void skipsNullValueIfConfigured() {
+
+		CustomerWrapper wrapper = new CustomerWrapper(null);
+
+		PersistentPropertyPathAccessor<CustomerWrapper> accessor = getAccessor(wrapper);
+		PersistentPropertyPath<SamplePersistentProperty> path = context.getPersistentPropertyPath("customer.firstname",
+				CustomerWrapper.class);
+
+		assertThatCode(() -> {
+			accessor.setProperty(path, "Dave", AccessOptions.DEFAULT.withNullHandling(AccessOptions.NullHandling.SKIP));
+		}).doesNotThrowAnyException();
+	}
+
+	private void assertFirstnamesSetFor(Customers customers, String path) {
+
+		PersistentPropertyPath<SamplePersistentProperty> propertyPath = context.getPersistentPropertyPath(path,
+				Customers.class);
+
+		getAccessor(customers).setProperty(propertyPath, "firstname");
+
+		Stream.of(first, second).forEach(it -> {
+			assertThat(it.firstname).isEqualTo("firstname");
+		});
+	}
+
+	private <T> PersistentPropertyPathAccessor<T> getAccessor(T source) {
+
+		Class<? extends Object> type = source.getClass();
+
+		PersistentEntity<Object, SamplePersistentProperty> entity = context.getRequiredPersistentEntity(type);
+		PersistentPropertyPathAccessor<T> accessor = entity.getPropertyPathAccessor(source);
+
+		return accessor;
+	}
+
+	@Data
+	@AllArgsConstructor
+	static class Customer {
+		String firstname;
+	}
+
+	@Value
+	static class Customers {
+		@Wither List<Customer> customers;
+		@Wither Map<String, Customer> customerMap;
+	}
+
+	@AllArgsConstructor
+	static class CustomerWrapper {
+		Customer customer;
+	}
+}


### PR DESCRIPTION
We now expose a dedicated `PersistentPropertyPathAccessor` and optionally take options for both the read and write access to properties. On read, clients can define to eagerly receive null in case one of the path segments is null. By default, we reject those as it indicates that there might be an issue with the backing object if the client assumes it can look up the more deeply nested path to receive a result.

On write access clients can define to either reject, skip or log intermediate null segments where skip means, that the setting is just silently aborted. Clients can also control how to deal with collection and map intermediates. By default we now propagate the attempt to set a value to all collection or map items respectively. This could be potentially extended to provide a filter receiving both the property and property value to selectively propagate those calls in the future.

The separation of these APIs (`PersistentPropertyAccessor` and `PersistentPropertyPathAccessor`) is introduced as the latter can be implemented on top of the former and the former potentially being dynamically generated. The logic of the latter can then be clearly separated from the actual individual property lookup. `ConvertingPropertyAccessor` is now a `PersistentPropertyPathAccessor`, too, and overrides `SimplePersistentPropertyPathAccessor.getTypedProperty(…)` to plug in conversion logic. This allows custom collection types being used if the `ConversionService` backing the accessor can convert from and to `Collection` or `Map` respectively.

Deprecated all `PersistentPropertyPath`-related methods on `PersistentPropertyAccessor` for removal in 2.3.

`MappingAuditableBeanWrapperFactory` now uses these new settings to skip both null values as well as collection and map values when setting auditing metadata.