### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Spring Data Commons
 
-[Spring Data Commons](http://projects.spring.io/spring-data/) is part of the umbrella Spring Data project that provides shared infrastructure across the Spring Data projects. It contains technology neutral repository interfaces as well as a metadata model for persisting Java classes.
+[Spring Data Commons](https://projects.spring.io/spring-data/) is part of the umbrella Spring Data project that provides shared infrastructure across the Spring Data projects. It contains technology neutral repository interfaces as well as a metadata model for persisting Java classes.
 
 ## Features
 
@@ -27,18 +27,18 @@ $ mvn clean install
 
 ## Getting Help
 
-This README as well as the [reference documentation](http://docs.spring.io/spring-data/data-commons/docs/current/reference/html/) are the best places to start learning about Spring Data Commons.
+This README as well as the [reference documentation](https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/) are the best places to start learning about Spring Data Commons.
 
-The main project [website](http://projects.spring.io/spring-data/) contains links to basic project information such as source code, JavaDocs, Issue tracking, etc.
+The main project [website](https://projects.spring.io/spring-data/) contains links to basic project information such as source code, JavaDocs, Issue tracking, etc.
 
-For more detailed questions, please refer to [spring-data on stackoverflow](http://stackoverflow.com/questions/tagged/spring-data). If you are new to Spring as well as to Spring Data, look for information about [Spring projects](https://spring.io/projects). 
+For more detailed questions, please refer to [spring-data on stackoverflow](https://stackoverflow.com/questions/tagged/spring-data). If you are new to Spring as well as to Spring Data, look for information about [Spring projects](https://spring.io/projects). 
 
 ## Contributing to Spring Data Commons
 
 Here are some ways for you to get involved in the community:
 
 * Create [JIRA](https://jira.spring.io/browse/DATACMNS) tickets for bugs and new features and comment and vote on the ones that you are interested in.
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
 * Watch for upcoming articles on Spring by [subscribing](https://spring.io/blog.atom) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability to merge pull requests.

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -5,7 +5,7 @@ The Spring Data Commons project applies core Spring concepts to the development 
 [[project]]
 == Project Metadata
 
-* Version control: http://github.com/spring-projects/spring-data-commons
+* Version control: https://github.com/spring-projects/spring-data-commons
 * Bugtracker: https://jira.spring.io/browse/DATACMNS
 * Release repository: https://repo.spring.io/libs-release
 * Milestone repository: https://repo.spring.io/libs-milestone

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -1,4 +1,4 @@
-:spring-framework-docs: http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference
+:spring-framework-docs: https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference
 :spring-framework-javadoc: https://docs.spring.io/spring/docs/{springVersion}/javadoc-api
 
 [[repositories]]
@@ -147,9 +147,9 @@ class Config { … }
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns:jpa="http://www.springframework.org/schema/data/jpa"
    xsi:schemaLocation="http://www.springframework.org/schema/beans
-     http://www.springframework.org/schema/beans/spring-beans.xsd
+     https://www.springframework.org/schema/beans/spring-beans.xsd
      http://www.springframework.org/schema/data/jpa
-     http://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
+     https://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
 
    <jpa:repositories base-package="com.acme.repositories"/>
 
@@ -455,7 +455,7 @@ NOTE: Limiting the results in combination with dynamic sorting by using a `Sort`
 [[repositories.collections-and-iterables]]
 === Repository Methods Returning Collections or Iterables
 Query methods that return multiple results can use standard Java `Iterable`, `List`, `Set`.
-Beyond that we support returning Spring Data's `Streamable`, a custom extension of `Iterable`, as well as collection types provided by http://www.vavr.io/[Vavr].
+Beyond that we support returning Spring Data's `Streamable`, a custom extension of `Iterable`, as well as collection types provided by https://www.vavr.io/[Vavr].
 
 [[repositories.collections-and-iterables.streamable]]
 ==== Using Streamable as Query Method Return Type
@@ -520,7 +520,7 @@ interface ProductRepository implements Repository<Product, Long> {
 [[repositories.collections-and-iterables.vavr]]
 ==== Support for Vavr Collections
 
-http://www.vavr.io/[Vavr] is a library to embrace functional programming concepts in Java.
+https://www.vavr.io/[Vavr] is a library to embrace functional programming concepts in Java.
 It ships with a custom set of collection types that can be used as query method return types.
 
 [options=header]
@@ -695,9 +695,9 @@ Each Spring Data module includes a `repositories` element that lets you define a
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.springframework.org/schema/data/jpa"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/jpa
-    http://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
+    https://www.springframework.org/schema/data/jpa/spring-jpa.xsd">
 
   <repositories base-package="com.acme.repositories" />
 
@@ -1290,7 +1290,7 @@ You see that the assembler produced the correct URI and also picked up the defau
 [[core.web.binding]]
 ==== Web Databinding Support
 
-Spring Data projections (described in <<projections>>) can be used to bind incoming request payloads by either using http://goessner.net/articles/JsonPath/[JSONPath] expressions (requires https://github.com/json-path/JsonPath[Jayway JsonPath] or https://www.w3.org/TR/xpath-31/[XPath] expressions (requires https://xmlbeam.org/[XmlBeam]), as shown in the following example:
+Spring Data projections (described in <<projections>>) can be used to bind incoming request payloads by either using https://goessner.net/articles/JsonPath/[JSONPath] expressions (requires https://github.com/json-path/JsonPath[Jayway JsonPath] or https://www.w3.org/TR/xpath-31/[XPath] expressions (requires https://xmlbeam.org/[XmlBeam]), as shown in the following example:
 
 .HTTP payload binding using JSONPath or XPath expressions
 ====
@@ -1434,9 +1434,9 @@ You can populate your repositories by using the populator elements of the reposi
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:repository="http://www.springframework.org/schema/data/repository"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/repository
-    http://www.springframework.org/schema/data/repository/spring-repository.xsd">
+    https://www.springframework.org/schema/data/repository/spring-repository.xsd">
 
   <repository:jackson2-populator locations="classpath:data.json" />
 
@@ -1461,11 +1461,11 @@ To instead use XML to define the data the repositories should be populated with,
   xmlns:repository="http://www.springframework.org/schema/data/repository"
   xmlns:oxm="http://www.springframework.org/schema/oxm"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/repository
-    http://www.springframework.org/schema/data/repository/spring-repository.xsd
+    https://www.springframework.org/schema/data/repository/spring-repository.xsd
     http://www.springframework.org/schema/oxm
-    http://www.springframework.org/schema/oxm/spring-oxm.xsd">
+    https://www.springframework.org/schema/oxm/spring-oxm.xsd">
 
   <repository:unmarshaller-populator locations="classpath:data.json"
     unmarshaller-ref="unmarshaller" />

--- a/src/main/java/org/springframework/data/convert/ThreeTenBackPortConverters.java
+++ b/src/main/java/org/springframework/data/convert/ThreeTenBackPortConverters.java
@@ -46,7 +46,7 @@ import org.threeten.bp.ZoneOffset;
  * @author Christoph Strobl
  * @author Jens Schauder
  * @author Mark Paluch
- * @see <a href="http://www.threeten.org/threetenbp">http://www.threeten.org/threetenbp</a>
+ * @see <a href="https://www.threeten.org/threetenbp">https://www.threeten.org/threetenbp</a>
  * @since 1.10
  */
 public abstract class ThreeTenBackPortConverters {

--- a/src/main/java/org/springframework/data/querydsl/ReactiveQuerydslPredicateExecutor.java
+++ b/src/main/java/org/springframework/data/querydsl/ReactiveQuerydslPredicateExecutor.java
@@ -26,7 +26,7 @@ import com.querydsl.core.types.Predicate;
 /**
  * Interface to issue queries using Querydsl {@link Predicate} instances. <br />
  * Intended for usage along with the {@link org.springframework.data.repository.reactive.ReactiveCrudRepository}
- * interface to wire in <a href="http://http://www.querydsl.com">Querydsl</a>support.
+ * interface to wire in <a href="https://http://www.querydsl.com">Querydsl</a>support.
  *
  * <pre>
  *     <code>

--- a/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/PartTree.java
@@ -53,8 +53,8 @@ public class PartTree implements Streamable<OrPart> {
 	 * OR
 	 *  any other letter NOT in the BASIC_LATIN Uni-code Block \\P{InBASIC_LATIN} (like Chinese, Korean, Japanese, etc.).
 	 *
-	 * @see <a href="http://www.regular-expressions.info/unicode.html">http://www.regular-expressions.info/unicode.html</a>
-	 * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#ubc">Pattern</a>
+	 * @see <a href="https://www.regular-expressions.info/unicode.html">https://www.regular-expressions.info/unicode.html</a>
+	 * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#ubc">Pattern</a>
 	 */
 	private static final String KEYWORD_TEMPLATE = "(%s)(?=(\\p{Lu}|\\P{InBASIC_LATIN}))";
 	private static final String QUERY_PATTERN = "find|read|get|query|stream";

--- a/src/main/java/org/springframework/data/web/XmlBeamHttpMessageConverter.java
+++ b/src/main/java/org/springframework/data/web/XmlBeamHttpMessageConverter.java
@@ -41,7 +41,7 @@ import org.xmlbeam.config.DefaultXMLFactoriesConfig;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
- * @see <a href="http://www.xmlbeam.org">http://www.xmlbeam.org</a>
+ * @see <a href="https://www.xmlbeam.org">https://www.xmlbeam.org</a>
  * @soundtrack Dr. Kobayashi Maru & The Mothership Connection - Anthem (EPisode One)
  */
 public class XmlBeamHttpMessageConverter extends AbstractHttpMessageConverter<Object> {
@@ -67,8 +67,8 @@ public class XmlBeamHttpMessageConverter extends AbstractHttpMessageConverter<Ob
 
 				DocumentBuilderFactory factory = super.createDocumentBuilderFactory();
 
-				factory.setAttribute("http://apache.org/xml/features/disallow-doctype-decl", true);
-				factory.setAttribute("http://xml.org/sax/features/external-general-entities", false);
+				factory.setAttribute("https://apache.org/xml/features/disallow-doctype-decl", true);
+				factory.setAttribute("http://www.xml.org/sax/features/external-general-entities", false);
 
 				return factory;
 			}

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/src/main/resources/org/springframework/data/domain/jaxb/atom.xsd
+++ b/src/main/resources/org/springframework/data/domain/jaxb/atom.xsd
@@ -5,10 +5,10 @@
 	<xs:annotation>
 		<xs:documentation>
 				This version of the Atom schema is based on version 1.0 of the format specifications,
-				found here http://www.atomenabled.org/developers/syndication/atom-format-spec.php.
+				found here https://www.atomenabled.org/developers/syndication/atom-format-spec.php.
 			</xs:documentation>
 	</xs:annotation>
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
+	<xs:import namespace="https://www.w3.org/XML/1998/namespace" schemaLocation="https://www.w3.org/2001/03/xml.xsd" />
 	<xs:annotation>
 		<xs:documentation>
 			An Atom document may have two root elements, feed and entry, as defined in section 2.

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.0.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.0.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.11.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.11.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.4.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.4.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.5.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.5.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.6.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.6.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.7.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.7.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-1.8.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-1.8.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/org/springframework/data/repository/config/spring-repository-2.1.xsd
+++ b/src/main/resources/org/springframework/data/repository/config/spring-repository-2.1.xsd
@@ -8,7 +8,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/context"
-		schemaLocation="http://www.springframework.org/schema/context/spring-context.xsd" />
+		schemaLocation="https://www.springframework.org/schema/context/spring-context.xsd" />
 
 	<xsd:complexType name="repositories">
 		<xsd:sequence>

--- a/src/main/resources/readme.txt
+++ b/src/main/resources/readme.txt
@@ -10,5 +10,5 @@ The reference manual and javadoc are located in the 'docs' directory.
 
 ADDITIONAL RESOURCES:
 
-Spring Data Homepage: http://projects.spring.io/spring-data
-Spring Data on Stackoverflow: http://stackoverflow.com/questions/tagged/spring-data
+Spring Data Homepage: https://projects.spring.io/spring-data
+Spring Data on Stackoverflow: https://stackoverflow.com/questions/tagged/spring-data

--- a/src/test/java/org/springframework/data/web/PagedResourcesAssemblerUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PagedResourcesAssemblerUnitTests.java
@@ -94,7 +94,7 @@ public class PagedResourcesAssemblerUnitTests {
 	@Test
 	public void usesBaseUriIfConfigured() {
 
-		UriComponents baseUri = UriComponentsBuilder.fromUriString("http://foo:9090").build();
+		UriComponents baseUri = UriComponentsBuilder.fromUriString("https://foo:9090").build();
 
 		PagedResourcesAssembler<Person> assembler = new PagedResourcesAssembler<>(resolver, baseUri);
 		PagedModel<EntityModel<Person>> resources = assembler.toModel(createPage(1));
@@ -107,7 +107,7 @@ public class PagedResourcesAssemblerUnitTests {
 	@Test
 	public void usesCustomLinkProvided() {
 
-		Link link = new Link("http://foo:9090", "rel");
+		Link link = new Link("https://foo:9090", "rel");
 
 		PagedModel<EntityModel<Person>> resources = assembler.toModel(createPage(1), link);
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://help.eclipse.org/oxygen/index.jsp?topic=/org.eclipse.jdt.doc.user/tasks/task-using_external_null_annotations.htm (200) with 1 occurrences could not be migrated:  
   ([https](https://help.eclipse.org/oxygen/index.jsp?topic=/org.eclipse.jdt.doc.user/tasks/task-using_external_null_annotations.htm) result SSLException).
* [ ] http://www.querydsl.com (200) with 2 occurrences could not be migrated:  
   ([https](https://www.querydsl.com) result AnnotatedConnectException).
* [ ] http://www.querydsl.com/ (200) with 2 occurrences could not be migrated:  
   ([https](https://www.querydsl.com/) result AnnotatedConnectException).
* [ ] http://xml.org/sax/features/external-general-entities (301) with 1 occurrences could not be migrated:  
   ([https](https://xml.org/sax/features/external-general-entities) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/2001/03/xml.xsd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/2001/03/xml.xsd ([https](https://www.w3.org/2001/03/xml.xsd) result SSLException).
* [ ] http://www.w3.org/XML/1998/namespace (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/XML/1998/namespace ([https](https://www.w3.org/XML/1998/namespace) result SSLException).
* [ ] http://foo:9090 (UnknownHostException) with 2 occurrences migrated to:  
  https://foo:9090 ([https](https://foo:9090) result UnknownHostException).
* [ ] http://http://www.querydsl.com (UnknownHostException) with 1 occurrences migrated to:  
  https://http://www.querydsl.com ([https](https://https://www.querydsl.com) result UnknownHostException).
* [ ] http://apache.org/xml/features/disallow-doctype-decl (404) with 1 occurrences migrated to:  
  https://apache.org/xml/features/disallow-doctype-decl ([https](https://apache.org/xml/features/disallow-doctype-decl) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html ([https](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://github.com/spring-projects/spring-data-commons with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-data-commons ([https](https://github.com/spring-projects/spring-data-commons) result 200).
* [ ] http://goessner.net/articles/JsonPath/ with 1 occurrences migrated to:  
  https://goessner.net/articles/JsonPath/ ([https](https://goessner.net/articles/JsonPath/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data ([https](https://stackoverflow.com/questions/tagged/spring-data) result 200).
* [ ] http://www.regular-expressions.info/unicode.html with 2 occurrences migrated to:  
  https://www.regular-expressions.info/unicode.html ([https](https://www.regular-expressions.info/unicode.html) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).
* [ ] http://www.vavr.io/ with 2 occurrences migrated to:  
  https://www.vavr.io/ ([https](https://www.vavr.io/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-data/data-commons/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://projects.spring.io/spring-data with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data ([https](https://projects.spring.io/spring-data) result 301).
* [ ] http://www.atomenabled.org/developers/syndication/atom-format-spec.php with 1 occurrences migrated to:  
  https://www.atomenabled.org/developers/syndication/atom-format-spec.php ([https](https://www.atomenabled.org/developers/syndication/atom-format-spec.php) result 301).
* [ ] http://www.springframework.org/schema/data/jpa/spring-jpa.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/jpa/spring-jpa.xsd ([https](https://www.springframework.org/schema/data/jpa/spring-jpa.xsd) result 301).
* [ ] http://www.springframework.org/schema/oxm/spring-oxm.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/oxm/spring-oxm.xsd ([https](https://www.springframework.org/schema/oxm/spring-oxm.xsd) result 301).
* [ ] http://www.threeten.org/threetenbp with 2 occurrences migrated to:  
  https://www.threeten.org/threetenbp ([https](https://www.threeten.org/threetenbp) result 301).
* [ ] http://www.xmlbeam.org with 2 occurrences migrated to:  
  https://www.xmlbeam.org ([https](https://www.xmlbeam.org) result 301).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/persons with 1 occurrences
* http://localhost:8080/persons?page=1&size=20 with 1 occurrences
* http://localhost:8080?page=0&size=10 with 1 occurrences
* http://www.springframework.org/schema/beans with 8 occurrences
* http://www.springframework.org/schema/context with 16 occurrences
* http://www.springframework.org/schema/data/jaxb with 3 occurrences
* http://www.springframework.org/schema/data/jpa with 4 occurrences
* http://www.springframework.org/schema/data/repository with 20 occurrences
* http://www.springframework.org/schema/oxm with 2 occurrences
* http://www.springframework.org/schema/tool with 16 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences
* http://www.w3.org/2001/XMLSchema with 10 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences
* http://www.w3.org/2005/Atom with 4 occurrences