### PR TITLE
DATACMNS-1557 - Sort Javadoc mentions wrong sorting order

### DIFF
--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -426,7 +426,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 		}
 
 		/**
-		 * Creates a new {@link Order} instance. Takes a single property. Direction is {@link Direction#ASC} and
+		 * Creates a new {@link Order} instance. Takes a single property. Direction is {@link Direction#DESC} and
 		 * NullHandling {@link NullHandling#NATIVE}.
 		 *
 		 * @param property must not be {@literal null} or empty.


### PR DESCRIPTION
From `ASC` to `DESC`.