### PR TITLE
DATACMNS-1596 - Modules not exposing identifying annotations do not claim repository interfaces anymore.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1596-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationExtensionSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationExtensionSupportUnitTests.java
@@ -34,9 +34,11 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
@@ -86,6 +88,15 @@ public class RepositoryConfigurationExtensionSupportUnitTests {
 				.hasMessageContaining("Reactive Repositories are not supported");
 	}
 
+	@Test // DATACMNS-1596
+	public void doesNotClaimEntityIfNoIdentifyingAnnotationsAreExposed() {
+
+		NonIdentifyingConfigurationExtension extension = new NonIdentifyingConfigurationExtension();
+		RepositoryMetadata metadata = AbstractRepositoryMetadata.getMetadata(AnnotatedTypeRepository.class);
+
+		assertThat(extension.isStrictRepositoryCandidate(metadata)).isFalse();
+	}
+
 	static class SampleRepositoryConfigurationExtension extends RepositoryConfigurationExtensionSupport {
 
 		@Override
@@ -106,6 +117,24 @@ public class RepositoryConfigurationExtensionSupportUnitTests {
 		@Override
 		protected Collection<Class<?>> getIdentifyingTypes() {
 			return Collections.singleton(StoreInterface.class);
+		}
+	}
+
+	static class NonIdentifyingConfigurationExtension extends RepositoryConfigurationExtensionSupport {
+
+		@Override
+		protected String getModulePrefix() {
+			return "non-identifying";
+		}
+
+		@Override
+		public String getRepositoryFactoryBeanClassName() {
+			return RepositoryFactoryBeanSupport.class.getName();
+		}
+
+		@Override
+		protected Collection<Class<?>> getIdentifyingTypes() {
+			return Collections.singleton(CrudRepository.class);
 		}
 	}
 


### PR DESCRIPTION
Previously, a module not exposing any entity identifying annotations would have claimed a repository definition and potentially overrode the bean definition of another store that was the proper claim in the first place. We have now changed this to abstain from a claim of the interface.

We' also tweaked the log output in the following cases:

1. If the module neither returns an identifying type nor entity identifying annotations, we now log a warning that a module does not support a multi-module setup and answer all assignment requests with false.

2. The info level warning indicating an interface has been dropped now reports which annotations or interface base types to use.

Related tickets: spring-projects/spring-boot#18721