### PR TITLE
DATACMNS-1721 - Lazily evaluate potential property matches in PropertyReferenceException.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATACMNS-1721-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
In some cases the caller of a `PropertyPath` is not interested in the potentially matching properties provided via `PropertyReferenceException`. 
Those cases would benefit from a lazy evaluation.