### PR TITLE
DATACMNS-1570 - Made the behaviour consistent between Subject part and Order By part.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1570-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/query/parser/Part.java
+++ b/src/main/java/org/springframework/data/repository/query/parser/Part.java
@@ -17,6 +17,7 @@ package org.springframework.data.repository.query.parser;
 
 import lombok.EqualsAndHashCode;
 
+import java.beans.Introspector;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,7 +28,6 @@ import java.util.regex.Pattern;
 
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * A single part of a method name that has to be transformed into a query part. The actual transformation is defined by
@@ -262,7 +262,7 @@ public class Part {
 		 */
 		public String extractProperty(String part) {
 
-			String candidate = StringUtils.uncapitalize(part);
+			String candidate = Introspector.decapitalize(part);
 
 			for (String keyword : keywords) {
 				if (candidate.endsWith(keyword)) {

--- a/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.junit.Test;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.data.repository.query.parser.Part.IgnoreCaseType;
 import org.springframework.data.repository.query.parser.Part.Type;
 import org.springframework.data.repository.query.parser.PartTree.OrPart;
@@ -601,6 +602,40 @@ public class PartTreeUnitTests {
 		assertThat(tree.hasPredicate()).isFalse();
 	}
 
+	/**
+	 * This test does not verify a desired behaviour but documents a limitation. If it starts failing and everything else
+	 * is green, remove the expectation to fail with an exception.
+	 */
+	@Test(expected = PropertyReferenceException.class) // DATACMNS-1570
+	public void specialCapitalizationInSubject() {
+		new PartTree("findByZIndex", SpecialCapitalization.class);
+	}
+
+	/**
+	 * This test does not verify a desired behaviour but documents a limitation. If it starts failing and everything else
+	 * is green, remove the expectation to fail with an exception.
+	 */
+	@Test(expected = PropertyReferenceException.class) // DATACMNS-1570
+	public void specialCapitalizationInOrderBy() {
+		new PartTree("findByOrderByZIndex", SpecialCapitalization.class);
+	}
+
+	@Test // DATACMNS-1570
+	public void allCapsInSubject() {
+
+		PartTree tree = new PartTree("findByURL", SpecialCapitalization.class);
+
+		assertThat(tree).hasSize(1);
+	}
+
+	@Test // DATACMNS-1570
+	public void allCapsInOrderBy() {
+
+		PartTree tree = new PartTree("findByOrderByURL", SpecialCapitalization.class);
+
+		assertThat(tree.getSort()).hasSize(1);
+	}
+
 	private static void assertLimiting(String methodName, Class<?> entityType, boolean limiting, Integer maxResults) {
 		assertLimiting(methodName, entityType, limiting, maxResults, false);
 	}
@@ -741,5 +776,18 @@ public class PartTreeUnitTests {
 	interface Anders {
 
 		Long getId();
+	}
+
+	public static class SpecialCapitalization {
+		int zIndex;
+		int URL;
+
+		int getZIndex() {
+			return zIndex;
+		}
+
+		int getURL() {
+			return URL;
+		}
 	}
 }


### PR DESCRIPTION

DATACMNS-1570 - Made the behaviour consistent between Subject part and Order By part.

The subject part wasn't decapitalizing properties starting with multiple characters properly.