### PR TITLE
DATACMNS-1487 - Dont cache candidate bean definitions

### DIFF
--- a/src/main/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetector.java
+++ b/src/main/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetector.java
@@ -103,8 +103,7 @@ public class CustomRepositoryImplementationDetector {
 
 		Assert.notNull(lookup, "ImplementationLookupConfiguration must not be null!");
 
-		Set<BeanDefinition> definitions = implementationCandidates.getOptional()
-				.orElseGet(() -> findCandidateBeanDefinitions(lookup)).stream() //
+		Set<BeanDefinition> definitions = findCandidateBeanDefinitions(lookup).stream() //
 				.filter(lookup::matches) //
 				.collect(StreamUtils.toUnmodifiableSet());
 


### PR DESCRIPTION
By not caching the discovered bean definitions (as the cached discovery is based on base packages of the repository) this fixed [DATACMNS-1487](https://jira.spring.io/browse/DATACMNS-1487) for me.

I consider this a partial PR as this change makes this constructor potentially removable.  However, I couldn't get the tests compiling on my clone due to missing querydsl classes and therefore I was unable to refactor the constructor out of the code and tests.  

You guys may have a better, more complete fix anyways.   

