### PR TITLE
Override modify the supportsParameter conditional judgment to support custom annotations to bind Predicate parameter parsing

### DIFF
--- a/src/main/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolver.java
@@ -44,6 +44,7 @@ import com.querydsl.core.types.Predicate;
  * {@link HandlerMethodArgumentResolver} to allow injection of {@link com.querydsl.core.types.Predicate} into Spring MVC
  * controller methods.
  *
+ * @author Fan Yang
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @since 1.11

--- a/src/main/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolver.java
@@ -74,16 +74,12 @@ public class QuerydslPredicateArgumentResolver implements HandlerMethodArgumentR
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
 
-		if (Predicate.class.equals(parameter.getParameterType())) {
-			return true;
-		}
-
-		if (parameter.hasParameterAnnotation(QuerydslPredicate.class)) {
+		if (parameter.hasParameterAnnotation(QuerydslPredicate.class) && !Predicate.class.equals(parameter.getParameterType())) {
 			throw new IllegalArgumentException(String.format("Parameter at position %s must be of type Predicate but was %s.",
 					parameter.getParameterIndex(), parameter.getParameterType()));
 		}
 
-		return false;
+		return parameter.hasParameterAnnotation(QuerydslPredicate.class);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/querydsl/QuerydslPredicateArgumentResolverUnitTests.java
@@ -74,7 +74,7 @@ public class QuerydslPredicateArgumentResolverUnitTests {
 	@Test // DATACMNS-669
 	public void supportsParameterReturnsTrueWhenMethodParameterIsPredicateButNotAnnotatedAsSuch() {
 		assertThat(resolver.supportsParameter(getMethodParameterFor("predicateWithoutAnnotation", Predicate.class)))
-				.isTrue();
+				.isFalse();
 	}
 
 	@Test // DATACMNS-669


### PR DESCRIPTION
The existing conditional judgment makes all the newly added Predicate custom Argument Resolver invalid, so I modified this conditional judgment to better support the support of Predicate parameter custom Argument Resolver.
As long as the reference type is Predicate, it will directly enter the QuerydslPredicateArgumentResolver, which greatly reduces the ability of the Predicate type to customize the ArgumentResolver.