### PR TITLE
Don't consider CompletableFuture as reactive type for repository determination.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATACMNS-1753-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
@@ -140,7 +140,8 @@ public abstract class ReactiveWrapperConverters {
 	 */
 	public static boolean supports(Class<?> type) {
 		return RegistryHolder.REACTIVE_ADAPTER_REGISTRY != null
-				&& RegistryHolder.REACTIVE_ADAPTER_REGISTRY.getAdapter(type) != null;
+				&& RegistryHolder.REACTIVE_ADAPTER_REGISTRY.getAdapter(type) != null
+				&& RegistryHolder.REACTIVE_ADAPTER_REGISTRY.getAdapter(type).getDescriptor().isDeferred();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/util/ReactiveWrappers.java
+++ b/src/main/java/org/springframework/data/repository/util/ReactiveWrappers.java
@@ -157,7 +157,9 @@ public abstract class ReactiveWrappers {
 
 		return Arrays.stream(type.getMethods())//
 				.flatMap(ReflectionUtils::returnTypeAndParameters)//
-				.anyMatch(ReactiveWrapperConverters::supports);
+				.anyMatch(possibleReactiveSupportedType ->
+					ReactiveWrapperConverters.supports(possibleReactiveSupportedType)
+					&& findDescriptor(possibleReactiveSupportedType).isPresent());
 	}
 
 	/**
@@ -267,7 +269,10 @@ public abstract class ReactiveWrappers {
 		}
 
 		ReactiveAdapter adapter = adapterRegistry.getAdapter(type);
+		if (adapter != null && adapter.getDescriptor().isDeferred()) {
+			return Optional.ofNullable(adapter.getDescriptor());
+		}
 
-		return Optional.ofNullable(adapter == null ? null : adapter.getDescriptor());
+		return Optional.empty();
 	}
 }

--- a/src/test/java/org/springframework/data/repository/util/ReactiveWrapperConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/ReactiveWrapperConvertersUnitTests.java
@@ -24,6 +24,8 @@ import rx.Completable;
 import rx.Observable;
 import rx.Single;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
@@ -59,6 +61,11 @@ class ReactiveWrapperConvertersUnitTests {
 		assertThat(ReactiveWrapperConverters.supports(io.reactivex.Observable.class)).isTrue();
 		assertThat(ReactiveWrapperConverters.supports(io.reactivex.Flowable.class)).isTrue();
 		assertThat(ReactiveWrapperConverters.supports(io.reactivex.Completable.class)).isTrue();
+	}
+
+	@Test // DATACMNS-1753
+	void shouldNotSupportCompletableFuture() {
+		assertThat(ReactiveWrapperConverters.supports(CompletableFuture.class)).isFalse();
 	}
 
 	@Test // DATACMNS-1653

--- a/src/test/java/org/springframework/data/repository/util/ReactiveWrappersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/ReactiveWrappersUnitTests.java
@@ -24,6 +24,8 @@ import reactor.core.publisher.Mono;
 import rx.Observable;
 import rx.Single;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
@@ -41,6 +43,7 @@ class ReactiveWrappersUnitTests {
 		assertThat(ReactiveWrappers.isNoValueType(Flux.class)).isFalse();
 		assertThat(ReactiveWrappers.isNoValueType(Single.class)).isFalse();
 		assertThat(ReactiveWrappers.isNoValueType(Completable.class)).isTrue();
+		assertThat(ReactiveWrappers.isNoValueType(CompletableFuture.class)).isFalse();
 		assertThat(ReactiveWrappers.isNoValueType(Observable.class)).isFalse();
 		assertThat(ReactiveWrappers.isNoValueType(Publisher.class)).isFalse();
 		assertThat(ReactiveWrappers.isNoValueType(io.reactivex.Single.class)).isFalse();
@@ -60,6 +63,7 @@ class ReactiveWrappersUnitTests {
 		assertThat(ReactiveWrappers.isSingleValueType(Flux.class)).isFalse();
 		assertThat(ReactiveWrappers.isSingleValueType(Single.class)).isTrue();
 		assertThat(ReactiveWrappers.isSingleValueType(Completable.class)).isFalse();
+		assertThat(ReactiveWrappers.isSingleValueType(CompletableFuture.class)).isFalse();
 		assertThat(ReactiveWrappers.isSingleValueType(Observable.class)).isFalse();
 		assertThat(ReactiveWrappers.isSingleValueType(Publisher.class)).isFalse();
 		assertThat(ReactiveWrappers.isSingleValueType(io.reactivex.Single.class)).isTrue();
@@ -81,6 +85,7 @@ class ReactiveWrappersUnitTests {
 		assertThat(ReactiveWrappers.isMultiValueType(Flux.class)).isTrue();
 		assertThat(ReactiveWrappers.isMultiValueType(Single.class)).isFalse();
 		assertThat(ReactiveWrappers.isSingleValueType(Completable.class)).isFalse();
+		assertThat(ReactiveWrappers.isSingleValueType(CompletableFuture.class)).isFalse();
 		assertThat(ReactiveWrappers.isMultiValueType(Observable.class)).isTrue();
 		assertThat(ReactiveWrappers.isMultiValueType(Publisher.class)).isTrue();
 		assertThat(ReactiveWrappers.isMultiValueType(io.reactivex.Single.class)).isFalse();


### PR DESCRIPTION
I completely dislike the duplication of the `isDeferred()` check but have not found a suitable alternative to reflect the same behaviour in both classes.