### PR TITLE
DATACMNS-1483 - Migrate Kotlin tests to Mockk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,24 +264,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.nhaarman</groupId>
-			<artifactId>mockito-kotlin</artifactId>
-			<version>1.5.0</version>
+			<groupId>io.mockk</groupId>
+			<artifactId>mockk</artifactId>
+			<version>1.9.1</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-stdlib</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jetbrains.kotlin</groupId>
-					<artifactId>kotlin-reflect</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.mockito</groupId>
-					<artifactId>mockito-core</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Scala -->

--- a/src/test/kotlin/org/springframework/data/convert/ReflectionEntityInstantiatorDataClassUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/convert/ReflectionEntityInstantiatorDataClassUnitTests.kt
@@ -15,14 +15,10 @@
  */
 package org.springframework.data.convert
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.whenever
+import io.mockk.every
+import io.mockk.mockk
 import org.assertj.core.api.Assertions
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.data.mapping.PersistentEntity
 import org.springframework.data.mapping.context.SamplePersistentProperty
 import org.springframework.data.mapping.model.ParameterValueProvider
@@ -32,22 +28,21 @@ import org.springframework.data.mapping.model.PreferredConstructorDiscoverer
  * Unit tests for [ReflectionEntityInstantiator] creating instances using Kotlin data classes.
  *
  * @author Mark Paluch
+ * @author Sebastien Deleuze
  */
-@RunWith(MockitoJUnitRunner::class)
 @Suppress("UNCHECKED_CAST")
 class ReflectionEntityInstantiatorDataClassUnitTests {
 
-	@Mock lateinit var entity: PersistentEntity<*, *>
-	@Mock lateinit var provider: ParameterValueProvider<SamplePersistentProperty>
+	val provider = mockk<ParameterValueProvider<SamplePersistentProperty>>()
 
 	@Test // DATACMNS-1126
 	fun `should create instance`() {
 
-		val entity = this.entity as PersistentEntity<Contact, SamplePersistentProperty>
+		val entity = mockk<PersistentEntity<Contact, SamplePersistentProperty>>()
 		val constructor = PreferredConstructorDiscoverer.discover<Contact, SamplePersistentProperty>(Contact::class.java)
 
-		doReturn("Walter", "White").`when`(provider).getParameterValue<SamplePersistentProperty>(any())
-		doReturn(constructor).whenever(entity).persistenceConstructor
+		every { provider.getParameterValue<String>(any()) }.returnsMany("Walter", "White")
+		every { entity.persistenceConstructor } returns constructor
 
 		val instance: Contact = ReflectionEntityInstantiator.INSTANCE.createInstance(entity, provider)
 
@@ -58,11 +53,11 @@ class ReflectionEntityInstantiatorDataClassUnitTests {
 	@Test // DATACMNS-1126
 	fun `should create instance and fill in defaults`() {
 
-		val entity = this.entity as PersistentEntity<ContactWithDefaulting, SamplePersistentProperty>
+		val entity = mockk<PersistentEntity<ContactWithDefaulting, SamplePersistentProperty>>()
 		val constructor = PreferredConstructorDiscoverer.discover<ContactWithDefaulting, SamplePersistentProperty>(ContactWithDefaulting::class.java)
 
-		doReturn("Walter", null).`when`(provider).getParameterValue<SamplePersistentProperty>(any())
-		doReturn(constructor).whenever(entity).persistenceConstructor
+		every { provider.getParameterValue<String>(any()) }.returnsMany("Walter", null)
+		every { entity.persistenceConstructor } returns constructor
 
 		val instance: ContactWithDefaulting = ReflectionEntityInstantiator.INSTANCE.createInstance(entity, provider)
 

--- a/src/test/kotlin/org/springframework/data/repository/CrudRepositoryExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/repository/CrudRepositoryExtensionsTests.kt
@@ -15,28 +15,30 @@
  */
 package org.springframework.data.repository
 
-import com.nhaarman.mockito_kotlin.verify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.data.repository.sample.User
+import java.util.*
+import kotlin.test.assertNull
 
 /**
  * Unit tests for CrudRepositoryExtensions.
  *
  * @author Sebastien Deleuze
  */
-@RunWith(MockitoJUnitRunner::class)
 class CrudRepositoryExtensionsTests {
 
-	@Mock(answer = Answers.RETURNS_MOCKS)
-	lateinit var repository: CrudRepository<User, String>
+	var repository = mockk<CrudRepository<User, String>>()
 
 	@Test // DATACMNS-1346
 	fun `CrudRepository#findByIdOrNull() extension should call its Java counterpart`() {
-		repository.findByIdOrNull("foo")
-		verify(repository).findById("foo")
+		val user = User()
+		every { repository.findById("foo") }.returnsMany(Optional.of(user), Optional.empty())
+		assertEquals(user, repository.findByIdOrNull("foo"))
+		assertNull(repository.findByIdOrNull("foo"))
+		verify(exactly = 2) { repository.findById("foo") }
 	}
 }


### PR DESCRIPTION
In order to be consistent with Spring Framework tests and recommendation to use [Mockk](https://mockk.io/) for Kotlin tests, and in order to be consistent with the upcoming Coroutines pull requests for Spring Data MongoDB and R2DBC which are using Mockk as well, I have migrated Spring Data Commons tests and will do as well with other Spring Data projects.