### PR TITLE
DATACMNS-1468 Support repository interface @Transactional customization.

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/TransactionalRepositoryProxyPostProcessor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/TransactionalRepositoryProxyPostProcessor.java
@@ -54,6 +54,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author MyeongHyeon Lee
  */
 class TransactionalRepositoryProxyPostProcessor implements RepositoryProxyPostProcessor {
 
@@ -442,6 +443,12 @@ class TransactionalRepositoryProxyPostProcessor implements RepositoryProxyPostPr
 			}
 
 			txAtt = findTransactionAttribute(targetClassMethod.getDeclaringClass());
+			if (txAtt != null) {
+				return txAtt;
+			}
+
+			Class<?> repositoryInterface = repositoryInformation.getRepositoryInterface();
+			txAtt = findTransactionAttribute(repositoryInterface);
 			if (txAtt != null) {
 				return txAtt;
 			}


### PR DESCRIPTION
AbstractFallbackTransactionAttributeSource should consider
repository interface transaction settings as fallback.

support @Transactional below `SampleRepository.save(Sample object)` method

``` java
@Transactional
public interface SampleRepository extends CrudRepository<Sample, Serializable> {
    @Override
    void delete(Sample entity);
}
```
[Ticket: DATACMNS-1468](https://jira.spring.io/browse/DATACMNS-1468)
Related tickets: [DATACMNS-464](https://jira.spring.io/browse/DATACMNS-464)
