### PR TITLE
fix projection with EnumSet field

### DIFF
--- a/src/main/java/org/springframework/data/projection/ProjectingMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/projection/ProjectingMethodInterceptor.java
@@ -89,7 +89,7 @@ class ProjectingMethodInterceptor implements MethodInterceptor {
 
 		Class<?> rawType = type.getType();
 		Collection<Object> result = CollectionFactory.createCollection(rawType.isArray() ? List.class : rawType,
-				sources.size());
+				type.getComponentType().getType(), sources.size());
 
 		for (Object source : sources) {
 			result.add(getProjection(source, type.getComponentType().getType()));


### PR DESCRIPTION
When you try to apply a projecton to an entity with some EnumSet field, it fails with "Cannot create EnumSet for unknown element type"

Problem related to: https://github.com/spring-projects/spring-boot/issues/15539