### PR TITLE
DATACMNS-1482 - Properly convert collections when collection type matches but element type doesn't.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1482-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
@@ -58,7 +58,7 @@ class QueryExecutionResultHandler {
 	 * Post-processes the given result of a query invocation to match the return type of the given method.
 	 *
 	 * @param result can be {@literal null}.
-	 * @param metho must not be {@literal null}.
+	 * @param method must not be {@literal null}.
 	 * @return
 	 */
 	@Nullable
@@ -74,7 +74,8 @@ class QueryExecutionResultHandler {
 	 * Post-processes the given result of a query invocation to the given type.
 	 *
 	 * @param result can be {@literal null}.
-	 * @param returnTypeDescriptor can be {@literal null}, if so, no conversion is performed.
+	 * @param nestingLevel
+	 * @param parameter must not be {@literal null}.
 	 * @return
 	 */
 	@Nullable

--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
@@ -34,6 +34,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 class QueryExecutionResultHandler {
 
@@ -63,10 +64,6 @@ class QueryExecutionResultHandler {
 	@Nullable
 	public Object postProcessInvocationResult(@Nullable Object result, Method method) {
 
-		if (method.getReturnType().isInstance(result)) {
-			return result;
-		}
-
 		MethodParameter parameter = new MethodParameter(method, -1);
 
 		return postProcessInvocationResult(result, 0, parameter);
@@ -91,19 +88,7 @@ class QueryExecutionResultHandler {
 
 		Class<?> expectedReturnType = returnTypeDescriptor.getType();
 
-		// Early return if the raw value matches
-
-		if (result != null && expectedReturnType.isInstance(result)) {
-			return result;
-		}
-
 		result = unwrapOptional(result);
-
-		// Early return if the unrwapped value matches
-
-		if (result != null && expectedReturnType.isInstance(result)) {
-			return result;
-		}
 
 		if (QueryExecutionConverters.supports(expectedReturnType)) {
 
@@ -132,8 +117,8 @@ class QueryExecutionResultHandler {
 				return ReactiveWrapperConverters.toWrapper(result, expectedReturnType);
 			}
 
-			return conversionService.canConvert(result.getClass(), expectedReturnType)
-					? conversionService.convert(result, expectedReturnType)
+			return conversionService.canConvert(TypeDescriptor.forObject(result), returnTypeDescriptor)
+					? conversionService.convert(result, returnTypeDescriptor)
 					: result;
 		}
 


### PR DESCRIPTION
Various fast returns and the use of `Class` instead of `TypeDescriptor` led to e.g. `List<BigDecimal>` not getting properly converted to `List<Integer>` leading to unexpected `ClassCastException`s when the collection elements where accessed.