### PR TITLE
DATACMNS-1676 - Create shared conversion service for AuditableBeanWrapper

### DIFF
--- a/src/main/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/DefaultAuditableBeanWrapperFactory.java
@@ -21,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -151,7 +150,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 			return value;
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.auditing.AuditableBeanWrapper#getBean()
 		 */
@@ -162,7 +161,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 	}
 
 	/**
-	 * Base class for {@link AuditableBeanWrapper} implementations that might need to convert {@link Calendar} values into
+	 * Base class for {@link AuditableBeanWrapper} implementations that might need to convert {@link TemporalAccessor} values into
 	 * compatible types when setting date/time information.
 	 *
 	 * @author Oliver Gierke
@@ -170,12 +169,9 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 	 */
 	abstract static class DateConvertingAuditableBeanWrapper<T> implements AuditableBeanWrapper<T> {
 
-		private final ConversionService conversionService;
+		private static ConversionService conversionService;
 
-		/**
-		 * Creates a new {@link DateConvertingAuditableBeanWrapper}.
-		 */
-		public DateConvertingAuditableBeanWrapper() {
+		static {
 
 			DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService();
 
@@ -183,11 +179,12 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 			Jsr310Converters.getConvertersToRegister().forEach(conversionService::addConverter);
 			ThreeTenBackPortConverters.getConvertersToRegister().forEach(conversionService::addConverter);
 
-			this.conversionService = conversionService;
+			DateConvertingAuditableBeanWrapper.conversionService = conversionService;
+
 		}
 
 		/**
-		 * Returns the {@link Calendar} in a type, compatible to the given field.
+		 * Returns the {@link TemporalAccessor} in a type, compatible to the given field.
 		 *
 		 * @param value can be {@literal null}.
 		 * @param targetType must not be {@literal null}.
@@ -221,7 +218,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 		}
 
 		/**
-		 * Returns the given object as {@link Calendar}.
+		 * Returns the given object as {@link TemporalAccessor}.
 		 *
 		 * @param source can be {@literal null}.
 		 * @param target must not be {@literal null}.
@@ -328,7 +325,7 @@ class DefaultAuditableBeanWrapperFactory implements AuditableBeanWrapperFactory 
 			return setDateField(metadata.getLastModifiedDateField(), value);
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.auditing.AuditableBeanWrapper#getBean()
 		 */

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import org.springframework.core.convert.ConversionService;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -87,7 +88,7 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 						key -> new MappingAuditingMetadata(context, it.getClass()));
 
 				return Optional.<AuditableBeanWrapper<T>> ofNullable(metadata.isAuditable() //
-						? new MappingMetadataAuditableBeanWrapper<T>(entity.getPropertyPathAccessor(it), metadata)
+						? new MappingMetadataAuditableBeanWrapper<T>(conversionService, entity.getPropertyPathAccessor(it), metadata)
 						: null);
 
 			}).orElseGet(() -> super.getBeanWrapperFor(source));
@@ -177,8 +178,11 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		 * @param accessor must not be {@literal null}.
 		 * @param metadata must not be {@literal null}.
 		 */
-		public MappingMetadataAuditableBeanWrapper(PersistentPropertyPathAccessor<T> accessor,
+		public MappingMetadataAuditableBeanWrapper(
+				ConversionService conversionService,
+				PersistentPropertyPathAccessor<T> accessor,
 				MappingAuditingMetadata metadata) {
+			super(conversionService);
 
 			Assert.notNull(accessor, "PersistentPropertyAccessor must not be null!");
 			Assert.notNull(metadata, "Auditing metadata must not be null!");

--- a/src/test/java/org/springframework/data/auditing/ReflectionAuditingBeanWrapperUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/ReflectionAuditingBeanWrapperUnitTests.java
@@ -23,6 +23,7 @@ import java.time.ZoneOffset;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.auditing.DefaultAuditableBeanWrapperFactory.ReflectionAuditingBeanWrapper;
@@ -36,6 +37,7 @@ import org.springframework.data.convert.Jsr310Converters.LocalDateTimeToDateConv
  */
 public class ReflectionAuditingBeanWrapperUnitTests {
 
+	ConversionService conversionService;
 	AnnotationAuditingMetadata metadata;
 	AnnotatedUser user;
 	AuditableBeanWrapper wrapper;
@@ -44,9 +46,9 @@ public class ReflectionAuditingBeanWrapperUnitTests {
 
 	@Before
 	public void setUp() {
-
+		this.conversionService = DefaultAuditableBeanWrapperFactory.getDateConversionService();
 		this.user = new AnnotatedUser();
-		this.wrapper = new ReflectionAuditingBeanWrapper(user);
+		this.wrapper = new ReflectionAuditingBeanWrapper(conversionService, user);
 	}
 
 	@Test
@@ -74,7 +76,7 @@ public class ReflectionAuditingBeanWrapperUnitTests {
 		}
 
 		Sample sample = new Sample();
-		AuditableBeanWrapper wrapper = new ReflectionAuditingBeanWrapper(sample);
+		AuditableBeanWrapper wrapper = new ReflectionAuditingBeanWrapper(conversionService, sample);
 
 		wrapper.setCreatedDate(time);
 		assertThat(sample.createdDate).isEqualTo(time.atZone(ZoneOffset.systemDefault()).toInstant().toEpochMilli());


### PR DESCRIPTION
While profiling our application I have discovered that a significant amount of time is being spent in conversion service instantiation (image is from 20s HTTP request):

![image](https://user-images.githubusercontent.com/2012726/75563440-a5905200-5a4a-11ea-9241-2487925de669.png)

Creating conversion service for each persisted object was not necessary so I have moved it to a static initializer. This is a similar change to https://jira.spring.io/browse/DATACMNS-1357 .

I have also tried to get rid of `DefaultFormattingConversionService` (replace with `GenericConversionService`) as it seemed a bit unecessary, but unfortunately [two of it's package private converters](https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeConverters.java#L75) are used when converting from/to long.

---

> You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Not sure if I should add myself when this is such a minor change (kind of "obvious fix" category).