### PR TITLE
DATACMNS-1615 - Allow fine grained store specific converter registration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1615-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.convert.converter.Converter;
@@ -57,6 +58,10 @@ public class CustomConversions {
 	private static final String READ_CONVERTER_NOT_SIMPLE = "Registering converter from %s to %s as reading converter although it doesn't convert from a store-supported type! You might wanna check you annotation setup at the converter implementation.";
 	private static final String WRITE_CONVERTER_NOT_SIMPLE = "Registering converter from %s to %s as writing converter although it doesn't convert to a store-supported type! You might wanna check you annotation setup at the converter implementation.";
 	private static final String NOT_A_CONVERTER = "Converter %s is neither a Spring Converter, GenericConverter or ConverterFactory!";
+	private static final String CONVERTER_FILTER = "converter from %s to %s as %s converter.";
+	private static final String ADD_CONVERTER = "Adding %s" + CONVERTER_FILTER;
+	private static final String SKIP_CONVERTER = "Skipping " + CONVERTER_FILTER
+			+ "%s is not a store supported simple type!";
 	private static final List<Object> DEFAULT_CONVERTERS;
 
 	static {
@@ -89,7 +94,10 @@ public class CustomConversions {
 			convertiblePair.getSourceType(), null, writingPairs);
 
 	/**
-	 * Creates a new {@link CustomConversions} instance registering the given converters.
+	 * Creates a new {@link CustomConversions} instance registering all given user defined converters and selecting
+	 * {@link Converter converters} from {@link StoreConversions} depending on
+	 * {@link StoreConversions#getSimpleTypeHolder() store simple types} only considering those that either convert
+	 * to/from a store supported type.
 	 *
 	 * @param storeConversions must not be {@literal null}.
 	 * @param converters must not be {@literal null}.
@@ -99,21 +107,47 @@ public class CustomConversions {
 		Assert.notNull(storeConversions, "StoreConversions must not be null!");
 		Assert.notNull(converters, "List of converters must not be null!");
 
-		List<Object> toRegister = new ArrayList<>();
+		List<Object> registeredConverters = collectPotentialConverterRegistrations(storeConversions, converters).stream() //
+				.filter(this::isSupportedConverter) //
+				.map(ConverterRegistrationIntent::getConverterRegistration) //
+				.map(this::register) //
+				.distinct() //
+				.collect(Collectors.toList());
 
-		// Add user provided converters to make sure they can override the defaults
-		toRegister.addAll(converters);
-		toRegister.addAll(storeConversions.getStoreConverters());
-		toRegister.addAll(DEFAULT_CONVERTERS);
+		Collections.reverse(registeredConverters);
 
-		toRegister.stream()//
-				.flatMap(it -> storeConversions.getRegistrationsFor(it).stream())//
-				.forEach(this::register);
-
-		Collections.reverse(toRegister);
-
-		this.converters = Collections.unmodifiableList(toRegister);
+		this.converters = Collections.unmodifiableList(registeredConverters);
 		this.simpleTypeHolder = new SimpleTypeHolder(customSimpleTypes, storeConversions.getStoreTypeHolder());
+	}
+
+	/**
+	 * Validate a given {@link ConverterRegistration} in a specific setup. <br />
+	 * Non {@link ReadingConverter reading} and user defined {@link Converter converters} are only considered supported if
+	 * the {@link ConverterRegistrationIntent#isSimpleTargetType() target type} is considered to be a store simple type.
+	 * 
+	 * @param registration
+	 * @return
+	 * @since 2.3
+	 */
+	protected boolean isSupportedConverter(ConverterRegistrationIntent registration) {
+
+		boolean register = registration.isUserConverter() || (registration.isReading() && registration.isSimpleSourceType())
+				|| (registration.isWriting() && registration.isSimpleTargetType());
+
+		if (LOG.isDebugEnabled()) {
+
+			if (register) {
+				LOG.debug(String.format(ADD_CONVERTER, registration.isUserConverter() ? "user defined " : "",
+						registration.getSourceType(), registration.getTargetType(),
+						registration.isReading() ? "reading" : "writing"));
+			} else {
+				LOG.debug(String.format(SKIP_CONVERTER, registration.getSourceType(), registration.getTargetType(),
+						registration.isReading() ? "reading" : "writing",
+						registration.isReading() ? registration.getSourceType() : registration.getTargetType()));
+			}
+		}
+
+		return register;
 	}
 
 	/**
@@ -150,6 +184,36 @@ public class CustomConversions {
 		Assert.notNull(conversionService, "ConversionService must not be null!");
 
 		converters.forEach(it -> registerConverterIn(it, conversionService));
+	}
+
+	/**
+	 * Get all converters and add some origin information
+	 * 
+	 * @param storeConversions
+	 * @param converters
+	 * @return
+	 */
+	private List<ConverterRegistrationIntent> collectPotentialConverterRegistrations(StoreConversions storeConversions,
+			Collection<?> converters) {
+
+		List<ConverterRegistrationIntent> converterRegistrations = new ArrayList<>();
+
+		converterRegistrations.addAll(converters.stream() //
+				.flatMap(it -> storeConversions.getRegistrationsFor(it).stream()) //
+				.map(ConverterRegistrationIntent::userConverters) //
+				.collect(Collectors.toList()));
+
+		converterRegistrations.addAll(storeConversions.getStoreConverters().stream() //
+				.flatMap(it -> storeConversions.getRegistrationsFor(it).stream()) //
+				.map(ConverterRegistrationIntent::storeConverters) //
+				.collect(Collectors.toList()));
+
+		converterRegistrations.addAll(DEFAULT_CONVERTERS.stream() //
+				.flatMap(it -> storeConversions.getRegistrationsFor(it).stream()) //
+				.map(ConverterRegistrationIntent::defaultConverters) //
+				.collect(Collectors.toList()));
+
+		return converterRegistrations;
 	}
 
 	/**
@@ -193,7 +257,7 @@ public class CustomConversions {
 	 *
 	 * @param converterRegistration
 	 */
-	private void register(ConverterRegistration converterRegistration) {
+	private Object register(ConverterRegistration converterRegistration) {
 
 		Assert.notNull(converterRegistration, "Converter registration must not be null!");
 
@@ -217,6 +281,8 @@ public class CustomConversions {
 				LOG.warn(String.format(WRITE_CONVERTER_NOT_SIMPLE, pair.getSourceType(), pair.getTargetType()));
 			}
 		}
+
+		return converterRegistration.getConverter();
 	}
 
 	/**
@@ -443,14 +509,89 @@ public class CustomConversions {
 	}
 
 	/**
+	 * Value class tying together a {@link ConverterRegistration} and its {@link ConverterOrigin origin} to allow fine
+	 * grained registration based on store supported types.
+	 *
+	 * @since 2.3
+	 * @author Christoph Strobl
+	 */
+	protected static class ConverterRegistrationIntent {
+
+		private final ConverterRegistration delegate;
+		private final ConverterOrigin origin;
+
+		ConverterRegistrationIntent(ConverterRegistration delegate, ConverterOrigin origin) {
+			this.delegate = delegate;
+			this.origin = origin;
+		}
+
+		static ConverterRegistrationIntent userConverters(ConverterRegistration delegate) {
+			return new ConverterRegistrationIntent(delegate, ConverterOrigin.USER_DEFINED);
+		}
+
+		static ConverterRegistrationIntent storeConverters(ConverterRegistration delegate) {
+			return new ConverterRegistrationIntent(delegate, ConverterOrigin.STORE);
+		}
+
+		static ConverterRegistrationIntent defaultConverters(ConverterRegistration delegate) {
+			return new ConverterRegistrationIntent(delegate, ConverterOrigin.DEFAULT);
+		}
+
+		Class<?> getSourceType() {
+			return delegate.getConvertiblePair().getSourceType();
+		}
+
+		Class<?> getTargetType() {
+			return delegate.getConvertiblePair().getTargetType();
+		}
+
+		public boolean isWriting() {
+			return delegate.isWriting();
+		}
+
+		public boolean isReading() {
+			return delegate.isReading();
+		}
+
+		public boolean isSimpleSourceType() {
+			return delegate.isSimpleSourceType();
+		}
+
+		public boolean isSimpleTargetType() {
+			return delegate.isSimpleTargetType();
+		}
+
+		public boolean isUserConverter() {
+			return isConverterOfSource(ConverterOrigin.USER_DEFINED);
+		}
+
+		public boolean isDefaultConveter() {
+			return isConverterOfSource(ConverterOrigin.DEFAULT);
+		}
+
+		public ConverterRegistration getConverterRegistration() {
+			return delegate;
+		}
+
+		private boolean isConverterOfSource(ConverterOrigin source) {
+			return origin.equals(source);
+		}
+
+		protected enum ConverterOrigin {
+			DEFAULT, USER_DEFINED, STORE
+		}
+	}
+
+	/**
 	 * Conversion registration information.
 	 *
 	 * @author Oliver Gierke
 	 * @author Mark Paluch
 	 */
 	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-	static class ConverterRegistration {
+	private static class ConverterRegistration {
 
+		private final Object converter;
 		private final @NonNull ConvertiblePair convertiblePair;
 		private final @NonNull StoreConversions storeConversions;
 		private final boolean reading;
@@ -499,6 +640,13 @@ public class CustomConversions {
 		 */
 		public boolean isSimpleTargetType() {
 			return storeConversions.isStoreSimpleType(convertiblePair.getTargetType());
+		}
+
+		/**
+		 * @return
+		 */
+		Object getConverter() {
+			return converter;
 		}
 	}
 
@@ -575,7 +723,7 @@ public class CustomConversions {
 
 				return convertibleTypes == null //
 						? Streamable.empty() //
-						: Streamable.of(convertibleTypes).map(it -> register(it, isReading, isWriting));
+						: Streamable.of(convertibleTypes).map(it -> register(converter, it, isReading, isWriting));
 
 			} else if (converter instanceof ConverterFactory) {
 
@@ -600,15 +748,17 @@ public class CustomConversions {
 				throw new IllegalStateException(String.format("Couldn't resolve type arguments for %s!", converterType));
 			}
 
-			return Streamable.of(register(arguments[0], arguments[1], isReading, isWriting));
+			return Streamable.of(register(converter, arguments[0], arguments[1], isReading, isWriting));
 		}
 
-		private ConverterRegistration register(Class<?> source, Class<?> target, boolean isReading, boolean isWriting) {
-			return register(new ConvertiblePair(source, target), isReading, isWriting);
+		private ConverterRegistration register(Object converter, Class<?> source, Class<?> target, boolean isReading,
+				boolean isWriting) {
+			return register(converter, new ConvertiblePair(source, target), isReading, isWriting);
 		}
 
-		private ConverterRegistration register(ConvertiblePair pair, boolean isReading, boolean isWriting) {
-			return new ConverterRegistration(pair, this, isReading, isWriting);
+		private ConverterRegistration register(Object converter, ConvertiblePair pair, boolean isReading,
+				boolean isWriting) {
+			return new ConverterRegistration(converter, pair, this, isReading, isWriting);
 		}
 
 		private boolean isStoreSimpleType(Class<?> type) {

--- a/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
@@ -27,16 +27,19 @@ import java.util.Date;
 import java.util.Locale;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterFactory;
 import org.springframework.core.convert.converter.ConverterRegistry;
+import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.convert.ConverterBuilder.ConverterAware;
+import org.springframework.data.convert.CustomConversions.ConverterConfiguration;
 import org.springframework.data.convert.CustomConversions.StoreConversions;
+import org.springframework.data.convert.Jsr310Converters.LocalDateTimeToDateConverter;
 import org.springframework.data.convert.ThreeTenBackPortConverters.LocalDateTimeToJavaTimeInstantConverter;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.threeten.bp.LocalDateTime;
@@ -50,6 +53,15 @@ import org.threeten.bp.LocalDateTime;
  * @since 2.0
  */
 public class CustomConversionsUnitTests {
+
+	static final SimpleTypeHolder DATE_EXCLUDING_SIMPLE_TYPE_HOLDER = new SimpleTypeHolder(
+			Collections.singleton(Date.class), true) {
+
+		@Override
+		public boolean isSimpleType(Class<?> type) {
+			return type.getName().startsWith("java.time") ? false : super.isSimpleType(type);
+		}
+	};
 
 	@Test // DATACMNS-1035
 	public void findsBasicReadAndWriteConversions() {
@@ -199,23 +211,47 @@ public class CustomConversionsUnitTests {
 	public void skipsUnsupportedDefaultWritingConverter() {
 
 		ConverterRegistry registry = mock(ConverterRegistry.class);
-		StoreConversions storeConversions = StoreConversions
-				.of(new SimpleTypeHolder(Collections.singleton(Date.class), true) {
 
-					@Override
-					public boolean isSimpleType(Class<?> type) {
-
-						if (type.getName().startsWith("java.time")) {
-							return false;
-						}
-
-						return super.isSimpleType(type);
-					}
-				});
-
-		new CustomConversions(storeConversions, Collections.emptyList()).registerConvertersIn(registry);
+		new CustomConversions(StoreConversions.of(DATE_EXCLUDING_SIMPLE_TYPE_HOLDER), Collections.emptyList())
+				.registerConvertersIn(registry);
 
 		verify(registry, never()).addConverter(any(LocalDateTimeToJavaTimeInstantConverter.class));
+	}
+
+	@Test // DATACMNS-1615
+	public void doesNotSkipUnsupportedUserConverter() {
+
+		ConverterRegistry registry = mock(ConverterRegistry.class);
+
+		new CustomConversions(StoreConversions.of(DATE_EXCLUDING_SIMPLE_TYPE_HOLDER),
+				Collections.singletonList(LocalDateTimeToJavaTimeInstantConverter.INSTANCE)).registerConvertersIn(registry);
+
+		verify(registry).addConverter(any(LocalDateTimeToJavaTimeInstantConverter.class));
+	}
+
+	@Test // DATACMNS-1615
+	public void skipsConverterBasedOnConfiguration() {
+
+		ConverterRegistry registry = mock(ConverterRegistry.class);
+
+		ConverterConfiguration config = new ConverterConfiguration(StoreConversions.NONE, Collections.emptyList(),
+				Collections.singleton(new ConvertiblePair(java.time.LocalDateTime.class, Date.class)));
+		new CustomConversions(config).registerConvertersIn(registry);
+
+		verify(registry, never()).addConverter(any(LocalDateTimeToDateConverter.class));
+	}
+
+	@Test // DATACMNS-1615
+	public void doesNotSkipUserConverterConverterEvenWhenConfigurationWouldNotAllowIt() {
+
+		ConverterRegistry registry = mock(ConverterRegistry.class);
+
+		ConverterConfiguration config = new ConverterConfiguration(StoreConversions.NONE,
+				Collections.singletonList(LocalDateTimeToDateConverter.INSTANCE),
+				Collections.singleton(new ConvertiblePair(java.time.LocalDateTime.class, Date.class)));
+		new CustomConversions(config).registerConvertersIn(registry);
+
+		verify(registry).addConverter(any(LocalDateTimeToDateConverter.class));
 	}
 
 	private static Class<?> createProxyTypeFor(Class<?> type) {


### PR DESCRIPTION
`CustomConversions` now registers all given user defined converters and selects only those converters from the `StoreConversions` (potentially containing superfluous default converters from  spring-data-commons) that convert to or from a store supported simple type.
By doing so we make sure to only register supported converters which removes warning messages from the log and reduces the number of converters within the `ConversionService`.