### PR TITLE
DATACMNS-1641 - Allow auditing annotations to configure overwrite behavior

### DIFF
--- a/src/main/java/org/springframework/data/annotation/CreatedBy.java
+++ b/src/main/java/org/springframework/data/annotation/CreatedBy.java
@@ -21,14 +21,23 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.data.auditing.OverwriteBehavior;
+
 /**
  * Declares a field as the one representing the principal that created the entity containing the field.
  *
  * @author Ranie Jade Ramiso
  * @author Oliver Gierke
+ * @author Daniel Shuy
  * @since 1.5
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = { FIELD, METHOD, ANNOTATION_TYPE })
 public @interface CreatedBy {
+
+	/**
+	 * The behavior if existing field value is not {@code null}. Defaults to {@link OverwriteBehavior#OVERWRITE}.
+	 */
+	OverwriteBehavior overwriteBehavior() default OverwriteBehavior.OVERWRITE;
+
 }

--- a/src/main/java/org/springframework/data/annotation/CreatedDate.java
+++ b/src/main/java/org/springframework/data/annotation/CreatedDate.java
@@ -21,14 +21,23 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.data.auditing.OverwriteBehavior;
+
 /**
  * Declares a field as the one representing the date the entity containing the field was created.
  *
  * @author Ranie Jade Ramiso
  * @author Oliver Gierke
+ * @author Daniel Shuy
  * @since 1.5
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = { FIELD, METHOD, ANNOTATION_TYPE })
 public @interface CreatedDate {
+
+	/**
+	 * The behavior if existing field value is not {@code null}. Defaults to {@link OverwriteBehavior#OVERWRITE}.
+	 */
+	OverwriteBehavior overwriteBehavior() default OverwriteBehavior.OVERWRITE;
+
 }

--- a/src/main/java/org/springframework/data/auditing/AnnotationAuditingMetadata.java
+++ b/src/main/java/org/springframework/data/auditing/AnnotationAuditingMetadata.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.auditing;
 
