### PR TITLE
DATACMNS-1736 - Use BeanFactory lookup in configuration classes instead of intercepted local bean methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATACMNS-1736-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +18,7 @@
 
 	<properties>
 		<javaslang>2.0.6</javaslang>
-		<vavr>0.10.2</vavr>
+		<vavr>0.10.3</vavr>
 		<scala>2.11.7</scala>
 		<xmlbeam>1.4.16</xmlbeam>
 
@@ -339,29 +340,70 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessors>
-						<annotationProcessor>
-							lombok.launch.AnnotationProcessorHider$AnnotationProcessor
-						</annotationProcessor>
-						<annotationProcessor>
-							lombok.launch.AnnotationProcessorHider$ClaimingProcessor
-						</annotationProcessor>
-						<annotationProcessor>
-							com.querydsl.apt.QuerydslAnnotationProcessor
-						</annotationProcessor>
-					</annotationProcessors>
-
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>com.mysema.maven</groupId>
+				<artifactId>apt-maven-plugin</artifactId>
+				<version>1.1.3</version>
+				<executions>
+					<execution>
+						<id>generate-querydsl-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>process</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>target/generated-sources</outputDirectory>
+							<processor>com.querydsl.apt.QuerydslAnnotationProcessor</processor>
+						</configuration>
+					</execution>
+					<execution>
+						<id>generate-querydsl-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>test-process</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>target/generated-test-sources</outputDirectory>
+							<processor>com.querydsl.apt.QuerydslAnnotationProcessor</processor>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.build.directory}/generated-sources/</source>
+							</sources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.build.directory}/generated-test-sources</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 		</plugins>

