### PR TITLE
[DATACMNS-1702] Fix nullability of EntityReader

### DIFF
--- a/src/main/java/org/springframework/data/convert/EntityReader.java
+++ b/src/main/java/org/springframework/data/convert/EntityReader.java
@@ -15,10 +15,13 @@
  */
 package org.springframework.data.convert;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface to read object from store specific sources.
  *
  * @author Oliver Gierke
+ * @author Piotr Kubowicz
  */
 public interface EntityReader<T, S> {
 
@@ -29,5 +32,5 @@ public interface EntityReader<T, S> {
 	 * @param source the source to create an object of the given type from.
 	 * @return
 	 */
-	<R extends T> R read(Class<R> type, S source);
+	<R extends T> R read(Class<R> type, @Nullable S source);
 }


### PR DESCRIPTION
'source' parameter *is* nullable - see for example MappingMongoConverter

With old code it was impossible to implement this interface in Kotlin
compiled with -Xjsr305=strict

Fixes [DATACMNS-1702](https://jira.spring.io/browse/DATACMNS-1702)

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
  - this affects compilation, behaviour is not changed, so no new tests are needed
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
