### PR TITLE
DATACMNS-1618 - Set log level for potentially unsupported custom conversion java.time target type to debug.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.2.2.BUILD-SNAPSHOT</version>
+	<version>2.2.2.DATACMNS-1618-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -214,9 +214,21 @@ public class CustomConversions {
 			customSimpleTypes.add(pair.getSourceType());
 
 			if (LOG.isWarnEnabled() && !converterRegistration.isSimpleTargetType()) {
-				LOG.warn(String.format(WRITE_CONVERTER_NOT_SIMPLE, pair.getSourceType(), pair.getTargetType()));
+
+				String msg = String.format(WRITE_CONVERTER_NOT_SIMPLE, pair.getSourceType(), pair.getTargetType());
+				if (isJavaTimeType(pair.getTargetType())) {
+
+					// TODO: this is a temporary fix seeking a better solution for 2.3
+					LOG.debug(msg);
+				} else {
+					LOG.warn(msg);
+				}
 			}
 		}
+	}
+
+	private boolean isJavaTimeType(Class<?> type) {
+		return type.getName().startsWith("java.time");
 	}
 
 	/**


### PR DESCRIPTION
This is a temporary solution that seeks a better one in 2.3 and therefore should not be forward ported!