+import lombok.Getter;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -33,6 +36,7 @@ import org.springframework.data.convert.ThreeTenBackPortConverters;
 import org.springframework.data.util.Optionals;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.data.util.ReflectionUtils.AnnotationFieldFilter;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -42,6 +46,7 @@ import org.springframework.util.Assert;
  * @author Ranie Jade Ramiso
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Daniel Shuy
  * @since 1.5
  */
 final class AnnotationAuditingMetadata {
@@ -76,6 +81,9 @@ final class AnnotationAuditingMetadata {
 	private final Optional<Field> lastModifiedByField;
 	private final Optional<Field> lastModifiedDateField;
 
+	private final @Nullable @Getter OverwriteBehavior createdByOverwriteBehavior;
+	private final @Nullable @Getter OverwriteBehavior createdDateOverwriteBehavior;
+
 	/**
 	 * Creates a new {@link AnnotationAuditingMetadata} instance for the given type.
 	 *
@@ -92,6 +100,14 @@ final class AnnotationAuditingMetadata {
 
 		assertValidDateFieldType(createdDateField);
 		assertValidDateFieldType(lastModifiedDateField);
+
+		Optional<CreatedBy> createdByAnnotation = createdByField
+				.map(field -> AnnotationUtils.getAnnotation(field, CreatedBy.class));
+		Optional<CreatedDate> createdDateAnnotation = createdDateField
+				.map(field -> AnnotationUtils.getAnnotation(field, CreatedDate.class));
+
+		createdByOverwriteBehavior = createdByAnnotation.map(CreatedBy::overwriteBehavior).orElse(null);
+		createdDateOverwriteBehavior = createdDateAnnotation.map(CreatedDate::overwriteBehavior).orElse(null);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/auditing/OverwriteBehavior.java
+++ b/src/main/java/org/springframework/data/auditing/OverwriteBehavior.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.auditing;
+
+/**
+ * Audit behavior when existing value is not {@code null}.
+ *
+ * @author Daniel Shuy
+ */
+public enum OverwriteBehavior {
+	/**
+	 * Replace existing value with new audit value.
+	 */
+	OVERWRITE,
+	/**
+	 * Skip generating new audit value if existing value is not {@code null}.
+	 */
+	SKIP,;
+}

--- a/src/test/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactoryUnitTests.java
@@ -17,6 +17,8 @@ package org.springframework.data.auditing;
 
 import static org.assertj.core.api.Assertions.*;
 
+import lombok.Setter;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -27,10 +29,12 @@ import java.util.Optional;
 
 import org.junit.Test;
 
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.auditing.DefaultAuditableBeanWrapperFactory.AuditableInterfaceBeanWrapper;
 import org.springframework.data.auditing.DefaultAuditableBeanWrapperFactory.ReflectionAuditingBeanWrapper;
+import org.springframework.data.domain.Auditable;
 
 /**
  * Unit tests for {@link DefaultAuditableBeanWrapperFactory}.
@@ -38,6 +42,7 @@ import org.springframework.data.auditing.DefaultAuditableBeanWrapperFactory.Refl
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Jens Schauder
+ * @author Daniel Shuy
  * @since 1.5
  */
 public class DefaultAuditableBeanWrapperFactoryUnitTests {
@@ -153,10 +158,316 @@ public class DefaultAuditableBeanWrapperFactoryUnitTests {
 		assertThat(result).hasValue(now);
 	}
 
+	@Test // DATACMNS-1641
+	public void fieldWithOverwriteBehaviorDefaultInClassExtendingAuditableShouldBeOverwritten() {
+
+		String oldUser = "old";
+		Instant oldDate = Instant.now();
+
+		ExtendingAuditableWithOverwriteBehaviorDefault source = new ExtendingAuditableWithOverwriteBehaviorDefault();
+		source.setCreatedBy(oldUser);
+		source.setCreatedDate(oldDate);
+		source.setLastModifiedBy(oldUser);
+		source.setLastModifiedDate(oldDate);
+
+		Optional<AuditableBeanWrapper<ExtendingAuditableWithOverwriteBehaviorDefault>> wrapper = factory
+				.getBeanWrapperFor(source);
+
+		assertThat(wrapper).hasValueSatisfying(it -> {
+
+			assertThat(it).isInstanceOf(DefaultAuditableBeanWrapperFactory.AuditableInterfaceBeanWrapper.class);
+
+			String newUser = "new";
+			Instant newDate = Instant.now();
+
+			it.setCreatedBy(newUser);
+			it.setCreatedDate(newDate);
+			it.setLastModifiedBy(newUser);
+			it.setLastModifiedDate(newDate);
+
+			assertThat(source.getCreatedBy()).hasValue(newUser);
+			assertThat(source.getCreatedDate()).hasValue(newDate);
+			assertThat(source.getLastModifiedBy()).hasValue(newUser);
+			assertThat(source.getLastModifiedDate()).hasValue(newDate);
+		});
+	}
+
+	@Test // DATACMNS-1641
+	public void fieldWithOverwriteBehaviorOverwriteInClassExtendingAuditableShouldBeOverwritten() {
+
+		String oldUser = "old";
+		Instant oldDate = Instant.now();
+
+		ExtendingAuditableWithOverwriteBehaviorOverwrite source = new ExtendingAuditableWithOverwriteBehaviorOverwrite();
+		source.setCreatedBy(oldUser);
+		source.setCreatedDate(oldDate);
+		source.setLastModifiedBy(oldUser);
+		source.setLastModifiedDate(oldDate);
+
+		Optional<AuditableBeanWrapper<ExtendingAuditableWithOverwriteBehaviorOverwrite>> wrapper = factory
+				.getBeanWrapperFor(source);
+
+		assertThat(wrapper).hasValueSatisfying(it -> {
+
+			assertThat(it).isInstanceOf(DefaultAuditableBeanWrapperFactory.AuditableInterfaceBeanWrapper.class);
+
+			String newUser = "new";
+			Instant newDate = Instant.now();
+
+			it.setCreatedBy(newUser);
+			it.setCreatedDate(newDate);
+			it.setLastModifiedBy(newUser);
+			it.setLastModifiedDate(newDate);
+
+			assertThat(source.getCreatedBy()).hasValue(newUser);
+			assertThat(source.getCreatedDate()).hasValue(newDate);
+			assertThat(source.getLastModifiedBy()).hasValue(newUser);
+			assertThat(source.getLastModifiedDate()).hasValue(newDate);
+		});
+	}
+
+	@Test // DATACMNS-1641
+	public void fieldWithOverwriteBehaviorSkipInClassExtendingAuditableShouldNotBeOverwritten() {
+
+		String oldUser = "old";
+		Instant oldDate = Instant.now();
+
+		ExtendingAuditableWithOverwriteBehaviorSkip source = new ExtendingAuditableWithOverwriteBehaviorSkip();
+		source.setCreatedBy(oldUser);
+		source.setCreatedDate(oldDate);
+		source.setLastModifiedBy(oldUser);
+		source.setLastModifiedDate(oldDate);
+
+		Optional<AuditableBeanWrapper<ExtendingAuditableWithOverwriteBehaviorSkip>> wrapper = factory
+				.getBeanWrapperFor(source);
+
+		assertThat(wrapper).hasValueSatisfying(it -> {
+
+			assertThat(it).isInstanceOf(DefaultAuditableBeanWrapperFactory.AuditableInterfaceBeanWrapper.class);
+
+			String newUser = "new";
+			Instant newDate = Instant.now();
+
+			it.setCreatedBy(newUser);
+			it.setCreatedDate(newDate);
+			it.setLastModifiedBy(newUser);
+			it.setLastModifiedDate(newDate);
+
+			assertThat(source.getCreatedBy()).hasValue(oldUser);
+			assertThat(source.getCreatedDate()).hasValue(oldDate);
+			assertThat(source.getLastModifiedBy()).hasValue(newUser);
+			assertThat(source.getLastModifiedDate()).hasValue(newDate);
+		});
+	}
+
+	@Test // DATACMNS-1641
+	public void fieldWithOverwriteBehaviorDefaultShouldBeOverwritten() {
+
+		String oldUser = "old";
+		Instant oldDate = Instant.now();
+
+		AuditableWithOverwriteBehaviorDefault source = new AuditableWithOverwriteBehaviorDefault();
+		source.createdBy = oldUser;
+		source.createdDate = oldDate;
+
+		Optional<AuditableBeanWrapper<AuditableWithOverwriteBehaviorDefault>> wrapper = factory.getBeanWrapperFor(source);
+
+		assertThat(wrapper).hasValueSatisfying(it -> {
+
+			assertThat(it).isInstanceOf(DefaultAuditableBeanWrapperFactory.ReflectionAuditingBeanWrapper.class);
+
+			String newUser = "new";
+			Instant newDate = Instant.now();
+
+			it.setCreatedBy(newUser);
+			it.setCreatedDate(newDate);
+			it.setLastModifiedBy(newUser);
+			it.setLastModifiedDate(newDate);
+
+			assertThat(source.createdBy).isEqualTo(newUser);
+			assertThat(source.createdDate).isEqualTo(newDate);
+		});
+	}
+
+	@Test // DATACMNS-1641
+	public void fieldWithOverwriteBehaviorOverwriteShouldBeOverwritten() {
+
+		String oldUser = "old";
+		Instant oldDate = Instant.now();
+
+		AuditableWithOverwriteBehaviorOverwrite source = new AuditableWithOverwriteBehaviorOverwrite();
+		source.createdBy = oldUser;
+		source.createdDate = oldDate;
+
+		Optional<AuditableBeanWrapper<AuditableWithOverwriteBehaviorOverwrite>> wrapper = factory.getBeanWrapperFor(source);
+
+		assertThat(wrapper).hasValueSatisfying(it -> {
+
+			assertThat(it).isInstanceOf(DefaultAuditableBeanWrapperFactory.ReflectionAuditingBeanWrapper.class);
+
+			String newUser = "new";
+			Instant newDate = Instant.now();
+
+			it.setCreatedBy(newUser);
+			it.setCreatedDate(newDate);
+			it.setLastModifiedBy(newUser);
+			it.setLastModifiedDate(newDate);
+
+			assertThat(source.createdBy).isEqualTo(newUser);
+			assertThat(source.createdDate).isEqualTo(newDate);
+		});
+	}
+
+	@Test // DATACMNS-1641
+	public void fieldWithOverwriteBehaviorSkipShouldNotBeOverwritten() {
+
+		String oldUser = "old";
+		Instant oldDate = Instant.now();
+
+		AuditableWithOverwriteBehaviorSkip source = new AuditableWithOverwriteBehaviorSkip();
+		source.createdBy = oldUser;
+		source.createdDate = oldDate;
+
+		Optional<AuditableBeanWrapper<AuditableWithOverwriteBehaviorSkip>> wrapper = factory.getBeanWrapperFor(source);
+
+		assertThat(wrapper).hasValueSatisfying(it -> {
+
+			assertThat(it).isInstanceOf(DefaultAuditableBeanWrapperFactory.ReflectionAuditingBeanWrapper.class);
+
+			String newUser = "new";
+			Instant newDate = Instant.now();
+
+			it.setCreatedBy(newUser);
+			it.setCreatedDate(newDate);
+			it.setLastModifiedBy(newUser);
+			it.setLastModifiedDate(newDate);
+
+			assertThat(source.createdBy).isEqualTo(oldUser);
+			assertThat(source.createdDate).isEqualTo(oldDate);
+		});
+	}
+
 	public static class LongBasedAuditable {
 
 		@CreatedDate public Long dateCreated;
 
 		@LastModifiedDate public Long dateModified;
+	}
+
+	@Setter
+	public static abstract class ExtendingAuditableBase implements Auditable<String, Long, Instant> {
+
+		protected String createdBy;
+		protected Instant createdDate;
+		protected String lastModifiedBy;
+		protected Instant lastModifiedDate;
+
+		@Override
+		public Long getId() {
+			return null;
+		}
+
+		@Override
+		public boolean isNew() {
+			return false;
+		}
+	}
+
+	public static class ExtendingAuditableWithOverwriteBehaviorDefault extends ExtendingAuditableBase {
+
+		@Override
+		public Optional<String> getCreatedBy() {
+			return Optional.ofNullable(createdBy);
+		}
+
+		@Override
+		public Optional<Instant> getCreatedDate() {
+			return Optional.ofNullable(createdDate);
+		}
+
+		@Override
+		public Optional<String> getLastModifiedBy() {
+			return Optional.ofNullable(lastModifiedBy);
+		}
+
+		@Override
+		public Optional<Instant> getLastModifiedDate() {
+			return Optional.ofNullable(lastModifiedDate);
+		}
+	}
+
+	public static class ExtendingAuditableWithOverwriteBehaviorOverwrite extends ExtendingAuditableBase {
+
+		@CreatedBy(overwriteBehavior = OverwriteBehavior.OVERWRITE)
+		@Override
+		public Optional<String> getCreatedBy() {
+			return Optional.ofNullable(createdBy);
+		}
+
+		@CreatedDate(overwriteBehavior = OverwriteBehavior.OVERWRITE)
+		@Override
+		public Optional<Instant> getCreatedDate() {
+			return Optional.ofNullable(createdDate);
+		}
+
+		@Override
+		public Optional<String> getLastModifiedBy() {
+			return Optional.ofNullable(lastModifiedBy);
+		}
+
+		@Override
+		public Optional<Instant> getLastModifiedDate() {
+			return Optional.ofNullable(lastModifiedDate);
+		}
+	}
+
+	public static class ExtendingAuditableWithOverwriteBehaviorSkip extends ExtendingAuditableBase {
+
+		@CreatedBy(overwriteBehavior = OverwriteBehavior.SKIP)
+		@Override
+		public Optional<String> getCreatedBy() {
+			return Optional.ofNullable(createdBy);
+		}
+
+		@CreatedDate(overwriteBehavior = OverwriteBehavior.SKIP)
+		@Override
+		public Optional<Instant> getCreatedDate() {
+			return Optional.ofNullable(createdDate);
+		}
+
+		@Override
+		public Optional<String> getLastModifiedBy() {
+			return Optional.ofNullable(lastModifiedBy);
+		}
+
+		@Override
+		public Optional<Instant> getLastModifiedDate() {
+			return Optional.ofNullable(lastModifiedDate);
+		}
+	}
+
+	public static class AuditableWithOverwriteBehaviorDefault {
+
+		@CreatedBy public String createdBy;
+
+		@CreatedDate public Instant createdDate;
+	}
+
+	public static class AuditableWithOverwriteBehaviorOverwrite {
+
+		@CreatedBy(overwriteBehavior = OverwriteBehavior.OVERWRITE) //
+		public String createdBy;
+
+		@CreatedDate(overwriteBehavior = OverwriteBehavior.OVERWRITE) //
+		public Instant createdDate;
+	}
+
+	public static class AuditableWithOverwriteBehaviorSkip {
+
+		@CreatedBy(overwriteBehavior = OverwriteBehavior.SKIP) //
+		public String createdBy;
+
+		@CreatedDate(overwriteBehavior = OverwriteBehavior.SKIP) //
+		public Instant createdDate;
 	}
 }


### PR DESCRIPTION
There are scenarios where we want the `@CreatedBy` and `@CreatedDate` auditing annotations to be ignored if the existing value is not null, eg. when synchronizing events/entities from one service/database to another (which can be quite a common pattern when using the databases as immutable event stores in a microservice architecture, where events are published to a messaging bus, then consumed asynchronously and cached in the dependent services' database). Currently the only workaround is to create custom entity listeners.

This PR adds an `overwriteBehavior` parameter to `@CreatedBy` and `@CreatedDate`. The parameter defaults to `OverwriteBehavior#OVERWRITE`, which is the same as the current behavior (for backwards compatibility), but can be set to `OverwriteBehavior#SKIP` to not overwrite the existing value if it is not `null`, eg.
```java
public class Auditable {
    @CreatedBy(overwriteBehavior = OverwriteBehavior.SKIP)
    private String createdBy;

    @CreatedDate(overwriteBehavior = OverwriteBehavior.SKIP)
    private Instant createdDate;
}
```

To maintain consistency, I also enhanced `DefaultAuditableBeanWrapperFactory.AuditableInterfaceBeanWrapper` to allow the overwrite behavior for entity classes implementing the [Auditable](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Auditable.html) interface to be configured by annotating the getter methods ([getCreatedBy()](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Auditable.html#getCreatedBy--) or [getCreatedDate()](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Auditable.html#getCreatedDate--)) with the corresponding annotation (`@CreatedBy` or `@CreatedDate`), eg.
```java
@MappedSuperclass
public abstract class AuditableImpl implements AbstractAuditable<String, Long> {
    @CreatedBy(overwriteBehavior = OverwriteBehavior.SKIP)
    @Override
    public Optional<String> getCreatedBy() {
        return super.getCreatedBy();
    }

    @CreatedDate(overwriteBehavior = OverwriteBehavior.SKIP)
    @Override
    public Optional<LocalDateTime> getCreatedDate() {
        return super.getCreatedDate();
    }
}
```

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
