### PR TITLE
DATACMNS-1683 - Rebuild quotation index from rewritten SpEL query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1683-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
@@ -67,11 +67,11 @@ public class SpelQueryContext {
 
 	/**
 	 * Parses the query for SpEL expressions using the pattern:
-	 * 
+	 *
 	 * <pre>
 	 * &lt;prefix&gt;#{&lt;spel&gt;}
 	 * </pre>
-	 * 
+	 *
 	 * with prefix being the character ':' or '?'. Parsing honors quoted {@literal String}s enclosed in single or double
 	 * quotation marks.
 	 *
@@ -86,7 +86,7 @@ public class SpelQueryContext {
 	/**
 	 * Createsa {@link EvaluatingSpelQueryContext} from the current one and the given
 	 * {@link QueryMethodEvaluationContextProvider}.
-	 * 
+	 *
 	 * @param provider must not be {@literal null}.
 	 * @return
 	 */
@@ -111,7 +111,7 @@ public class SpelQueryContext {
 		/**
 		 * Creates a new {@link EvaluatingSpelQueryContext} for the given {@link QueryMethodEvaluationContextProvider},
 		 * parameter name source and replacement source.
-		 * 
+		 *
 		 * @param evaluationContextProvider must not be {@literal null}.
 		 * @param parameterNameSource must not be {@literal null}.
 		 * @param replacementSource must not be {@literal null}.
@@ -126,11 +126,11 @@ public class SpelQueryContext {
 
 		/**
 		 * Parses the query for SpEL expressions using the pattern:
-		 * 
+		 *
 		 * <pre>
 		 * &lt;prefix&gt;#{&lt;spel&gt;}
 		 * </pre>
-		 * 
+		 *
 		 * with prefix being the character ':' or '?'. Parsing honors quoted {@literal String}s enclosed in single or double
 		 * quotation marks.
 		 *
@@ -165,7 +165,7 @@ public class SpelQueryContext {
 
 		/**
 		 * Creates a SpelExtractor from a query String.
-		 * 
+		 *
 		 * @param query must not be {@literal null}.
 		 */
 		SpelExtractor(String query) {
@@ -184,7 +184,7 @@ public class SpelQueryContext {
 
 				if (quotedAreas.isQuoted(matcher.start())) {
 
-					resultQuery.append(query.substring(matchedUntil, matcher.end()));
+					resultQuery.append(query, matchedUntil, matcher.end());
 
 				} else {
 
@@ -194,7 +194,7 @@ public class SpelQueryContext {
 					String parameterName = parameterNameSource.apply(expressionCounter, spelExpression);
 					String replacement = replacementSource.apply(prefix, parameterName);
 
-					resultQuery.append(query.substring(matchedUntil, matcher.start()));
+					resultQuery.append(query, matchedUntil, matcher.start());
 					resultQuery.append(replacement);
 
 					expressions.put(parameterName, spelExpression);
@@ -230,7 +230,7 @@ public class SpelQueryContext {
 
 		/**
 		 * A {@literal Map} from parameter name to SpEL expression.
-		 * 
+		 *
 		 * @return Guaranteed to be not {@literal null}.
 		 */
 		Map<String, String> getParameterMap() {
@@ -258,7 +258,7 @@ public class SpelQueryContext {
 
 		/**
 		 * Creates a new {@link QuotationMap} for the query.
-		 * 
+		 *
 		 * @param query can be {@literal null}.
 		 */
 		public QuotationMap(@Nullable String query) {

--- a/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  *
  * @author Jens Schauder
  * @author Gerrit Meier
+ * @author Mark Paluch
  * @since 2.1
  */
 @RequiredArgsConstructor(staticName = "of")
@@ -145,7 +146,7 @@ public class SpelQueryContext {
 
 	/**
 	 * Parses a query string, identifies the contained SpEL expressions, replaces them with bind parameters and offers a
-	 * {@link Map} from those bind parameters to the spel expression.
+	 * {@link Map} from those bind parameters to the SpEL expression.
 	 * <p>
 	 * The parser detects quoted parts of the query string and does not detect SpEL expressions inside such quoted parts
 	 * of the query.
@@ -208,7 +209,9 @@ public class SpelQueryContext {
 
 			this.expressions = Collections.unmodifiableMap(expressions);
 			this.query = resultQuery.toString();
-			this.quotations = quotedAreas;
+
+			// recreate quotation map based on rewritten query.
+			this.quotations = new QuotationMap(this.query);
 		}
 
 		/**
@@ -220,6 +223,12 @@ public class SpelQueryContext {
 			return query;
 		}
 
+		/**
+		 * Return whether the {@link #getQueryString() query} at {@code index} is quoted.
+		 *
+		 * @param index
+		 * @return {@literal true} if quoted; {@literal false} otherwise.
+		 */
 		public boolean isQuoted(int index) {
 			return quotations.isQuoted(index);
 		}

--- a/src/test/java/org/springframework/data/repository/query/SpelQueryContextUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/SpelQueryContextUnitTests.java
@@ -23,14 +23,15 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@link SpelQueryContext}.
- * 
+ *
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 public class SpelQueryContextUnitTests {
 
 	static final QueryMethodEvaluationContextProvider EVALUATION_CONTEXT_PROVIDER = QueryMethodEvaluationContextProvider.DEFAULT;
-	static final BiFunction<Integer, String, String> PARAMETER_NAME_SOURCE = (index, spel) -> "EPP" + index;
+	static final BiFunction<Integer, String, String> PARAMETER_NAME_SOURCE = (index, spel) -> "__$synthetic$__" + index;
 	static final BiFunction<String, String, String> REPLACEMENT_SOURCE = (prefix, name) -> prefix + name;
 
 	@Test // DATACMNS-1258
@@ -62,5 +63,19 @@ public class SpelQueryContextUnitTests {
 		SpelQueryContext context = SpelQueryContext.of(PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
 
 		assertThat(context.withEvaluationContextProvider(EVALUATION_CONTEXT_PROVIDER)).isNotNull();
+	}
+
+	@Test // DATACMNS-1683
+	public void reportsQuotationCorrectly() {
+
+		SpelQueryContext context = SpelQueryContext.of(PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
+
+		SpelQueryContext.SpelExtractor extractor = context.parse(
+				"select n from NetworkServer n where (LOWER(n.name) LIKE LOWER(NULLIF(text(concat('%',:#{#networkRequest.name},'%')), '')) OR :#{#networkRequest.name} IS NULL )");
+
+		assertThat(extractor.getQueryString()).isEqualTo(
+				"select n from NetworkServer n where (LOWER(n.name) LIKE LOWER(NULLIF(text(concat('%',:__$synthetic$__0,'%')), '')) OR :__$synthetic$__1 IS NULL )");
+		assertThat(extractor.isQuoted(extractor.getQueryString().indexOf(":__$synthetic$__0"))).isFalse();
+		assertThat(extractor.isQuoted(extractor.getQueryString().indexOf(":__$synthetic$__1"))).isFalse();
 	}
 }


### PR DESCRIPTION
We now use the correct quotation map that is based on the rewritten SpEL query to detect whether an expression was quoted. Previously, we used the quotation map from the original query. After augmenting the query with synthetic parameters, the quotation offset no longer matched the query that was under inspection and calls to `SpelExtractor.isQuoted(…)` could report an improper result.

---

Related ticket: [DATACMNS-1683](https://jira.spring.io/browse/DATACMNS-1683).