### PR TITLE
DATACMNS-1625 - Lazily initialize EvaluationContextExtension functions and properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.1.16.BUILD-SNAPSHOT</version>
+	<version>2.1.16.DATACMNS-1625-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
We now make sure to lazily evaluate `Functions` and properties of a given `EvaluationContextExtension` based on the `rootObject` that might not be present when creating the context in first place, but delay the resolution to a time that actually may call the desired function.

----

Should be forward ported to 2.2.x and 2.3