### PR TITLE
DATACMNS-1609 - Auditing metadata should skip paths containing map or collection like segments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1609-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -113,7 +113,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		 * @param context must not be {@literal null}.
 		 * @param type the domain type.
 		 */
-		public <P> MappingAuditingMetadata(MappingContext<?, ? extends PersistentProperty<?>> context, Class<?> type) {
+		<P> MappingAuditingMetadata(MappingContext<?, ? extends PersistentProperty<?>> context, Class<?> type) {
 
 			Assert.notNull(type, "Type must not be null!");
 
@@ -142,7 +142,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		 *
 		 * @return
 		 */
-		public boolean isAuditable() {
+		boolean isAuditable() {
 			return isAuditable.get();
 		}
 	}
@@ -166,8 +166,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		 * @param accessor must not be {@literal null}.
 		 * @param metadata must not be {@literal null}.
 		 */
-		public MappingMetadataAuditableBeanWrapper(PersistentPropertyAccessor<T> accessor,
-				MappingAuditingMetadata metadata) {
+		MappingMetadataAuditableBeanWrapper(PersistentPropertyAccessor<T> accessor, MappingAuditingMetadata metadata) {
 
 			Assert.notNull(accessor, "PersistentPropertyAccessor must not be null!");
 			Assert.notNull(metadata, "Auditing metadata must not be null!");

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -98,24 +98,32 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 	 */
 	static class MappingAuditingMetadata {
 
+		private static final Predicate<PersistentProperty<?>> TRAVERSAL_GURAD = PersistentPropertyPaths.SKIP_ASSOICATIONS
+				.and(it -> !it.isCollectionLike() && !it.isMap());
+
 		private final PersistentPropertyPaths<?, ? extends PersistentProperty<?>> createdByPaths, createdDatePaths,
 				lastModifiedByPaths, lastModifiedDatePaths;
 
 		private final Lazy<Boolean> isAuditable;
 
 		/**
-		 * Creates a new {@link MappingAuditingMetadata} instance from the given {@link PersistentEntity}.
+		 * Creates a new {@link MappingAuditingMetadata} instance from the given {@link PersistentEntity} identified by the
+		 * {@link MappingContext} via its {@literal type}.
 		 *
-		 * @param entity must not be {@literal null}.
+		 * @param context must not be {@literal null}.
+		 * @param type the domain type.
 		 */
 		public <P> MappingAuditingMetadata(MappingContext<?, ? extends PersistentProperty<?>> context, Class<?> type) {
 
 			Assert.notNull(type, "Type must not be null!");
 
-			this.createdByPaths = context.findPersistentPropertyPaths(type, withAnnotation(CreatedBy.class));
-			this.createdDatePaths = context.findPersistentPropertyPaths(type, withAnnotation(CreatedDate.class));
-			this.lastModifiedByPaths = context.findPersistentPropertyPaths(type, withAnnotation(LastModifiedBy.class));
-			this.lastModifiedDatePaths = context.findPersistentPropertyPaths(type, withAnnotation(LastModifiedDate.class));
+			this.createdByPaths = context.findPersistentPropertyPaths(type, withAnnotation(CreatedBy.class), TRAVERSAL_GURAD);
+			this.createdDatePaths = context.findPersistentPropertyPaths(type, withAnnotation(CreatedDate.class),
+					TRAVERSAL_GURAD);
+			this.lastModifiedByPaths = context.findPersistentPropertyPaths(type, withAnnotation(LastModifiedBy.class),
+					TRAVERSAL_GURAD);
+			this.lastModifiedDatePaths = context.findPersistentPropertyPaths(type, withAnnotation(LastModifiedDate.class),
+					TRAVERSAL_GURAD);
 
 			this.isAuditable = Lazy.of( //
 					() -> Arrays.asList(createdByPaths, createdDatePaths, lastModifiedByPaths, lastModifiedDatePaths) //

--- a/src/main/java/org/springframework/data/mapping/PersistentPropertyPaths.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentPropertyPaths.java
@@ -16,6 +16,7 @@
 package org.springframework.data.mapping;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.springframework.data.util.Streamable;
 
@@ -23,11 +24,17 @@ import org.springframework.data.util.Streamable;
  * A wrapper for a collection of {@link PersistentPropertyPath}s.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 2.1
  * @soundtrack Stuart McCallum - North Star (City)
  */
 public interface PersistentPropertyPaths<T, P extends PersistentProperty<P>>
 		extends Streamable<PersistentPropertyPath<P>> {
+
+	/**
+	 * @since 2.2.2
+	 */
+	Predicate<PersistentProperty<?>> SKIP_ASSOICATIONS = it -> !it.isAssociation();
 
 	/**
 	 * Returns the first {@link PersistentPropertyPath}.

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -286,15 +286,16 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.mapping.context.MappingContext#findPersistentPropertyPath(java.lang.Class, java.util.function.Predicate)
+	 * @see org.springframework.data.mapping.context.MappingContext#findPersistentPropertyPath(java.lang.Class, java.util.function.Predicate, java.util.function.Predicate)
 	 */
-	@Override
-	public <T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate) {
+	public <T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate,
+			Predicate<? super P> traversalGuard) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(predicate, "Selection predicate must not be null!");
+		Assert.notNull(traversalGuard, "TraversalGuard must not be null!");
 
-		return doFindPersistentPropertyPaths(type, predicate, it -> !it.isAssociation());
+		return doFindPersistentPropertyPaths(type, predicate, traversalGuard);
 	}
 
 	/**
@@ -309,7 +310,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 	 * @see #findPersistentPropertyPaths(Class, Predicate)
 	 */
 	protected final <T> PersistentPropertyPaths<T, P> doFindPersistentPropertyPaths(Class<T> type,
-			Predicate<? super P> predicate, Predicate<P> traversalGuard) {
+			Predicate<? super P> predicate, Predicate<? super P> traversalGuard) {
 		return persistentPropertyPathFactory.from(ClassTypeInformation.from(type), predicate, traversalGuard);
 	}
 

--- a/src/main/java/org/springframework/data/mapping/context/MappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/MappingContext.java
@@ -176,15 +176,34 @@ public interface MappingContext<E extends PersistentEntity<?, P>, P extends Pers
 	/**
 	 * Returns all {@link PersistentPropertyPath}s pointing to properties on the given type that match the given
 	 * {@link Predicate}. In case of circular references the detection will stop at the property that references a type
-	 * that's already included in the path. Note, that is is a potentially expensive operation as results cannot be
-	 * cached.
+	 * that's already included in the path. <br />
+	 * Skips {@link PersistentProperty#isAssociation() associations} by default. <br />
+	 * <strong>Note</strong>, that is a potentially expensive operation as results cannot be cached.
 	 *
 	 * @param type must not be {@literal null}.
 	 * @param predicate must not be {@literal null}.
 	 * @return
 	 * @since 2.1
 	 */
-	<T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate);
+	default <T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate) {
+		return findPersistentPropertyPaths(type, predicate, PersistentPropertyPaths.SKIP_ASSOICATIONS);
+	}
+
+	/**
+	 * Returns all {@link PersistentPropertyPath}s pointing to properties on the given type that match the given
+	 * {@link Predicate}. In case of circular references the detection will stop at the property that references a type
+	 * that's already included in the path. The traversal guard allows to additionally limit the path traversal to eg.
+	 * exclude associations. <br />
+	 * <strong>Note</strong>, that is a potentially expensive operation as results cannot be cached.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param predicate must not be {@literal null}.
+	 * @parm traversalGuard must not be {@literal null}.
+	 * @return
+	 * @since 2.2.2
+	 */
+	<T> PersistentPropertyPaths<T, P> findPersistentPropertyPaths(Class<T> type, Predicate<? super P> predicate,
+			Predicate<? super P> traversalGuard);
 
 	/**
 	 * Returns the {@link TypeInformation}s for all {@link PersistentEntity}s in the {@link MappingContext}.

--- a/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
@@ -64,7 +64,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param propertyPath must not be {@literal null}.
 	 * @return
 	 */
-	public PersistentPropertyPath<P> from(Class<?> type, String propertyPath) {
+	PersistentPropertyPath<P> from(Class<?> type, String propertyPath) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(propertyPath, "Property path must not be null!");
@@ -79,7 +79,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param propertyPath must not be {@literal null}.
 	 * @return
 	 */
-	public PersistentPropertyPath<P> from(TypeInformation<?> type, String propertyPath) {
+	PersistentPropertyPath<P> from(TypeInformation<?> type, String propertyPath) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(propertyPath, "Property path must not be null!");
@@ -93,7 +93,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param path must not be {@literal null}.
 	 * @return
 	 */
-	public PersistentPropertyPath<P> from(PropertyPath path) {
+	PersistentPropertyPath<P> from(PropertyPath path) {
 
 		Assert.notNull(path, "Property path must not be null!");
 
@@ -108,7 +108,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param propertyFilter must not be {@literal null}.
 	 * @return
 	 */
-	public <T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter) {
+	<T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(propertyFilter, "Property filter must not be null!");
@@ -125,7 +125,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param traversalGuard must not be {@literal null}.
 	 * @return
 	 */
-	public <T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter,
+	<T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter,
 			Predicate<? super P> traversalGuard) {
 
 		Assert.notNull(type, "Type must not be null!");
@@ -143,7 +143,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param propertyFilter must not be {@literal null}.
 	 * @return
 	 */
-	public <T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter) {
+	<T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter) {
 		return from(type, propertyFilter, it -> !it.isAssociation());
 	}
 
@@ -156,7 +156,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @param traversalGuard must not be {@literal null}.
 	 * @return
 	 */
-	public <T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter,
+	<T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter,
 			Predicate<? super P> traversalGuard) {
 
 		Assert.notNull(type, "Type must not be null!");
@@ -354,8 +354,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 		 * @author Oliver Gierke
 		 * @since 2.1
 		 */
-		private static enum ShortestSegmentFirst
-				implements Comparator<PersistentPropertyPath<? extends PersistentProperty<?>>> {
+		private enum ShortestSegmentFirst implements Comparator<PersistentPropertyPath<? extends PersistentProperty<?>>> {
 
 			INSTANCE;
 

--- a/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
@@ -20,17 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.Value;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -55,6 +45,7 @@ import org.springframework.util.StringUtils;
  * A factory implementation to create {@link PersistentPropertyPath} instances in various ways.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  * @since 2.1
  * @soundtrack Cypress Hill - Boom Biddy Bye Bye (Fugees Remix, Unreleased & Revamped)
  */
@@ -135,7 +126,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @return
 	 */
 	public <T> PersistentPropertyPaths<T, P> from(Class<T> type, Predicate<? super P> propertyFilter,
-			Predicate<P> traversalGuard) {
+			Predicate<? super P> traversalGuard) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(propertyFilter, "Property filter must not be null!");
@@ -166,7 +157,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	 * @return
 	 */
 	public <T> PersistentPropertyPaths<T, P> from(TypeInformation<T> type, Predicate<? super P> propertyFilter,
-			Predicate<P> traversalGuard) {
+			Predicate<? super P> traversalGuard) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(propertyFilter, "Property filter must not be null!");
@@ -237,7 +228,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 	}
 
 	private <T> Collection<PersistentPropertyPath<P>> from(TypeInformation<T> type, Predicate<? super P> filter,
-			Predicate<P> traversalGuard, DefaultPersistentPropertyPath<P> basePath) {
+			Predicate<? super P> traversalGuard, DefaultPersistentPropertyPath<P> basePath) {
 
 		TypeInformation<?> actualType = type.getActualType();
 
@@ -263,7 +254,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 				properties.add(currentPath);
 			}
 
-			if (traversalGuard.and(IS_ENTITY).test(persistentProperty)) {
+			if (traversalGuard.and((Predicate) IS_ENTITY).test(persistentProperty)) {
 				properties.addAll(from(typeInformation, filter, traversalGuard, currentPath));
 			}
 		};

--- a/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
@@ -32,8 +32,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.AbstractLongAssert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -58,8 +58,8 @@ public class MappingAuditableBeanWrapperFactoryUnitTests {
 
 	DefaultAuditableBeanWrapperFactory factory;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	public void beforeEach() {
 
 		SampleMappingContext context = new SampleMappingContext();
 		context.getPersistentEntity(Sample.class);


### PR DESCRIPTION
Should be back ported to _2.2.x_.