### PR TITLE
DATACMNS-1757 PagedResourcesAssembler generated navigation links ignore non pageable request parameters

### DIFF
--- a/src/test/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolverIntegrationTests.java
+++ b/src/test/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolverIntegrationTests.java
@@ -1,0 +1,88 @@
+package org.springframework.data.web;
+
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.config.HateoasAwareSpringDataWebConfiguration;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+public class HateoasPageableHandlerMethodArgumentResolverIntegrationTests {
+
+	@Configuration
+	@EnableWebMvc
+	@EnableHypermediaSupport(type = {EnableHypermediaSupport.HypermediaType.HAL})
+	@Import(HateoasAwareSpringDataWebConfiguration.class)
+	static class Config {
+
+		@Bean
+		SampleController controller() {
+			return new SampleController();
+		}
+	}
+
+	@BeforeEach
+	void setUp() {
+		WebTestUtils.initWebTest();
+	}
+
+	@Test // DATACMNS-1757
+	void navigationLinksPreserveQueryParams() throws Exception {
+		WebApplicationContext context = WebTestUtils.createApplicationContext(Config.class);
+		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/persons").queryParam("foo", "bar")
+				.accept(MediaTypes.HAL_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$._links.first.href").value("http://localhost/persons?foo=bar&page=0&size=20"))
+				.andExpect(jsonPath("$._links.self.href").value("http://localhost/persons?foo=bar&page=0&size=20"))
+				.andExpect(jsonPath("$._links.next.href").value("http://localhost/persons?foo=bar&page=1&size=20"))
+				.andExpect(jsonPath("$._links.last.href").value("http://localhost/persons?foo=bar&page=1&size=20"));
+	}
+
+	@Controller
+	static class SampleController {
+
+		@GetMapping("/persons")
+		@ResponseBody
+		PagedModel<EntityModel<Person>> sample(Pageable pageable, PagedResourcesAssembler<Person> assembler) {
+
+			Page<Person> page = new PageImpl<>(Collections.singletonList(new Person("John Doe")), pageable,
+					pageable.getOffset() + pageable.getPageSize() + 1);
+
+			return assembler.toModel(page);
+		}
+	}
+
+	static class Person {
+
+		public final String name;
+
+		Person(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