--- a/src/main/java/org/springframework/data/web/config/ProjectingArgumentResolverRegistrar.java
+++ b/src/main/java/org/springframework/data/web/config/ProjectingArgumentResolverRegistrar.java
@@ -38,9 +38,10 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * {@link ProxyingHandlerMethodArgumentResolver}.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @soundtrack Apparat With Soap & Skin - Goodbye (Dark Theme Song - https://www.youtube.com/watch?v=66VnOdk6oto)
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class ProjectingArgumentResolverRegistrar {
 
 	/**

--- a/src/main/java/org/springframework/data/web/config/SpringDataWebConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/SpringDataWebConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.data.geo.format.DistanceFormatter;
 import org.springframework.data.geo.format.PointFormatter;
 import org.springframework.data.repository.support.DomainClassConverter;
+import org.springframework.data.util.Lazy;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.ProjectingJackson2HttpMessageConverter;
 import org.springframework.data.web.ProxyingHandlerMethodArgumentResolver;
@@ -62,6 +63,9 @@ public class SpringDataWebConfiguration implements WebMvcConfigurer, BeanClassLo
 	private final ObjectFactory<ConversionService> conversionService;
 	private @Nullable ClassLoader beanClassLoader = ClassUtils.getDefaultClassLoader();
 
+	protected Lazy<SortHandlerMethodArgumentResolver> sortResolver;
+	protected Lazy<PageableHandlerMethodArgumentResolver> pageableResolver;
+
 	private @Autowired Optional<PageableHandlerMethodArgumentResolverCustomizer> pageableResolverCustomizer;
 	private @Autowired Optional<SortHandlerMethodArgumentResolverCustomizer> sortResolverCustomizer;
 
@@ -73,6 +77,9 @@ public class SpringDataWebConfiguration implements WebMvcConfigurer, BeanClassLo
 
 		this.context = context;
 		this.conversionService = conversionService;
+		this.sortResolver = Lazy.of(() -> context.getBean("sortResolver", SortHandlerMethodArgumentResolver.class));
+		this.pageableResolver = Lazy
+				.of(() -> context.getBean("pageableResolver", PageableHandlerMethodArgumentResolver.class));
 	}
 
 	/*
@@ -89,10 +96,10 @@ public class SpringDataWebConfiguration implements WebMvcConfigurer, BeanClassLo
 	 * @see org.springframework.data.web.config.SpringDataWebConfiguration#pageableResolver()
 	 */
 	@Bean
-	public PageableHandlerMethodArgumentResolver pageableResolver() {
+	public PageableHandlerMethodArgumentResolver pageableResolver(SortHandlerMethodArgumentResolver sortResolver) {
 
 		PageableHandlerMethodArgumentResolver pageableResolver = //
-				new PageableHandlerMethodArgumentResolver(getSortResolverBean());
+				new PageableHandlerMethodArgumentResolver(sortResolver);
 		customizePageableResolver(pageableResolver);
 		return pageableResolver;
 	}
@@ -136,8 +143,8 @@ public class SpringDataWebConfiguration implements WebMvcConfigurer, BeanClassLo
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
 
-		argumentResolvers.add(getSortResolverBean());
-		argumentResolvers.add(getPageableResolverBean());
+		argumentResolvers.add(this.sortResolver.get());
+		argumentResolvers.add(this.pageableResolver.get());
 
 		ProxyingHandlerMethodArgumentResolver resolver = new ProxyingHandlerMethodArgumentResolver(conversionService, true);
 		resolver.setBeanFactory(context);
@@ -168,16 +175,8 @@ public class SpringDataWebConfiguration implements WebMvcConfigurer, BeanClassLo
 		if (ClassUtils.isPresent("org.xmlbeam.XBProjector", context.getClassLoader())) {
 
 			converters.add(0, context.getBeanProvider(XmlBeamHttpMessageConverter.class) //
-					.getIfAvailable(() -> new XmlBeamHttpMessageConverter()));
+					.getIfAvailable(XmlBeamHttpMessageConverter::new));
 		}
-	}
-
-	protected SortHandlerMethodArgumentResolver getSortResolverBean() {
-		return context.getBean("sortResolver", SortHandlerMethodArgumentResolver.class);
-	}
-
-	protected PageableHandlerMethodArgumentResolver getPageableResolverBean() {
-		return context.getBean("pageableResolver", PageableHandlerMethodArgumentResolver.class);
 	}
 
 	protected void customizePageableResolver(PageableHandlerMethodArgumentResolver pageableResolver) {

--- a/src/test/java/org/springframework/data/web/config/EnableSpringDataWebSupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/web/config/EnableSpringDataWebSupportIntegrationTests.java
@@ -204,7 +204,7 @@ class EnableSpringDataWebSupportIntegrationTests {
 
 		ApplicationContext context = WebTestUtils.createApplicationContext(PageableResolverCustomizerConfig.class);
 		List<String> names = Arrays.asList(context.getBeanDefinitionNames());
-		PageableHandlerMethodArgumentResolver resolver = context.getBean(PageableHandlerMethodArgumentResolver.class);
+		PageableHandlerMethodArgumentResolver resolver = context.getBean("pageableResolver", PageableHandlerMethodArgumentResolver.class);
 
 		assertThat(names).contains("testPageableResolverCustomizer");
 		assertThat((Integer) ReflectionTestUtils.getField(resolver, "maxPageSize")).isEqualTo(100);
@@ -215,7 +215,7 @@ class EnableSpringDataWebSupportIntegrationTests {
 
 		ApplicationContext context = WebTestUtils.createApplicationContext(SortResolverCustomizerConfig.class);
 		List<String> names = Arrays.asList(context.getBeanDefinitionNames());
-		SortHandlerMethodArgumentResolver resolver = context.getBean(SortHandlerMethodArgumentResolver.class);
+		SortHandlerMethodArgumentResolver resolver = context.getBean("sortResolver", SortHandlerMethodArgumentResolver.class);
 
 		assertThat(names).contains("testSortResolverCustomizer");
 		assertThat((String) ReflectionTestUtils.getField(resolver, "sortParameter")).isEqualTo("foo");


### PR DESCRIPTION
We now use `@Configuration(proxyBeanMethods = false)` and use `BeanFactory` bean lookups to avoid CGlib proxy creation.

Using Spring's `BeanProvider.getIfUnique(…)` instead of catching `NoSuchBeanDefinitionException`.

---

Related ticket: DATACMNS-1736