### PR TITLE
DATACMNS-1081 - Add ReactiveQuerydslPredicateExecutor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1081-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/querydsl/ReactiveQuerydslPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/querydsl/ReactiveQuerydslPredicateExecutor.java
@@ -24,66 +24,97 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 
 /**
- * Interface to issue queries using Querydsl {@link Predicate} instances.
+ * Interface to issue queries using Querydsl {@link Predicate} instances. <br />
+ * Intended for usage along with the {@link org.springframework.data.repository.reactive.ReactiveCrudRepository}
+ * interface to wire in <a href="http://http://www.querydsl.com">Querydsl</a>support.
+ *
+ * <pre>
+ *     <code>
+ *
+ *  public interface PersonRepository extends ReactiveCrudRepository&lt;Person, String&gt;, ReactiveQuerydslPredicateExecutor&lt;Person&gt; {
+ *             
+ *  }
+ *
+ *  // ...
+ *
+ *  personRepository.findOne(QPerson.person.email.eq("t-800@skynet.com"))
+ *      .flatMap(t800 ->
+ *      //....
+ *
+ *     </code>
+ * </pre>
+ *
+ * <strong>IMPORTANT:</strong> Please check the module specific documentation whether or not Querydsl is supported.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
 public interface ReactiveQuerydslPredicateExecutor<T> {
 
 	/**
-	 * Returns a single entity matching the given {@link Predicate} or {@link Mono#empty()} if none was found.
+	 * Returns a {@link Mono} emitting the entity matching the given {@link Predicate} or {@link Mono#empty()} if none was
+	 * found.
 	 *
 	 * @param predicate must not be {@literal null}.
-	 * @return a single entity matching the given {@link Predicate} or {@link Mono#empty()} if none was found.
+	 * @return a {@link Mono} emitting a single entity matching the given {@link Predicate} or {@link Mono#empty()} if
+	 *         none was found.
+	 * @throws IllegalArgumentException if the required parameter is {@literal null}.
 	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if the predicate yields more than one
 	 *           result.
 	 */
 	Mono<T> findOne(Predicate predicate);
 
 	/**
-	 * Returns all entities matching the given {@link Predicate}. In case no match could be found, {@link Flux} emits no
-	 * items.
+	 * Returns a {@link Flux} emitting all entities matching the given {@link Predicate}. In case no match could be found,
+	 * {@link Flux} emits no items.
 	 *
 	 * @param predicate must not be {@literal null}.
-	 * @return all entities matching the given {@link Predicate}.
+	 * @return a {@link Flux} emitting all entities matching the given {@link Predicate} one by one.
+	 * @throws IllegalArgumentException if the required parameter is {@literal null}.
 	 */
 	Flux<T> findAll(Predicate predicate);
 
 	/**
-	 * Returns all entities matching the given {@link Predicate} applying the given {@link Sort}. In case no match could
-	 * be found, {@link Flux} emits no items.
+	 * Returns a {@link Flux} emitting all entities matching the given {@link Predicate} applying the given {@link Sort}.
+	 * In case no match could be found, {@link Flux} emits no items.
 	 *
 	 * @param predicate must not be {@literal null}.
-	 * @param sort the {@link Sort} specification to sort the results by, may be {@link Sort#empty()}, must not be
+	 * @param sort the {@link Sort} specification to sort the results by, may be {@link Sort#unsorted()}, must not be
 	 *          {@literal null}.
-	 * @return all entities matching the given {@link Predicate}.
+	 * @return a {@link Flux} emitting all entities matching the given {@link Predicate} one by one.
+	 * @throws IllegalArgumentException if one of the required parameters is {@literal null}.
 	 */
 	Flux<T> findAll(Predicate predicate, Sort sort);
 
 	/**
-	 * Returns all entities matching the given {@link Predicate} applying the given {@link OrderSpecifier}s. In case no
-	 * match could be found, {@link Flux} emits no items.
+	 * Returns a {@link Flux} emitting all entities matching the given {@link Predicate} applying the given
+	 * {@link OrderSpecifier}s. In case no match could be found, {@link Flux} emits no items.
 	 *
 	 * @param predicate must not be {@literal null}.
 	 * @param orders the {@link OrderSpecifier}s to sort the results by.
-	 * @return all entities matching the given {@link Predicate} applying the given {@link OrderSpecifier}s.
+	 * @return a {@link Flux} emitting all entities matching the given {@link Predicate} applying the given
+	 *         {@link OrderSpecifier}s.
+	 * @throws IllegalArgumentException if one of the required parameter is {@literal null}, or contains a {@literal null}
+	 *           value.
 	 */
 	Flux<T> findAll(Predicate predicate, OrderSpecifier<?>... orders);
 
 	/**
-	 * Returns all entities ordered by the given {@link OrderSpecifier}s.
+	 * Returns a {@link Flux} emitting all entities ordered by the given {@link OrderSpecifier}s.
 	 *
 	 * @param orders the {@link OrderSpecifier}s to sort the results by.
-	 * @return all entities ordered by the given {@link OrderSpecifier}s.
+	 * @return a {@link Flux} emitting all entities ordered by the given {@link OrderSpecifier}s.
+	 * @throws IllegalArgumentException one of the {@link OrderSpecifier OrderSpecifiers} is {@literal null}.
 	 */
 	Flux<T> findAll(OrderSpecifier<?>... orders);
 
 	/**
-	 * Returns the number of instances matching the given {@link Predicate}.
+	 * Returns a {@link Mono} emitting the number of instances matching the given {@link Predicate}.
 	 *
 	 * @param predicate the {@link Predicate} to count instances for, must not be {@literal null}.
-	 * @return the number of instances matching the {@link Predicate}.
+	 * @return a {@link Mono} emitting the number of instances matching the {@link Predicate} or {@code 0} if none found.
+	 * @throws IllegalArgumentException if the required parameter is {@literal null}.
 	 */
 	Mono<Long> count(Predicate predicate);
 
