### PR TITLE
DATACMNS-1665 - Consider store conversions as ConverterRegistrationIntent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1665-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -288,7 +288,7 @@ public class CustomConversions {
 	 */
 	private boolean isSupportedConverter(ConverterRegistrationIntent registrationIntent) {
 
-		boolean register = registrationIntent.isUserConverter()
+		boolean register = registrationIntent.isUserConverter() || registrationIntent.isStoreConverter()
 				|| (registrationIntent.isReading() && registrationIntent.isSimpleSourceType())
 				|| (registrationIntent.isWriting() && registrationIntent.isSimpleTargetType());
 
@@ -595,6 +595,10 @@ public class CustomConversions {
 
 		public boolean isUserConverter() {
 			return isConverterOfSource(ConverterOrigin.USER_DEFINED);
+		}
+
+		public boolean isStoreConverter() {
+			return isConverterOfSource(ConverterOrigin.STORE);
 		}
 
 		public boolean isDefaultConverter() {

--- a/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.joda.time.DateTime;
@@ -42,6 +43,7 @@ import org.springframework.data.convert.CustomConversions.ConverterConfiguration
 import org.springframework.data.convert.CustomConversions.StoreConversions;
 import org.springframework.data.convert.Jsr310Converters.LocalDateTimeToDateConverter;
 import org.springframework.data.convert.ThreeTenBackPortConverters.LocalDateTimeToJavaTimeInstantConverter;
+import org.springframework.data.geo.Point;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.threeten.bp.LocalDateTime;
 
@@ -219,6 +221,21 @@ public class CustomConversionsUnitTests {
 		verify(registry, never()).addConverter(any(LocalDateTimeToJavaTimeInstantConverter.class));
 	}
 
+	@Test // DATACMNS-1665
+	public void registersStoreConverter() {
+
+		ConverterRegistry registry = mock(ConverterRegistry.class);
+
+		SimpleTypeHolder holder = new SimpleTypeHolder(Collections.emptySet(), true);
+
+		CustomConversions conversions = new CustomConversions(StoreConversions.of(holder, PointToMapConverter.INSTANCE),
+				Collections.emptyList());
+		conversions.registerConvertersIn(registry);
+
+		assertThat(conversions.isSimpleType(Point.class));
+		verify(registry).addConverter(any(PointToMapConverter.class));
+	}
+
 	@Test // DATACMNS-1615
 	public void doesNotSkipUnsupportedUserConverter() {
 
@@ -336,6 +353,18 @@ public class CustomConversionsUnitTests {
 		@Override
 		public String convert(Object source) {
 			return source != null ? source.toString() : null;
+		}
+
+	}
+
+	@WritingConverter
+	enum PointToMapConverter implements Converter<Point, Map<String, String>> {
+
+		INSTANCE;
+
+		@Override
+		public Map<String, String> convert(Point source) {
+			return source != null ? Collections.emptyMap() : null;
 		}
 
 	}


### PR DESCRIPTION
Store converters are now properly considered as registration candidates.

---

Related ticket: [DATACMNS-1665](https://jira.spring.io/browse/DATACMNS-1665).