### PR TITLE
DATACMNS-1591 - @Primary is now considered on repository interfaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1591-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -205,4 +205,13 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 
 		return toImplementationDetectionConfiguration(factory).forRepositoryConfiguration(this);
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfiguration#isPrimary()
+	 */
+	@Override
+	public boolean isPrimary() {
+		return definition.isPrimary();
+	}
 }

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -182,7 +182,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 		return configurationSource.getExcludeFilters();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfiguration#toImplementationDetectionConfiguration(org.springframework.core.type.classreading.MetadataReaderFactory)
 	 */
@@ -194,7 +194,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 		return configurationSource.toImplementationDetectionConfiguration(factory);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfiguration#toLookupConfiguration(org.springframework.core.type.classreading.MetadataReaderFactory)
 	 */

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -124,7 +124,7 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 
 	/**
 	 * Returns the {@link ImplementationLookupConfiguration} for the given {@link MetadataReaderFactory}.
-	 * 
+	 *
 	 * @param factory must not be {@literal null}.
 	 * @return will never be {@literal null}.
 	 * @since 2.1

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -130,4 +130,11 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 * @since 2.1
 	 */
 	ImplementationLookupConfiguration toLookupConfiguration(MetadataReaderFactory factory);
+
+	/**
+	 * Returns whether the repository is the primary one for its type.
+	 *
+	 * @return
+	 */
+	boolean isPrimary();
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -161,6 +161,8 @@ public class RepositoryConfigurationDelegate {
 			}
 
 			AbstractBeanDefinition beanDefinition = definitionBuilder.getBeanDefinition();
+			beanDefinition.setPrimary(configuration.isPrimary());
+
 			String beanName = configurationSource.generateBeanName(beanDefinition);
 
 			if (LOG.isTraceEnabled()) {

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -192,7 +192,7 @@ public class RepositoryConfigurationDelegate {
 	 * Registers a {@link LazyRepositoryInjectionPointResolver} over the default
 	 * {@link ContextAnnotationAutowireCandidateResolver} to make injection points of lazy repositories lazy, too. Will
 	 * augment the {@link LazyRepositoryInjectionPointResolver}'s configuration if there already is one configured.
-	 * 
+	 *
 	 * @param configurations must not be {@literal null}.
 	 * @param registry must not be {@literal null}.
 	 */
@@ -265,7 +265,7 @@ public class RepositoryConfigurationDelegate {
 		/**
 		 * Returns a new {@link LazyRepositoryInjectionPointResolver} that will have its configurations augmented with the
 		 * given ones.
-		 * 
+		 *
 		 * @param configurations must not be {@literal null}.
 		 * @return
 		 */
@@ -278,7 +278,7 @@ public class RepositoryConfigurationDelegate {
 			return new LazyRepositoryInjectionPointResolver(map);
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.context.annotation.ContextAnnotationAutowireCandidateResolver#isLazy(org.springframework.beans.factory.config.DependencyDescriptor)
 		 */

--- a/src/test/java/org/springframework/data/repository/config/PrimaryRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/config/PrimaryRepositoryIntegrationTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Integration tests for DATACMNS-1591.
+ *
+ * @author Oliver Drotbohm
+ */
+public class PrimaryRepositoryIntegrationTests {
+
+	@Test // DATACMNS-1591
+	public void returnsPrimaryInstance() {
+
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
+
+		// Two beans available but FirstRepository is the primary one
+		assertThatCode(() -> context.getBean(FirstRepository.class)).doesNotThrowAnyException();
+	}
+
+	@Configuration
+	@EnableRepositories(considerNestedRepositories = true, //
+			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = Marker.class))
+	static class Config {}
+
+	interface Marker {}
+
+	@Primary
+	interface FirstRepository<T> extends CrudRepository<T, Long>, Marker {}
+
+	interface SecondRepository extends FirstRepository<Object>, Marker {}
+}


### PR DESCRIPTION
We now elevate the primary annotation from the scanned repository bean definition to the one created for the repository factory. This previously got lost as the former is hidden behind the RepositoryConfiguration interface that previously didn't expose the primary nature of the underlying bean definition.