### PR TITLE
DATACMNS-1512 - Allow customization of ConversionService in RepositoryFactorySupport

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
@@ -39,6 +39,7 @@ import org.springframework.lang.Nullable;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author wreulicke
  */
 class QueryExecutionResultHandler {
 

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -44,8 +44,6 @@ import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.ResolvableType;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor;
@@ -141,8 +139,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 	private final QueryCollectingQueryCreationListener collectingListener = new QueryCollectingQueryCreationListener();
 
 	@SuppressWarnings("null")
-	public RepositoryFactorySupport() {
-
+	public RepositoryFactorySupport(GenericConversionService conversionService) {
 		this.repositoryInformationCache = new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK);
 		this.postProcessors = new ArrayList<>();
 
@@ -152,9 +149,24 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		this.evaluationContextProvider = QueryMethodEvaluationContextProvider.DEFAULT;
 		this.queryPostProcessors = new ArrayList<>();
 		this.queryPostProcessors.add(collectingListener);
-		this.conversionService = new DefaultConversionService();
+		this.conversionService = conversionService;
+	}
+	
+	@SuppressWarnings("null")
+	public RepositoryFactorySupport() {
+		this(defaultConversionService());
+	}
+	
+	/**
+	 * Creates default ConversionService.
+	 *
+	 * @return default conversion service
+	 */
+	private static GenericConversionService defaultConversionService() {
+		final DefaultConversionService conversionService = new DefaultConversionService();
 		QueryExecutionConverters.registerConvertersIn(conversionService);
 		conversionService.removeConvertible(Object.class, Object.class);
+		return conversionService;
 	}
 
 	/**
@@ -239,26 +251,6 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 		Assert.notNull(processor, "RepositoryProxyPostProcessor must not be null!");
 		this.postProcessors.add(processor);
-	}
-
-	/**
-	 * Adds a {@link Converter} to the conversionService.
-	 *
-	 * @param converter
-	 */
-	public <T, R> void addConverter(Converter<T, R> converter) {
-		Assert.notNull(converter, "converter must not be null!");
-		this.conversionService.addConverter(converter);
-	}
-
-	/**
-	 * Adds a {@link Converter} to the conversionService.
-	 *
-	 * @param converter
-	 */
-	public void addConverter(GenericConverter converter) {
-		Assert.notNull(converter, "converter must not be null!");
-		this.conversionService.addConverter(converter);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/core/support/QueryExecutionResultHandlerUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/QueryExecutionResultHandlerUnitTests.java
@@ -39,10 +39,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.Before;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
+
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.util.QueryExecutionConverters;
 import org.springframework.data.util.Streamable;
 
 /**
@@ -51,11 +55,20 @@ import org.springframework.data.util.Streamable;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author wreulicke
  */
 public class QueryExecutionResultHandlerUnitTests {
 
-	QueryExecutionResultHandler handler = new QueryExecutionResultHandler(RepositoryFactorySupport.CONVERSION_SERVICE);
+	QueryExecutionResultHandler handler;
 
+	@Before
+	public void setUp() {
+		DefaultConversionService conversionService = new DefaultConversionService();
+		QueryExecutionConverters.registerConvertersIn(conversionService);
+		conversionService.removeConvertible(Object.class, Object.class);
+		handler = new QueryExecutionResultHandler(conversionService);
+	}
+	
 	@Test // DATACMNS-610
 	public void convertsListsToSet() throws Exception {
 

--- a/src/test/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptorUnitTests.java
@@ -20,14 +20,17 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.query.QueryLookupStrategy;
+import org.springframework.data.repository.util.QueryExecutionConverters;
 import org.springframework.data.util.Streamable;
 
 /**
@@ -36,6 +39,7 @@ import org.springframework.data.util.Streamable;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author wreulicke
  */
 @RunWith(MockitoJUnitRunner.class)
 public class QueryExecutorMethodInterceptorUnitTests {
@@ -43,6 +47,15 @@ public class QueryExecutorMethodInterceptorUnitTests {
 	@Mock RepositoryFactorySupport factory;
 	@Mock RepositoryInformation information;
 	@Mock QueryLookupStrategy strategy;
+	
+	private DefaultConversionService conversionService;
+	
+	@Before
+	public void setUp() {
+		conversionService = new DefaultConversionService();
+		QueryExecutionConverters.registerConvertersIn(conversionService);
+		conversionService.removeConvertible(Object.class, Object.class);
+	}
 
 	@Test
 	public void rejectsRepositoryInterfaceWithQueryMethodsIfNoQueryLookupStrategyIsDefined() {
@@ -51,7 +64,7 @@ public class QueryExecutorMethodInterceptorUnitTests {
 		when(factory.getQueryLookupStrategy(any(), any())).thenReturn(Optional.empty());
 
 		assertThatIllegalStateException().isThrownBy(
-				() -> factory.new QueryExecutorMethodInterceptor(information, new SpelAwareProxyProjectionFactory()));
+				() -> factory.new QueryExecutorMethodInterceptor(information, new SpelAwareProxyProjectionFactory(), conversionService));
 	}
 
 	@Test
@@ -60,7 +73,7 @@ public class QueryExecutorMethodInterceptorUnitTests {
 		when(information.getQueryMethods()).thenReturn(Streamable.empty());
 		when(factory.getQueryLookupStrategy(any(), any())).thenReturn(Optional.of(strategy));
 
-		factory.new QueryExecutorMethodInterceptor(information, new SpelAwareProxyProjectionFactory());
+		factory.new QueryExecutorMethodInterceptor(information, new SpelAwareProxyProjectionFactory(), conversionService);
 
 		verify(strategy, times(0)).resolveQuery(any(), any(), any(), any());
 	}


### PR DESCRIPTION
Fix [DATACMNS-1512](https://jira.spring.io/projects/DATACMNS/issues/DATACMNS-1512)

I have a library using spring-data-commons, [spring-data-mirage](https://github.com/dai0304/spring-data-mirage).

In the library, it is able to use custom collection as return type, such as a below custom collection.

We have the interface, Chunk and the implementation, ChunkImpl.
But, We cannot return ChunkImpl as implementation of Chunk in 2.1.6.RELEASE of spring-data-commons.
This causes by element type conversion introduced by https://jira.spring.io/browse/DATACMNS-1482.

```
public interface Chunk<T> extends Collection<T> {
  // some methods...
}

public class ChunkImpl<T> implements Chunk<T> {
  // some implmentations...
}
```

I cannot find the workaround.
So, I would like to make to register custom conversion.

# checklist

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
