### PR TITLE
 DATACMNS-1572 - Setting properties across multivalued properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATACMNS-1572-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/TraversalContext.java
+++ b/src/main/java/org/springframework/data/mapping/TraversalContext.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.springframework.lang.Nullable;
@@ -29,30 +30,42 @@ import org.springframework.util.Assert;
  * A context object for lookups of values for {@link PersistentPropertyPaths} via a {@link PersistentPropertyAccessor}.
  * It allows to register functions to post-process the objects returned for a particular property, so that the
  * subsequent traversal would rather use the processed object. This is especially helpful if you need to traverse paths
- * that contain {@link Collection}s and {@link Map} that usually need indices and keys to reasonably traverse nested
- * properties.
+ * that contain {@link Collection} and {@link Map} elements that usually need indices and keys to reasonably traverse
+ * nested properties. It also allows to register functions to pre-process objects to be set as value for a property.
+ * Again this is helpful if you need to set properties with a path that contain {@link Collection} and {@link Map}
+ * elements by allowing to set such a property to an element value which may be converted to an add operation on an
+ * existing collection or creation of a new collection with an additional or replaced element.
  *
  * @author Oliver Drotbohm
+ * @author Jens Schauder
  * @since 2.2
  * @soundtrack 8-Bit Misfits - Crash Into Me (Dave Matthews Band cover)
  */
 public class TraversalContext {
 
-	private Map<PersistentProperty<?>, Function<Object, Object>> handlers = new HashMap<>();
+	static private BiFunction NO_WRITE_HANDLER = (ov, nv) -> {
+		throw new UnsupportedOperationException("No handler registered for writing");
+	};
+
+	private Map<PersistentProperty<?>, Function<Object, Object>> readHandlers = new HashMap<>();
+	private Map<PersistentProperty<?>, BiFunction<Object, Object, Object>> writeHandlers = new HashMap<>();
 
 	/**
 	 * Registers a {@link Function} to post-process values for the given property.
 	 *
 	 * @param property must not be {@literal null}.
-	 * @param handler must not be {@literal null}.
-	 * @return
+	 * @param readHandler must not be {@literal null}.
+	 * @param writeHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
 	 */
-	public TraversalContext registerHandler(PersistentProperty<?> property, Function<Object, Object> handler) {
+	public TraversalContext registerHandler(PersistentProperty<?> property, Function<Object, Object> readHandler,
+			BiFunction<Object, Object, Object> writeHandler) {
 
 		Assert.notNull(property, "Property must not be null!");
-		Assert.notNull(handler, "Handler must not be null!");
+		Assert.notNull(readHandler, "Handler must not be null!");
 
-		handlers.put(property, handler);
+		readHandlers.put(property, readHandler);
+		writeHandlers.put(property, writeHandler);
 
 		return this;
 	}
@@ -61,51 +74,106 @@ public class TraversalContext {
 	 * Registers a {@link Function} to handle {@link Collection} values for the given property.
 	 *
 	 * @param property must not be {@literal null}.
-	 * @param handler must not be {@literal null}.
-	 * @return
+	 * @param readHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
 	 */
 	@SuppressWarnings("unchecked")
 	public TraversalContext registerCollectionHandler(PersistentProperty<?> property,
-			Function<? super Collection<?>, Object> handler) {
-		return registerHandler(property, Collection.class, (Function<Object, Object>) handler);
+			Function<? super Collection, Object> readHandler) {
+		return registerHandler(property, Collection.class, readHandler, NO_WRITE_HANDLER);
+	}
+
+	/**
+	 * Registers a {@link Function} to handle {@link Collection} values for the given property.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @param readHandler must not be {@literal null}.
+	 * @param writeHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
+	 */
+	public TraversalContext registerCollectionHandler(PersistentProperty<?> property,
+			Function<? super Collection, Object> readHandler,
+			BiFunction<? super Collection, Object, ? extends Collection> writeHandler) {
+		return registerHandler(property, Collection.class, readHandler, writeHandler);
 	}
 
 	/**
 	 * Registers a {@link Function} to handle {@link List} values for the given property.
 	 *
 	 * @param property must not be {@literal null}.
-	 * @param handler must not be {@literal null}.
-	 * @return
+	 * @param readHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
 	 */
 	@SuppressWarnings("unchecked")
 	public TraversalContext registerListHandler(PersistentProperty<?> property,
-			Function<? super List<?>, Object> handler) {
-		return registerHandler(property, List.class, (Function<Object, Object>) handler);
+			Function<? super List, Object> readHandler) {
+		return registerHandler(property, List.class, readHandler, NO_WRITE_HANDLER);
+	}
+
+	/**
+	 * Registers a {@link Function} to handle {@link List} values for the given property.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @param readHandler must not be {@literal null}.
+	 * @param writeHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
+	 */
+	public TraversalContext registerListHandler(PersistentProperty<?> property,
+			Function<? super List, Object> readHandler, BiFunction<? super List, Object, List> writeHandler) {
+		return registerHandler(property, List.class, readHandler, writeHandler);
 	}
 
 	/**
 	 * Registers a {@link Function} to handle {@link Set} values for the given property.
 	 *
 	 * @param property must not be {@literal null}.
-	 * @param handler must not be {@literal null}.
-	 * @return
+	 * @param readHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
 	 */
 	@SuppressWarnings("unchecked")
-	public TraversalContext registerSetHandler(PersistentProperty<?> property, Function<? super Set<?>, Object> handler) {
-		return registerHandler(property, Set.class, (Function<Object, Object>) handler);
+	public TraversalContext registerSetHandler(PersistentProperty<?> property,
+			Function<? super Set, Object> readHandler) {
+		return registerSetHandler(property, readHandler, NO_WRITE_HANDLER);
+	}
+
+	/**
+	 * Registers a {@link Function} to handle {@link Set} values for the given property.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @param readHandler must not be {@literal null}.
+	 * @param writeHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
+	 */
+	public TraversalContext registerSetHandler(PersistentProperty<?> property, Function<? super Set, Object> readHandler,
+			BiFunction<? super Set, Object, Set> writeHandler) {
+		return registerHandler(property, Set.class, readHandler, writeHandler);
 	}
 
 	/**
 	 * Registers a {@link Function} to handle {@link Map} values for the given property.
 	 *
 	 * @param property must not be {@literal null}.
-	 * @param handler must not be {@literal null}.
-	 * @return
+	 * @param readHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
 	 */
 	@SuppressWarnings("unchecked")
 	public TraversalContext registerMapHandler(PersistentProperty<?> property,
-			Function<? super Map<?, ?>, Object> handler) {
-		return registerHandler(property, Map.class, (Function<Object, Object>) handler);
+			Function<? super Map, Object> readHandler) {
+		return registerMapHandler(property, readHandler, NO_WRITE_HANDLER);
+	}
+
+	/**
+	 * Registers a {@link Function} to handle {@link Map} values for the given property.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @param readHandler must not be {@literal null}.
+	 * @param writeHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
+	 */
+	@SuppressWarnings("unchecked")
+	public TraversalContext registerMapHandler(PersistentProperty<?> property, Function<? super Map, Object> readHandler,
+			BiFunction<? super Map, Object, Map> writeHandler) {
+		return registerHandler(property, Map.class, readHandler, writeHandler);
 	}
 
 	/**
@@ -115,18 +183,36 @@ public class TraversalContext {
 	 * @param <T> the type of the value to handle.
 	 * @param property must not be {@literal null}.
 	 * @param type must not be {@literal null}.
-	 * @param handler must not be {@literal null}.
-	 * @return
+	 * @param readHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
 	 */
 	public <T> TraversalContext registerHandler(PersistentProperty<?> property, Class<T> type,
-			Function<? super T, Object> handler) {
+			Function<? super T, Object> readHandler) {
+		return registerHandler(property, type, readHandler, NO_WRITE_HANDLER);
+	}
+
+	/**
+	 * Registers the given {@link Function} to post-process values obtained for the given {@link PersistentProperty} for
+	 * the given type.
+	 *
+	 * @param <T> the type of the value to handle.
+	 * @param property must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @param readHandler must not be {@literal null}.
+	 * @param writeHandler must not be {@literal null}.
+	 * @return this instance for use as a fluent interface.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> TraversalContext registerHandler(PersistentProperty<?> property, Class<T> type,
+			Function<? super T, Object> readHandler, BiFunction<? super T, Object, ? extends T> writeHandler) {
 
 		Assert.isTrue(type.isAssignableFrom(property.getType()), () -> String
 				.format("Cannot register a property handler for %s on a property of type %s!", type, property.getType()));
 
-		Function<Object, T> caster = it -> type.cast(it);
+		Function<Object, T> caster = type::cast;
 
-		return registerHandler(property, caster.andThen(handler));
+		BiFunction<Object, Object, Object> castWriteHandler = (ov, nv) -> writeHandler.apply((T) ov, nv);
+		return registerHandler(property, caster.andThen(readHandler), castWriteHandler);
 	}
 
 	/**
@@ -139,8 +225,16 @@ public class TraversalContext {
 	@Nullable
 	Object postProcess(PersistentProperty<?> property, @Nullable Object value) {
 
-		Function<Object, Object> handler = handlers.get(property);
+		Function<Object, Object> handler = readHandlers.get(property);
 
 		return handler == null ? value : handler.apply(value);
+	}
+
+	public Object preProcess(PersistentProperty property, @Nullable Object originalValue, Object newValue) {
+
+		BiFunction<Object, Object, Object> handler = writeHandlers.get(property);
+
+		return handler == null ? newValue : handler.apply(originalValue, newValue);
+
 	}
 }

--- a/src/test/java/org/springframework/data/mapping/PersistentPropertyAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PersistentPropertyAccessorUnitTests.java
@@ -43,6 +43,7 @@ import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 
 /**
  * @author Oliver Gierke
+ * @author Jens Schauder
  */
 public class PersistentPropertyAccessorUnitTests {
 
@@ -53,7 +54,7 @@ public class PersistentPropertyAccessorUnitTests {
 
 	private void setUp(Order order, String path) {
 
-		this.accessor = context.getPersistentEntity(Order.class).getPropertyAccessor(order);
+		this.accessor = context.getRequiredPersistentEntity(Order.class).getPropertyAccessor(order);
 		this.path = context.getPersistentPropertyPath(path, Order.class);
 	}
 
@@ -110,7 +111,7 @@ public class PersistentPropertyAccessorUnitTests {
 	@Test // DATACMNS-1322
 	public void correctlyReplacesObjectInstancesWhenSettingPropertyPathOnImmutableObjects() {
 
-		PersistentEntity<Object, SamplePersistentProperty> entity = context.getPersistentEntity(Outer.class);
+		PersistentEntity<Object, SamplePersistentProperty> entity = context.getRequiredPersistentEntity(Outer.class);
 		PersistentPropertyPath<SamplePersistentProperty> path = context.getPersistentPropertyPath("immutable.value",
 				entity.getType());
 
@@ -163,7 +164,7 @@ public class PersistentPropertyAccessorUnitTests {
 				(context, property) -> context.registerSetHandler(property, it -> it.iterator().next()));
 		Spec mapHelper = Spec.of("map", (context, property) -> context.registerMapHandler(property, it -> it.get("key")));
 		Spec stringHelper = Spec.of("string",
-				(context, property) -> context.registerHandler(property, String.class, it -> it.trim()));
+				(context, property) -> context.registerHandler(property, String.class, String::trim));
 
 		Stream.of(collectionHelper, listHelper, setHelper, mapHelper, stringHelper).forEach(it -> {
 
@@ -184,7 +185,7 @@ public class PersistentPropertyAccessorUnitTests {
 	@Test // DATACMNS-1555
 	public void traversalContextRejectsInvalidPropertyHandler() {
 
-		PersistentEntity<Object, SamplePersistentProperty> entity = context.getPersistentEntity(WithContext.class);
+		PersistentEntity<Object, SamplePersistentProperty> entity = context.getRequiredPersistentEntity(WithContext.class);
 		PersistentProperty<?> property = entity.getRequiredPersistentProperty("collection");
 
 		TraversalContext traversal = new TraversalContext();


### PR DESCRIPTION
Expanded the the usage of `TraversalContext` to writing operations.