### PR TITLE
DATACMNS-1534 - Cache BeanFactory lookup for EvaluationContextExtension.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1534-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/query/ExtensionAwareQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ExtensionAwareQueryMethodEvaluationContextProvider.java
@@ -30,7 +30,6 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
 import org.springframework.data.spel.spi.EvaluationContextExtension;
-import org.springframework.data.util.Lazy;
 import org.springframework.data.util.Streamable;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -52,7 +51,7 @@ import org.springframework.util.StringUtils;
  */
 public class ExtensionAwareQueryMethodEvaluationContextProvider implements QueryMethodEvaluationContextProvider {
 
-	private final Lazy<org.springframework.data.spel.ExtensionAwareEvaluationContextProvider> delegate;
+	private final ExtensionAwareEvaluationContextProvider delegate;
 
 	/**
 	 * Creates a new {@link ExtensionAwareQueryMethodEvaluationContextProvider}.
@@ -64,7 +63,7 @@ public class ExtensionAwareQueryMethodEvaluationContextProvider implements Query
 
 		Assert.notNull(beanFactory, "ListableBeanFactory must not be null!");
 
-		this.delegate = Lazy.of(() -> new ExtensionAwareEvaluationContextProvider(() -> getExtensionsFrom(beanFactory)));
+		this.delegate = new ExtensionAwareEvaluationContextProvider(beanFactory);
 	}
 
 	/**
@@ -77,7 +76,7 @@ public class ExtensionAwareQueryMethodEvaluationContextProvider implements Query
 
 		Assert.notNull(extensions, "EvaluationContextExtensions must not be null!");
 
-		this.delegate = Lazy.of(new org.springframework.data.spel.ExtensionAwareEvaluationContextProvider(extensions));
+		this.delegate = new org.springframework.data.spel.ExtensionAwareEvaluationContextProvider(extensions);
 	}
 
 	/*
@@ -87,7 +86,7 @@ public class ExtensionAwareQueryMethodEvaluationContextProvider implements Query
 	@Override
 	public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues) {
 
-		StandardEvaluationContext evaluationContext = delegate.get().getEvaluationContext(parameterValues);
+		StandardEvaluationContext evaluationContext = delegate.getEvaluationContext(parameterValues);
 
 		evaluationContext.setVariables(collectVariables(parameters, parameterValues));
 

--- a/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -37,6 +36,7 @@ import org.springframework.data.spel.EvaluationContextExtensionInformation.Exten
 import org.springframework.data.spel.EvaluationContextExtensionInformation.RootObjectInformation;
 import org.springframework.data.spel.spi.EvaluationContextExtension;
 import org.springframework.data.spel.spi.Function;
+import org.springframework.data.util.Lazy;
 import org.springframework.data.util.Optionals;
 import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
@@ -66,7 +66,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 
 	private final Map<Class<?>, EvaluationContextExtensionInformation> extensionInformationCache = new ConcurrentHashMap<>();
 
-	private final Supplier<? extends Collection<? extends EvaluationContextExtension>> extensions;
+	private final Lazy<? extends Collection<? extends EvaluationContextExtension>> extensions;
 	private ListableBeanFactory beanFactory;
 
 	ExtensionAwareEvaluationContextProvider() {
@@ -81,7 +81,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	 */
 	public ExtensionAwareEvaluationContextProvider(ListableBeanFactory beanFactory) {
 
-		this(() -> getExtensionsFrom(beanFactory));
+		this(Lazy.of(() -> getExtensionsFrom(beanFactory)));
 
 		this.beanFactory = beanFactory;
 	}
@@ -92,7 +92,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	 * @param extensions must not be {@literal null}.
 	 */
 	public ExtensionAwareEvaluationContextProvider(Collection<? extends EvaluationContextExtension> extensions) {
-		this(() -> extensions);
+		this(Lazy.of(extensions));
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
We now cache the `BeanFactory` lookup for `EvaluationContextExtension` within the `ExtensionAwareEvalutationContextProvider` to avoid (expensive) repeated context scans when creating the actual `EvaluationContext`.