@@ -91,7 +122,9 @@ public interface ReactiveQuerydslPredicateExecutor<T> {
 	 * Checks whether the data store contains elements that match the given {@link Predicate}.
 	 *
 	 * @param predicate the {@link Predicate} to use for the existence check, must not be {@literal null}.
-	 * @return {@literal true} if the data store contains elements that match the given {@link Predicate}.
+	 * @return a {@link Mono} emitting {@literal true} if the data store contains elements that match the given
+	 *         {@link Predicate}, {@literal false} otherwise.
+	 * @throws IllegalArgumentException if the required parameter is {@literal null}.
 	 */
 	Mono<Boolean> exists(Predicate predicate);
 }

--- a/src/main/java/org/springframework/data/querydsl/ReactiveQuerydslPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/querydsl/ReactiveQuerydslPredicateExecutor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.querydsl;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.domain.Sort;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+
+/**
+ * Interface to issue queries using Querydsl {@link Predicate} instances.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+public interface ReactiveQuerydslPredicateExecutor<T> {
+
+	/**
+	 * Returns a single entity matching the given {@link Predicate} or {@link Mono#empty()} if none was found.
+	 *
+	 * @param predicate must not be {@literal null}.
+	 * @return a single entity matching the given {@link Predicate} or {@link Mono#empty()} if none was found.
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if the predicate yields more than one
+	 *           result.
+	 */
+	Mono<T> findOne(Predicate predicate);
+
+	/**
+	 * Returns all entities matching the given {@link Predicate}. In case no match could be found, {@link Flux} emits no
+	 * items.
+	 *
+	 * @param predicate must not be {@literal null}.
+	 * @return all entities matching the given {@link Predicate}.
+	 */
+	Flux<T> findAll(Predicate predicate);
+
+	/**
+	 * Returns all entities matching the given {@link Predicate} applying the given {@link Sort}. In case no match could
+	 * be found, {@link Flux} emits no items.
+	 *
+	 * @param predicate must not be {@literal null}.
+	 * @param sort the {@link Sort} specification to sort the results by, may be {@link Sort#empty()}, must not be
+	 *          {@literal null}.
+	 * @return all entities matching the given {@link Predicate}.
+	 */
+	Flux<T> findAll(Predicate predicate, Sort sort);
+
+	/**
+	 * Returns all entities matching the given {@link Predicate} applying the given {@link OrderSpecifier}s. In case no
+	 * match could be found, {@link Flux} emits no items.
+	 *
+	 * @param predicate must not be {@literal null}.
+	 * @param orders the {@link OrderSpecifier}s to sort the results by.
+	 * @return all entities matching the given {@link Predicate} applying the given {@link OrderSpecifier}s.
+	 */
+	Flux<T> findAll(Predicate predicate, OrderSpecifier<?>... orders);
+
+	/**
+	 * Returns all entities ordered by the given {@link OrderSpecifier}s.
+	 *
+	 * @param orders the {@link OrderSpecifier}s to sort the results by.
+	 * @return all entities ordered by the given {@link OrderSpecifier}s.
+	 */
+	Flux<T> findAll(OrderSpecifier<?>... orders);
+
+	/**
+	 * Returns the number of instances matching the given {@link Predicate}.
+	 *
+	 * @param predicate the {@link Predicate} to count instances for, must not be {@literal null}.
+	 * @return the number of instances matching the {@link Predicate}.
+	 */
+	Mono<Long> count(Predicate predicate);
+
+	/**
+	 * Checks whether the data store contains elements that match the given {@link Predicate}.
+	 *
+	 * @param predicate the {@link Predicate} to use for the existence check, must not be {@literal null}.
+	 * @return {@literal true} if the data store contains elements that match the given {@link Predicate}.
+	 */
+	Mono<Boolean> exists(Predicate predicate);
+}


### PR DESCRIPTION
We now ship with a common interface for reactive repositories that want to support Querydsl.

---

Related ticket: [DATACMNS-1081](https://jira.spring.io/browse/DATACMNS-1081).