### PR TITLE
DATACMNS-1108 - Add support for reactive SpEL extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATACMNS-1108-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/core/support/ReactiveRepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/ReactiveRepositoryFactorySupport.java
@@ -19,8 +19,11 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.reactivestreams.Publisher;
+
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
+import org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.util.ReactiveWrapperConverters;
 import org.springframework.data.repository.util.ReactiveWrappers;
 import org.springframework.util.ClassUtils;
@@ -54,6 +57,20 @@ public abstract class ReactiveRepositoryFactorySupport extends RepositoryFactory
 			Arrays.stream(repositoryMetadata.getRepositoryInterface().getMethods())
 					.forEach(RxJavaOneConversionSetup::validate);
 		}
+	}
+
+	/**
+	 * Sets the {@link QueryMethodEvaluationContextProvider} to be used to evaluate SpEL expressions in manually defined
+	 * queries.
+	 *
+	 * @param evaluationContextProvider can be {@literal null}, defaults to
+	 *          {@link ReactiveQueryMethodEvaluationContextProvider#INSTANCE}.
+	 */
+	@Override
+	public void setEvaluationContextProvider(QueryMethodEvaluationContextProvider evaluationContextProvider) {
+		super.setEvaluationContextProvider(
+				evaluationContextProvider == null ? ReactiveQueryMethodEvaluationContextProvider.DEFAULT
+						: evaluationContextProvider);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
@@ -182,9 +182,21 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		this.beanFactory = beanFactory;
 
 		if (!this.evaluationContextProvider.isPresent() && ListableBeanFactory.class.isInstance(beanFactory)) {
-			this.evaluationContextProvider = Optional
-					.of(new ExtensionAwareQueryMethodEvaluationContextProvider((ListableBeanFactory) beanFactory));
+			this.evaluationContextProvider = createDefaultQueryMethodEvaluationContextProvider(
+					(ListableBeanFactory) beanFactory);
 		}
+	}
+
+	/**
+	 * Create a default {@link QueryMethodEvaluationContextProvider} (or subclass) from {@link ListableBeanFactory}.
+	 *
+	 * @param beanFactory the bean factory to use.
+	 * @return the default instance. May be {@link Optional#empty()}.
+	 * @since 2.4
+	 */
+	protected Optional<QueryMethodEvaluationContextProvider> createDefaultQueryMethodEvaluationContextProvider(
+			ListableBeanFactory beanFactory) {
+		return Optional.of(new ExtensionAwareQueryMethodEvaluationContextProvider(beanFactory));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/repository/query/ExtensionAwareQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ExtensionAwareQueryMethodEvaluationContextProvider.java
@@ -15,27 +15,17 @@
  */
 package org.springframework.data.repository.query;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.aopalliance.intercept.MethodInterceptor;
-import org.aopalliance.intercept.MethodInvocation;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
 import org.springframework.data.spel.spi.EvaluationContextExtension;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ConcurrentReferenceHashMap;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -92,6 +82,21 @@ public class ExtensionAwareQueryMethodEvaluationContextProvider implements Query
 		return evaluationContext;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.QueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[], ExpressionDependencies)
+	 */
+	@Override
+	public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues,
+			ExpressionDependencies dependencies) {
+
+		StandardEvaluationContext evaluationContext = delegate.getEvaluationContext(parameterValues, dependencies);
+
+		evaluationContext.setVariables(collectVariables(parameters, parameterValues));
+
+		return evaluationContext;
+	}
+
 	/**
 	 * Exposes variables for all named parameters for the given arguments. Also exposes non-bindable parameters under the
 	 * names of their types.
@@ -100,7 +105,7 @@ public class ExtensionAwareQueryMethodEvaluationContextProvider implements Query
 	 * @param arguments must not be {@literal null}.
 	 * @return
 	 */
-	private static Map<String, Object> collectVariables(Parameters<?, ?> parameters, Object[] arguments) {
+	static Map<String, Object> collectVariables(Parameters<?, ?> parameters, Object[] arguments) {
 
 		Map<String, Object> variables = new HashMap<>();
 
@@ -119,86 +124,4 @@ public class ExtensionAwareQueryMethodEvaluationContextProvider implements Query
 		return variables;
 	}
 
-	/**
-	 * Looks up all {@link EvaluationContextExtension} and
-	 * {@link org.springframework.data.repository.query.spi.EvaluationContextExtension} instances from the given
-	 * {@link ListableBeanFactory} and wraps the latter into proxies so that they implement the former.
-	 *
-	 * @param beanFactory must not be {@literal null}.
-	 * @return
-	 */
-	private static List<EvaluationContextExtension> getExtensionsFrom(ListableBeanFactory beanFactory) {
-
-		Stream<EvaluationContextExtension> extensions = beanFactory
-				.getBeansOfType(EvaluationContextExtension.class, true, false).values().stream();
-
-		return extensions.collect(Collectors.toList());
-	}
-
-	/**
-	 * A {@link MethodInterceptor} that forwards all invocations of methods (by name and parameter types) that are
-	 * available on a given target object
-	 *
-	 * @author Oliver Gierke
-	 */
-	static class DelegatingMethodInterceptor implements MethodInterceptor {
-
-		private static final Map<Method, Method> methodCache = new ConcurrentReferenceHashMap<Method, Method>();
-
-		private final Object target;
-		private final Map<String, Function<Object, Object>> directMappings = new HashMap<>();
-
-		DelegatingMethodInterceptor(Object target) {
-			this.target = target;
-		}
-
-		/**
-		 * Registers a result mapping for the method with the given name. Invocation results for matching methods will be
-		 * piped through the mapping.
-		 *
-		 * @param methodName
-		 * @param mapping
-		 */
-		public void registerResultMapping(String methodName, Function<Object, Object> mapping) {
-			this.directMappings.put(methodName, mapping);
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.aopalliance.intercept.MethodInterceptor#invoke(org.aopalliance.intercept.MethodInvocation)
-		 */
-		@Nullable
-		@Override
-		public Object invoke(@Nullable MethodInvocation invocation) throws Throwable {
-
-			if (invocation == null) {
-				throw new IllegalArgumentException("Invocation must not be null!");
-			}
-
-			Method method = invocation.getMethod();
-			Method targetMethod = methodCache.computeIfAbsent(method,
-					it -> Optional.ofNullable(findTargetMethod(it)).orElse(it));
-
-			Object result = method.equals(targetMethod) ? invocation.proceed()
-					: ReflectionUtils.invokeMethod(targetMethod, target, invocation.getArguments());
-
-			if (result == null) {
-				return result;
-			}
-
-			Function<Object, Object> mapper = this.directMappings.get(targetMethod.getName());
-
-			return mapper != null ? mapper.apply(result) : result;
-		}
-
-		@Nullable
-		private Method findTargetMethod(Method method) {
-
-			try {
-				return target.getClass().getMethod(method.getName(), method.getParameterTypes());
-			} catch (Exception e) {
-				return null;
-			}
-		}
-	}
 }

--- a/src/main/java/org/springframework/data/repository/query/QueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethodEvaluationContextProvider.java
@@ -30,7 +30,7 @@ import org.springframework.expression.EvaluationContext;
  */
 public interface QueryMethodEvaluationContextProvider {
 
-	static QueryMethodEvaluationContextProvider DEFAULT = new ExtensionAwareQueryMethodEvaluationContextProvider(
+	QueryMethodEvaluationContextProvider DEFAULT = new ExtensionAwareQueryMethodEvaluationContextProvider(
 			Collections.emptyList());
 
 	/**

--- a/src/main/java/org/springframework/data/repository/query/ReactiveExtensionAwareQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveExtensionAwareQueryMethodEvaluationContextProvider.java
@@ -42,7 +42,7 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 	private final ReactiveExtensionAwareEvaluationContextProvider delegate;
 
 	/**
-	 * Creates a new {@link ReactiveExtensionAwareQueryMethodEvaluationContextProvider}.
+	 * Create a new {@link ReactiveExtensionAwareQueryMethodEvaluationContextProvider}.
 	 *
 	 * @param beanFactory the {@link ListableBeanFactory} to lookup the {@link EvaluationContextExtension}s from, must not
 	 *          be {@literal null}.
@@ -55,7 +55,7 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 	}
 
 	/**
-	 * Creates a new {@link ReactiveExtensionAwareQueryMethodEvaluationContextProvider} using the given
+	 * Create a new {@link ReactiveExtensionAwareQueryMethodEvaluationContextProvider} using the given
 	 * {@link EvaluationContextExtension}s and
 	 * {@link org.springframework.data.spel.spi.ReactiveEvaluationContextExtension}s.
 	 *
@@ -68,7 +68,7 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 		this.delegate = new ReactiveExtensionAwareEvaluationContextProvider(extensions);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.QueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[])
 	 */
@@ -85,7 +85,7 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 		return evaluationContext;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.QueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[], org.springframework.data.spel.ExpressionDependencies)
 	 */
@@ -119,7 +119,7 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 				.cast(EvaluationContext.class);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider#getEvaluationContextLater(org.springframework.data.repository.query.Parameters, java.lang.Object[], org.springframework.data.spel.ExpressionDependencies)
 	 */

--- a/src/main/java/org/springframework/data/repository/query/ReactiveExtensionAwareQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveExtensionAwareQueryMethodEvaluationContextProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.data.spel.ExpressionDependencies;
+import org.springframework.data.spel.ReactiveExtensionAwareEvaluationContextProvider;
+import org.springframework.data.spel.spi.EvaluationContextExtension;
+import org.springframework.data.spel.spi.ExtensionIdAware;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.util.Assert;
+
+/**
+ * An reactive {@link QueryMethodEvaluationContextProvider} that assembles an {@link EvaluationContext} from a list of
+ * {@link EvaluationContextExtension} and {@link org.springframework.data.spel.spi.ReactiveEvaluationContextExtension}.
+ * instances.
+ *
+ * @author Mark Paluch
+ * @since 2.4
+ */
+public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
+		implements ReactiveQueryMethodEvaluationContextProvider {
+
+	private final ReactiveExtensionAwareEvaluationContextProvider delegate;
+
+	/**
+	 * Creates a new {@link ReactiveExtensionAwareQueryMethodEvaluationContextProvider}.
+	 *
+	 * @param beanFactory the {@link ListableBeanFactory} to lookup the {@link EvaluationContextExtension}s from, must not
+	 *          be {@literal null}.
+	 */
+	public ReactiveExtensionAwareQueryMethodEvaluationContextProvider(ListableBeanFactory beanFactory) {
+
+		Assert.notNull(beanFactory, "ListableBeanFactory must not be null!");
+
+		this.delegate = new ReactiveExtensionAwareEvaluationContextProvider(beanFactory);
+	}
+
+	/**
+	 * Creates a new {@link ReactiveExtensionAwareQueryMethodEvaluationContextProvider} using the given
+	 * {@link EvaluationContextExtension}s and
+	 * {@link org.springframework.data.spel.spi.ReactiveEvaluationContextExtension}s.
+	 *
+	 * @param extensions must not be {@literal null}.
+	 */
+	public ReactiveExtensionAwareQueryMethodEvaluationContextProvider(List<? extends ExtensionIdAware> extensions) {
+
+		Assert.notNull(extensions, "EvaluationContextExtensions must not be null!");
+
+		this.delegate = new ReactiveExtensionAwareEvaluationContextProvider(extensions);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[])
+	 */
+	@Override
+	public <T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters,
+			Object[] parameterValues) {
+
+		Mono<StandardEvaluationContext> evaluationContext = delegate.getEvaluationContext(parameterValues);
+
+		return evaluationContext
+				.doOnNext(it -> it.setVariables(
+						ExtensionAwareQueryMethodEvaluationContextProvider.collectVariables(parameters, parameterValues)))
+				.cast(EvaluationContext.class);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[], ExpressionDependencies)
+	 */
+	@Override
+	public <T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters,
+			Object[] parameterValues, ExpressionDependencies dependencies) {
+
+		Mono<StandardEvaluationContext> evaluationContext = delegate.getEvaluationContext(parameterValues, dependencies);
+
+		return evaluationContext
+				.doOnNext(it -> it.setVariables(
+						ExtensionAwareQueryMethodEvaluationContextProvider.collectVariables(parameters, parameterValues)))
+				.cast(EvaluationContext.class);
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/ReactiveExtensionAwareQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveExtensionAwareQueryMethodEvaluationContextProvider.java
@@ -68,15 +68,50 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 		this.delegate = new ReactiveExtensionAwareEvaluationContextProvider(extensions);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.QueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[])
+	 */
+	@Override
+	public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues) {
+
+		EvaluationContext evaluationContext = delegate.getEvaluationContext(parameterValues);
+
+		if (evaluationContext instanceof StandardEvaluationContext) {
+			((StandardEvaluationContext) evaluationContext).setVariables(
+					ExtensionAwareQueryMethodEvaluationContextProvider.collectVariables(parameters, parameterValues));
+		}
+
+		return evaluationContext;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.query.QueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[], org.springframework.data.spel.ExpressionDependencies)
+	 */
+	@Override
+	public <T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues,
+			ExpressionDependencies dependencies) {
+
+		EvaluationContext evaluationContext = delegate.getEvaluationContext(parameterValues, dependencies);
+
+		if (evaluationContext instanceof StandardEvaluationContext) {
+			((StandardEvaluationContext) evaluationContext).setVariables(
+					ExtensionAwareQueryMethodEvaluationContextProvider.collectVariables(parameters, parameterValues));
+		}
+
+		return evaluationContext;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[])
 	 */
 	@Override
-	public <T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters,
+	public <T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContextLater(T parameters,
 			Object[] parameterValues) {
 
-		Mono<StandardEvaluationContext> evaluationContext = delegate.getEvaluationContext(parameterValues);
+		Mono<StandardEvaluationContext> evaluationContext = delegate.getEvaluationContextLater(parameterValues);
 
 		return evaluationContext
 				.doOnNext(it -> it.setVariables(
@@ -84,15 +119,16 @@ public class ReactiveExtensionAwareQueryMethodEvaluationContextProvider
 				.cast(EvaluationContext.class);
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider#getEvaluationContext(org.springframework.data.repository.query.Parameters, java.lang.Object[], ExpressionDependencies)
+	 * @see org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider#getEvaluationContextLater(org.springframework.data.repository.query.Parameters, java.lang.Object[], org.springframework.data.spel.ExpressionDependencies)
 	 */
 	@Override
-	public <T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters,
+	public <T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContextLater(T parameters,
 			Object[] parameterValues, ExpressionDependencies dependencies) {
 
-		Mono<StandardEvaluationContext> evaluationContext = delegate.getEvaluationContext(parameterValues, dependencies);
+		Mono<StandardEvaluationContext> evaluationContext = delegate.getEvaluationContextLater(parameterValues,
+				dependencies);
 
 		return evaluationContext
 				.doOnNext(it -> it.setVariables(

--- a/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
@@ -17,33 +17,40 @@ package org.springframework.data.repository.query;
 
 import reactor.core.publisher.Mono;
 
+import java.util.Collections;
+
 import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
 
 /**
- * Provides a way to access a centrally defined potentially shared {@link EvaluationContext}.
+ * Provides a way to access a centrally defined potentially shared {@link EvaluationContext} by considering
+ * {@link org.springframework.data.spel.spi.ReactiveEvaluationContextExtension}.
  *
  * @author Mark Paluch
  * @since 2.4
  */
-public interface ReactiveQueryMethodEvaluationContextProvider {
+public interface ReactiveQueryMethodEvaluationContextProvider extends QueryMethodEvaluationContextProvider {
+
+	ReactiveQueryMethodEvaluationContextProvider DEFAULT = new ReactiveExtensionAwareQueryMethodEvaluationContextProvider(
+			Collections.emptyList());
 
 	/**
 	 * Returns an {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
 	 *
 	 * @param parameters the {@link Parameters} instance obtained from the query method the context is built for.
 	 * @param parameterValues the values for the parameters.
-	 * @return
+	 * @return a mono that emits exactly one {@link EvaluationContext}.
 	 */
-	<T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters, Object[] parameterValues);
+	<T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContextLater(T parameters,
+			Object[] parameterValues);
 
 	/**
 	 * Returns an {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
 	 *
 	 * @param parameters the {@link Parameters} instance obtained from the query method the context is built for.
 	 * @param parameterValues the values for the parameters.
-	 * @return
+	 * @return a mono that emits exactly one {@link EvaluationContext}.
 	 */
-	<T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters, Object[] parameterValues,
+	<T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContextLater(T parameters, Object[] parameterValues,
 			ExpressionDependencies dependencies);
 }

--- a/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
@@ -35,7 +35,7 @@ public interface ReactiveQueryMethodEvaluationContextProvider extends QueryMetho
 			Collections.emptyList());
 
 	/**
-	 * Returns an {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
+	 * Return a {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
 	 *
 	 * @param parameters the {@link Parameters} instance obtained from the query method the context is built for.
 	 * @param parameterValues the values for the parameters.
@@ -45,7 +45,7 @@ public interface ReactiveQueryMethodEvaluationContextProvider extends QueryMetho
 			Object[] parameterValues);
 
 	/**
-	 * Returns an {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
+	 * Return a {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
 	 *
 	 * @param parameters the {@link Parameters} instance obtained from the query method the context is built for.
 	 * @param parameterValues the values for the parameters.

--- a/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.repository.query;
 
-import java.util.Collections;
+import reactor.core.publisher.Mono;
 
 import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
@@ -23,15 +23,10 @@ import org.springframework.expression.EvaluationContext;
 /**
  * Provides a way to access a centrally defined potentially shared {@link EvaluationContext}.
  *
- * @author Thomas Darimont
- * @author Oliver Gierke
- * @author Christoph Strobl
- * @since 1.9
+ * @author Mark Paluch
+ * @since 2.4
  */
-public interface QueryMethodEvaluationContextProvider {
-
-	static QueryMethodEvaluationContextProvider DEFAULT = new ExtensionAwareQueryMethodEvaluationContextProvider(
-			Collections.emptyList());
+public interface ReactiveQueryMethodEvaluationContextProvider {
 
 	/**
 	 * Returns an {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
@@ -40,7 +35,7 @@ public interface QueryMethodEvaluationContextProvider {
 	 * @param parameterValues the values for the parameters.
 	 * @return
 	 */
-	<T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues);
+	<T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters, Object[] parameterValues);
 
 	/**
 	 * Returns an {@link EvaluationContext} built using the given {@link Parameters} and parameter values.
@@ -49,6 +44,6 @@ public interface QueryMethodEvaluationContextProvider {
 	 * @param parameterValues the values for the parameters.
 	 * @return
 	 */
-	<T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues,
+	<T extends Parameters<?, ?>> Mono<EvaluationContext> getEvaluationContext(T parameters, Object[] parameterValues,
 			ExpressionDependencies dependencies);
 }

--- a/src/main/java/org/springframework/data/repository/query/SpelEvaluator.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelEvaluator.java
@@ -20,7 +20,9 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.springframework.data.repository.query.SpelQueryContext.SpelExtractor;
+import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -60,11 +62,10 @@ public class SpelEvaluator {
 
 		Assert.notNull(values, "Values must not be null.");
 
-		EvaluationContext evaluationContext = evaluationContextProvider.getEvaluationContext(parameters, values);
 
 		return extractor.getParameters().collect(Collectors.toMap(//
 				Entry::getKey, //
-				it -> getSpElValue(evaluationContext, it.getValue()) //
+				it -> getSpElValue(it.getValue(), values) //
 		));
 	}
 
@@ -78,7 +79,12 @@ public class SpelEvaluator {
 	}
 
 	@Nullable
-	private static Object getSpElValue(EvaluationContext evaluationContext, String expression) {
-		return PARSER.parseExpression(expression).getValue(evaluationContext);
+	private Object getSpElValue(String expressionString, Object[] values) {
+
+		Expression expression = PARSER.parseExpression(expressionString);
+		EvaluationContext evaluationContext = evaluationContextProvider.getEvaluationContext(parameters, values,
+				ExpressionDependencies.discover(expression));
+
+		return expression.getValue(evaluationContext);
 	}
 }

--- a/src/main/java/org/springframework/data/spel/EvaluationContextExtensionInformation.java
+++ b/src/main/java/org/springframework/data/spel/EvaluationContextExtensionInformation.java
@@ -102,7 +102,7 @@ class EvaluationContextExtensionInformation {
 	}
 
 	/**
-	 * Returns whether this extension provides {@link ExpressionDependencies.ExpressionDependency}.
+	 * Return {@literal true} if this extension provides {@link ExpressionDependencies.ExpressionDependency}.
 	 *
 	 * @param dependency the expression dependency.
 	 * @return {@literal true} if {@link ExpressionDependencies.ExpressionDependency} is provided by this root object or
@@ -159,7 +159,7 @@ class EvaluationContextExtensionInformation {
 		}
 
 		/**
-		 * Returns whether this extension provides {@link ExpressionDependencies.ExpressionDependency}.
+		 * Return {@literal true} if this extension provides {@link ExpressionDependencies.ExpressionDependency}.
 		 *
 		 * @param dependency the expression dependency.
 		 * @return {@literal true} if {@link ExpressionDependencies.ExpressionDependency} is provided by this root object.

--- a/src/main/java/org/springframework/data/spel/EvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/EvaluationContextProvider.java
@@ -34,12 +34,12 @@ public interface EvaluationContextProvider {
 	 * A simple default {@link EvaluationContextProvider} returning a {@link StandardEvaluationContext} with the given
 	 * root object.
 	 */
-	static EvaluationContextProvider DEFAULT = rootObject -> rootObject == null //
+	EvaluationContextProvider DEFAULT = rootObject -> rootObject == null //
 			? new StandardEvaluationContext() //
 			: new StandardEvaluationContext(rootObject);
 
 	/**
-	 * Returns an {@link EvaluationContext} built using the given parameter values.
+	 * Return a {@link EvaluationContext} built using the given parameter values.
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @return
@@ -47,10 +47,10 @@ public interface EvaluationContextProvider {
 	EvaluationContext getEvaluationContext(Object rootObject);
 
 	/**
-	 * Returns a tailored {@link EvaluationContext} built using the given parameter values and considering
-	 * {@link ExpressionDependencies.ExpressionDependency expression dependencies}. The returned {@link EvaluationContext}
-	 * may contain a reduced visibility of methods and properties/fields according to the required
-	 * {@link ExpressionDependencies.ExpressionDependency expression dependencies}.
+	 * Return a tailored {@link EvaluationContext} built using the given parameter values and considering
+	 * {@link ExpressionDependencies expression dependencies}. The returned {@link EvaluationContext} may contain a
+	 * reduced visibility of methods and properties/fields according to the required {@link ExpressionDependencies
+	 * expression dependencies}.
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @param dependencies the requested expression dependencies to be available.

--- a/src/main/java/org/springframework/data/spel/ExpressionDependencies.java
+++ b/src/main/java/org/springframework/data/spel/ExpressionDependencies.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.spel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.data.util.Streamable;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.SpelNode;
+import org.springframework.expression.spel.ast.CompoundExpression;
+import org.springframework.expression.spel.ast.MethodReference;
+import org.springframework.expression.spel.ast.PropertyOrFieldReference;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * Value object capturing dependencies to a method or property/field that is referenced from a SpEL expression.
+ *
+ * @author Mark Paluch
+ * @since 2.4
+ */
+public class ExpressionDependencies implements Streamable<ExpressionDependencies.ExpressionDependency> {
+
+	private static final ExpressionDependencies EMPTY = new ExpressionDependencies(Collections.emptyList());
+
+	private final List<ExpressionDependency> dependencies;
+
+	private ExpressionDependencies(List<ExpressionDependency> dependencies) {
+		this.dependencies = dependencies;
+	}
+
+	/**
+	 * Discover all expression dependencies that are referenced in the {@link SpelNode expression root}.
+	 *
+	 * @param expression the SpEL expression to inspect.
+	 * @return a set of {@link ExpressionDependencies}.
+	 */
+	public static ExpressionDependencies discover(Expression expression) {
+		return expression instanceof SpelExpression ? discover(((SpelExpression) expression).getAST(), true) : EMPTY;
+	}
+
+	/**
+	 * Discover all expression dependencies that are referenced in the {@link SpelNode expression root}.
+	 *
+	 * @param root the SpEL expression to inspect.
+	 * @param topLevelOnly whether to include top-level dependencies only. Top-level dependencies are dependencies that
+	 *          indicate the start of a compound expression and required to resolve the next expression item.
+	 * @return a set of {@link ExpressionDependencies}.
+	 */
+	public static ExpressionDependencies discover(SpelNode root, boolean topLevelOnly) {
+
+		List<ExpressionDependency> dependencies = new ArrayList<>();
+
+		collectDependencies(root, 0, expressionDependency -> {
+			if (!topLevelOnly || expressionDependency.isTopLevel()) {
+				dependencies.add(expressionDependency);
+			}
+		});
+
+		return new ExpressionDependencies(Collections.unmodifiableList(dependencies));
+	}
+
+	private static void collectDependencies(SpelNode node, int compoundPosition,
+			Consumer<ExpressionDependency> dependencies) {
+
+		if (node instanceof MethodReference) {
+			dependencies.accept(ExpressionDependency.forMethod(((MethodReference) node).getName()).nest(compoundPosition));
+		}
+
+		if (node instanceof PropertyOrFieldReference) {
+			dependencies.accept(
+					ExpressionDependency.forPropertyOrField(((PropertyOrFieldReference) node).getName()).nest(compoundPosition));
+		}
+
+		for (int i = 0; i < node.getChildCount(); i++) {
+			collectDependencies(node.getChild(i), node instanceof CompoundExpression ? i : 0, dependencies);
+		}
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see java.lang.Iterable#iterator()
+	 */
+	@Override
+	public Iterator<ExpressionDependency> iterator() {
+		return this.dependencies.iterator();
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof ExpressionDependencies)) {
+			return false;
+		}
+		ExpressionDependencies that = (ExpressionDependencies) o;
+		return ObjectUtils.nullSafeEquals(dependencies, that.dependencies);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		return ObjectUtils.nullSafeHashCode(dependencies);
+	}
+
+	/**
+	 * Value object to describe a dependency to a method or property/field that is referenced from a SpEL expression.
+	 *
+	 * @author Mark Paluch
+	 * @since 2.4
+	 */
+	public static class ExpressionDependency {
+
+		private final DependencyType type;
+		private final String symbol;
+		private final int nestLevel;
+
+		private ExpressionDependency(DependencyType type, String symbol, int nestLevel) {
+			this.symbol = symbol;
+			this.nestLevel = nestLevel;
+			this.type = type;
+		}
+
+		/**
+		 * Create a new {@link ExpressionDependency} for a method.
+		 *
+		 * @param symbol the method name.
+		 * @return
+		 */
+		public static ExpressionDependency forMethod(String symbol) {
+			return new ExpressionDependency(DependencyType.METHOD, symbol, 0);
+		}
+
+		/**
+		 * Create a new {@link ExpressionDependency} for a property or field.
+		 *
+		 * @param symbol the property/field name.
+		 * @return
+		 */
+		public static ExpressionDependency forPropertyOrField(String symbol) {
+			return new ExpressionDependency(DependencyType.PROPERTY, symbol, 0);
+		}
+
+		/**
+		 * Associate a nesting {@code level} with the {@link ExpressionDependency}. Returns
+		 *
+		 * @param level
+		 * @return
+		 */
+		public ExpressionDependency nest(int level) {
+			return nestLevel == level ? this : new ExpressionDependency(type, symbol, level);
+		}
+
+		public boolean isNested() {
+			return !isTopLevel();
+		}
+
+		public boolean isTopLevel() {
+			return this.nestLevel == 0;
+		}
+
+		public boolean isMethod() {
+			return this.type == DependencyType.METHOD;
+		}
+
+		public boolean isPropertyOrField() {
+			return this.type == DependencyType.PROPERTY;
+		}
+
+		public String getSymbol() {
+			return symbol;
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof ExpressionDependency)) {
+				return false;
+			}
+			ExpressionDependency that = (ExpressionDependency) o;
+			if (nestLevel != that.nestLevel) {
+				return false;
+			}
+			if (type != that.type) {
+				return false;
+			}
+			return ObjectUtils.nullSafeEquals(symbol, that.symbol);
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
+		@Override
+		public int hashCode() {
+			int result = ObjectUtils.nullSafeHashCode(type);
+			result = 31 * result + ObjectUtils.nullSafeHashCode(symbol);
+			result = 31 * result + nestLevel;
+			return result;
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return "ExpressionDependency{" + "type=" + type + ", symbol='" + symbol + '\'' + ", nestLevel=" + nestLevel + '}';
+		}
+
+		enum DependencyType {
+			PROPERTY, METHOD;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/spel/ExpressionDependencies.java
+++ b/src/main/java/org/springframework/data/spel/ExpressionDependencies.java
@@ -179,21 +179,21 @@ public class ExpressionDependencies implements Streamable<ExpressionDependencies
 		/**
 		 * Create a new {@link ExpressionDependency} for a method.
 		 *
-		 * @param symbol the method name.
-		 * @return
+		 * @param methodName the method name.
+		 * @return a method dependency on {@code methodName}.
 		 */
-		public static ExpressionDependency forMethod(String symbol) {
-			return new ExpressionDependency(DependencyType.METHOD, symbol, 0);
+		public static ExpressionDependency forMethod(String methodName) {
+			return new ExpressionDependency(DependencyType.METHOD, methodName, 0);
 		}
 
 		/**
 		 * Create a new {@link ExpressionDependency} for a property or field.
 		 *
-		 * @param symbol the property/field name.
-		 * @return
+		 * @param fieldOrPropertyName the property/field name.
+		 * @return a method dependency on {@code fieldOrPropertyName}.
 		 */
-		public static ExpressionDependency forPropertyOrField(String symbol) {
-			return new ExpressionDependency(DependencyType.PROPERTY, symbol, 0);
+		public static ExpressionDependency forPropertyOrField(String fieldOrPropertyName) {
+			return new ExpressionDependency(DependencyType.PROPERTY, fieldOrPropertyName, 0);
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
@@ -59,13 +59,14 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Jens Schauder
+ * @author Mark Paluch
  * @since 2.1
  */
 public class ExtensionAwareEvaluationContextProvider implements EvaluationContextProvider {
 
 	private final Map<Class<?>, EvaluationContextExtensionInformation> extensionInformationCache = new ConcurrentHashMap<>();
-
 	private final Lazy<? extends Collection<? extends ExtensionIdAware>> extensions;
+
 	private ListableBeanFactory beanFactory;
 
 	ExtensionAwareEvaluationContextProvider() {
@@ -80,7 +81,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	 */
 	public ExtensionAwareEvaluationContextProvider(ListableBeanFactory beanFactory) {
 
-		this(Lazy.of(() -> getExtensionsFrom(beanFactory)));
+		this(Lazy.of(() -> beanFactory.getBeansOfType(ExtensionIdAware.class, true, false).values()));
 
 		this.beanFactory = beanFactory;
 	}
@@ -142,12 +143,12 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		return this.extensions.get();
 	}
 
-	Collection<? extends EvaluationContextExtension> getExtensions(
+	private Collection<? extends EvaluationContextExtension> getExtensions(
 			Predicate<EvaluationContextExtensionInformation> extensionFilter) {
 
 		Collection<EvaluationContextExtension> extensionsToUse = new ArrayList<>();
 
-		for (ExtensionIdAware candidate : this.extensions.get()) {
+		for (ExtensionIdAware candidate : getExtensions()) {
 
 			if (candidate instanceof EvaluationContextExtension) {
 
@@ -159,16 +160,6 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		}
 
 		return extensionsToUse;
-	}
-
-	/**
-	 * Looks up all {@link ExtensionIdAware} instances from the given {@link ListableBeanFactory}.
-	 *
-	 * @param beanFactory must not be {@literal null}.
-	 * @return
-	 */
-	private static Collection<? extends ExtensionIdAware> getExtensionsFrom(ListableBeanFactory beanFactory) {
-		return beanFactory.getBeansOfType(ExtensionIdAware.class, true, false).values();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
@@ -99,7 +99,8 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		this.extensions = extensions;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.spel.EvaluationContextProvider#getEvaluationContext(Object)
 	 */
 	@Override
@@ -107,8 +108,9 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		return doGetEvaluationContext(rootObject, getExtensions(it -> true));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.spel.EvaluationContextProvider#getEvaluationContext(Object, Collection, ExpressionDependencies)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.spel.EvaluationContextProvider#getEvaluationContext(Object, ExpressionDependencies)
 	 */
 	@Override
 	public StandardEvaluationContext getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {

--- a/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
@@ -50,6 +50,7 @@ import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * An {@link EvaluationContextProvider} that assembles an {@link EvaluationContext} from a list of
@@ -64,7 +65,7 @@ import org.springframework.util.Assert;
  */
 public class ExtensionAwareEvaluationContextProvider implements EvaluationContextProvider {
 
-	private final Map<Class<?>, EvaluationContextExtensionInformation> extensionInformationCache = new ConcurrentHashMap<>();
+	private final Map<String, EvaluationContextExtensionInformation> extensionInformationCache = new ConcurrentHashMap<>();
 	private final Lazy<? extends Collection<? extends ExtensionIdAware>> extensions;
 
 	private ListableBeanFactory beanFactory;
@@ -181,7 +182,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	 * @return
 	 */
 	EvaluationContextExtensionInformation getOrCreateInformation(Class<? extends EvaluationContextExtension> extension) {
-		return extensionInformationCache.computeIfAbsent(extension,
+		return extensionInformationCache.computeIfAbsent(ClassUtils.getUserClass(extension).getName(),
 				type -> new EvaluationContextExtensionInformation(extension));
 	}
 

--- a/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.expression.EvaluationContext;
 public interface ReactiveEvaluationContextProvider extends EvaluationContextProvider {
 
 	/**
-	 * Returns an {@link EvaluationContext} built using the given parameter values.
+	 * Return a {@link EvaluationContext} built using the given parameter values.
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @return a mono that emits exactly one {@link EvaluationContext}.
@@ -36,10 +36,10 @@ public interface ReactiveEvaluationContextProvider extends EvaluationContextProv
 	Mono<? extends EvaluationContext> getEvaluationContextLater(Object rootObject);
 
 	/**
-	 * Returns a tailored {@link EvaluationContext} built using the given parameter values and considering
-	 * {@link ExpressionDependencies.ExpressionDependency expression dependencies}. The returned {@link EvaluationContext}
-	 * may contain a reduced visibility of methods and properties/fields according to the required
-	 * {@link ExpressionDependencies.ExpressionDependency expression dependencies}.
+	 * Return a tailored {@link EvaluationContext} built using the given parameter values and considering
+	 * {@link ExpressionDependencies expression dependencies}. The returned {@link EvaluationContext} may contain a
+	 * reduced visibility of methods and properties/fields according to the required {@link ExpressionDependencies
+	 * expression dependencies}.
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @param dependencies the requested expression dependencies to be available.

--- a/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
@@ -25,16 +25,15 @@ import org.springframework.expression.EvaluationContext;
  * @author Mark Paluch
  * @since 2.4
  */
-@FunctionalInterface
-public interface ReactiveEvaluationContextProvider {
+public interface ReactiveEvaluationContextProvider extends EvaluationContextProvider {
 
 	/**
 	 * Returns an {@link EvaluationContext} built using the given parameter values.
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
-	 * @return mono emitting the {@link EvaluationContext}.
+	 * @return a mono that emits exactly one {@link EvaluationContext}.
 	 */
-	Mono<? extends EvaluationContext> getEvaluationContext(Object rootObject);
+	Mono<? extends EvaluationContext> getEvaluationContextLater(Object rootObject);
 
 	/**
 	 * Returns a tailored {@link EvaluationContext} built using the given parameter values and considering
@@ -44,11 +43,11 @@ public interface ReactiveEvaluationContextProvider {
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @param dependencies the requested expression dependencies to be available.
-	 * @return mono emitting the {@link EvaluationContext}.
+	 * @return a mono that emits exactly one {@link EvaluationContext}.
 	 * @since 2.4
 	 */
-	default Mono<? extends EvaluationContext> getEvaluationContext(Object rootObject,
+	default Mono<? extends EvaluationContext> getEvaluationContextLater(Object rootObject,
 			ExpressionDependencies dependencies) {
-		return getEvaluationContext(rootObject);
+		return getEvaluationContextLater(rootObject);
 	}
 }

--- a/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
@@ -15,36 +15,26 @@
  */
 package org.springframework.data.spel;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
- * Provides a way to access a centrally defined potentially shared {@link StandardEvaluationContext}.
+ * Provides a way to access a centrally defined potentially shared {@link EvaluationContext}.
  *
- * @author Thomas Darimont
- * @author Oliver Gierke
- * @author Christoph Strobl
  * @author Mark Paluch
- * @since 2.1
+ * @since 2.4
  */
 @FunctionalInterface
-public interface EvaluationContextProvider {
-
-	/**
-	 * A simple default {@link EvaluationContextProvider} returning a {@link StandardEvaluationContext} with the given
-	 * root object.
-	 */
-	static EvaluationContextProvider DEFAULT = rootObject -> rootObject == null //
-			? new StandardEvaluationContext() //
-			: new StandardEvaluationContext(rootObject);
+public interface ReactiveEvaluationContextProvider {
 
 	/**
 	 * Returns an {@link EvaluationContext} built using the given parameter values.
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
-	 * @return
+	 * @return mono emitting the {@link EvaluationContext}.
 	 */
-	EvaluationContext getEvaluationContext(Object rootObject);
+	Mono<? extends EvaluationContext> getEvaluationContext(Object rootObject);
 
 	/**
 	 * Returns a tailored {@link EvaluationContext} built using the given parameter values and considering
@@ -54,10 +44,11 @@ public interface EvaluationContextProvider {
 	 *
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @param dependencies the requested expression dependencies to be available.
-	 * @return
+	 * @return mono emitting the {@link EvaluationContext}.
 	 * @since 2.4
 	 */
-	default EvaluationContext getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {
+	default Mono<? extends EvaluationContext> getEvaluationContext(Object rootObject,
+			ExpressionDependencies dependencies) {
 		return getEvaluationContext(rootObject);
 	}
 }

--- a/src/main/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProvider.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.spel;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.data.spel.spi.EvaluationContextExtension;
+import org.springframework.data.spel.spi.ExtensionIdAware;
+import org.springframework.data.spel.spi.ReactiveEvaluationContextExtension;
+import org.springframework.data.util.Lazy;
+import org.springframework.data.util.ReflectionUtils;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * A reactive {@link EvaluationContextProvider} that assembles an {@link EvaluationContext} from a list of
+ * {@link ReactiveEvaluationContextExtension} and {@link EvaluationContextExtension} instances.
+ *
+ * @author Mark Paluch
+ */
+public class ReactiveExtensionAwareEvaluationContextProvider implements ReactiveEvaluationContextProvider {
+
+	private static final ResolvableType GENERIC_EXTENSION_TYPE = ResolvableType
+			.forClass(EvaluationContextExtension.class);
+
+	private final ExtensionAwareEvaluationContextProvider evaluationContextProvider;
+
+	public ReactiveExtensionAwareEvaluationContextProvider() {
+		evaluationContextProvider = new ExtensionAwareEvaluationContextProvider();
+	}
+
+	public ReactiveExtensionAwareEvaluationContextProvider(ListableBeanFactory beanFactory) {
+		evaluationContextProvider = new ExtensionAwareEvaluationContextProvider(beanFactory);
+	}
+
+	public ReactiveExtensionAwareEvaluationContextProvider(Collection<? extends ExtensionIdAware> extensions) {
+		evaluationContextProvider = new ExtensionAwareEvaluationContextProvider(extensions);
+	}
+
+	public ReactiveExtensionAwareEvaluationContextProvider(
+			Lazy<? extends Collection<? extends ExtensionIdAware>> extensions) {
+		evaluationContextProvider = new ExtensionAwareEvaluationContextProvider(extensions);
+	}
+
+	@Override
+	public Mono<StandardEvaluationContext> getEvaluationContext(Object rootObject) {
+		return getExtensions(it -> true) //
+				.map(it -> evaluationContextProvider.doGetEvaluationContext(rootObject, it));
+	}
+
+	@Override
+	public Mono<StandardEvaluationContext> getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {
+
+		return getExtensions(it -> dependencies.stream().anyMatch(it::provides)) //
+				.map(it -> evaluationContextProvider.doGetEvaluationContext(rootObject, it));
+	}
+
+	private Mono<List<EvaluationContextExtension>> getExtensions(
+			Predicate<EvaluationContextExtensionInformation> extensionFilter) {
+
+		Collection<? extends ExtensionIdAware> extensions = evaluationContextProvider.getExtensions();
+
+		return Flux.fromIterable(extensions).concatMap(it -> {
+
+			if (it instanceof EvaluationContextExtension) {
+				EvaluationContextExtension extension = (EvaluationContextExtension) it;
+				EvaluationContextExtensionInformation information = evaluationContextProvider.getOrCreateInformation(extension);
+
+				if (extensionFilter.test(information)) {
+					return Mono.just(extension);
+				}
+			}
+
+			if (it instanceof ReactiveEvaluationContextExtension) {
+
+				ReactiveEvaluationContextExtension extension = (ReactiveEvaluationContextExtension) it;
+				ResolvableType actualType = getExtensionType(it);
+
+				if (actualType.equals(ResolvableType.NONE) || actualType.isAssignableFrom(GENERIC_EXTENSION_TYPE)) {
+					return extension.getExtension();
+				}
+
+				EvaluationContextExtensionInformation information = evaluationContextProvider
+						.getOrCreateInformation((Class) actualType.getRawClass());
+
+				if (extensionFilter.test(information)) {
+					return extension.getExtension();
+				}
+
+				return Mono.empty();
+			}
+
+			return Mono.error(new IllegalStateException("Unsupported extension type: " + it));
+		}).collectList();
+	}
+
+	private ResolvableType getExtensionType(ExtensionIdAware extensionCandidate) {
+
+		ResolvableType extensionType = ResolvableType
+				.forMethodReturnType(ReflectionUtils.findRequiredMethod(extensionCandidate.getClass(), "getExtension"))
+				.getGeneric(0);
+
+		return extensionType;
+	}
+
+}

--- a/src/main/java/org/springframework/data/spel/spi/EvaluationContextExtension.java
+++ b/src/main/java/org/springframework/data/spel/spi/EvaluationContextExtension.java
@@ -37,7 +37,7 @@ import org.springframework.lang.Nullable;
 public interface EvaluationContextExtension extends ExtensionIdAware {
 
 	/**
-	 * Returns the properties exposed by the extension.
+	 * Return the properties exposed by the extension.
 	 *
 	 * @return the properties
 	 */
@@ -46,7 +46,7 @@ public interface EvaluationContextExtension extends ExtensionIdAware {
 	}
 
 	/**
-	 * Returns the functions exposed by the extension.
+	 * Return the functions exposed by the extension.
 	 *
 	 * @return the functions
 	 */
@@ -55,11 +55,11 @@ public interface EvaluationContextExtension extends ExtensionIdAware {
 	}
 
 	/**
-	 * Returns the root object to be exposed by the extension. It's strongly recommended to declare the most concrete type
+	 * Return the root object to be exposed by the extension. It's strongly recommended to declare the most concrete type
 	 * possible as return type of the implementation method. This will allow us to obtain the necessary metadata once and
 	 * not for every evaluation.
 	 *
-	 * @return
+	 * @return the root object to be exposed by the extension.
 	 */
 	@Nullable
 	default Object getRootObject() {

--- a/src/main/java/org/springframework/data/spel/spi/EvaluationContextExtension.java
+++ b/src/main/java/org/springframework/data/spel/spi/EvaluationContextExtension.java
@@ -18,13 +18,13 @@ package org.springframework.data.spel.spi;
 import java.util.Collections;
 import java.util.Map;
 
-import org.springframework.data.repository.query.ExtensionAwareQueryMethodEvaluationContextProvider;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.lang.Nullable;
 
 /**
  * SPI to allow adding a set of properties and function definitions accessible via the root of an
- * {@link EvaluationContext} provided by a {@link ExtensionAwareQueryMethodEvaluationContextProvider}.
+ * {@link EvaluationContext} provided by an
+ * {@link org.springframework.data.repository.query.ExtensionAwareQueryMethodEvaluationContextProvider}.
  * <p>
  * Extensions can be ordered by following Spring's {@link org.springframework.core.Ordered} conventions.
  *

--- a/src/main/java/org/springframework/data/spel/spi/ExtensionIdAware.java
+++ b/src/main/java/org/springframework/data/spel/spi/ExtensionIdAware.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.spel.spi;
+
+/**
+ * Marker interface for Spring Data {@link org.springframework.expression.EvaluationContext} extensions.
+ *
+ * @author Mark Paluch
+ * @since 2.4
+ * @see EvaluationContextExtension
+ * @see ReactiveEvaluationContextExtension
+ */
+public interface ExtensionIdAware {
+
+	/**
+	 * Returns the identifier of the extension. The id can be leveraged by users to fully qualify property lookups and
+	 * thus overcome ambiguities in case multiple extensions expose properties with the same name.
+	 *
+	 * @return the extension id, must not be {@literal null}.
+	 */
+	String getExtensionId();
+}

--- a/src/main/java/org/springframework/data/spel/spi/ExtensionIdAware.java
+++ b/src/main/java/org/springframework/data/spel/spi/ExtensionIdAware.java
@@ -26,8 +26,8 @@ package org.springframework.data.spel.spi;
 public interface ExtensionIdAware {
 
 	/**
-	 * Returns the identifier of the extension. The id can be leveraged by users to fully qualify property lookups and
-	 * thus overcome ambiguities in case multiple extensions expose properties with the same name.
+	 * Return the identifier of the extension. The id can be leveraged by users to fully qualify property lookups and thus
+	 * overcome ambiguities in case multiple extensions expose properties with the same name.
 	 *
 	 * @return the extension id, must not be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/data/spel/spi/ExtensionIdAware.java
+++ b/src/main/java/org/springframework/data/spel/spi/ExtensionIdAware.java
@@ -29,7 +29,7 @@ public interface ExtensionIdAware {
 	 * Return the identifier of the extension. The id can be leveraged by users to fully qualify property lookups and thus
 	 * overcome ambiguities in case multiple extensions expose properties with the same name.
 	 *
-	 * @return the extension id, must not be {@literal null}.
+	 * @return the extension id, never {@literal null}.
 	 */
 	String getExtensionId();
 }

--- a/src/main/java/org/springframework/data/spel/spi/ReactiveEvaluationContextExtension.java
+++ b/src/main/java/org/springframework/data/spel/spi/ReactiveEvaluationContextExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,9 @@ import org.springframework.expression.EvaluationContext;
 public interface ReactiveEvaluationContextExtension extends ExtensionIdAware {
 
 	/**
-	 * Returns the {@link EvaluationContextExtension} to be consumed during the actual execution. It's strongly
-	 * recommended to declare the most concrete type possible as return type of the implementation method. This will allow
-	 * us to obtain the necessary metadata once and not for every evaluation.
+	 * Return the {@link EvaluationContextExtension} to be consumed during the actual execution. It's strongly recommended
+	 * to declare the most concrete type possible as return type of the implementation method. This will allow us to
+	 * obtain the necessary metadata once and not for every evaluation.
 	 *
 	 * @return the resolved {@link EvaluationContextExtension}. Publishers emitting no value will be skipped.
 	 */

--- a/src/main/java/org/springframework/data/spel/spi/ReactiveEvaluationContextExtension.java
+++ b/src/main/java/org/springframework/data/spel/spi/ReactiveEvaluationContextExtension.java
@@ -15,54 +15,31 @@
  */
 package org.springframework.data.spel.spi;
 
-import java.util.Collections;
-import java.util.Map;
+import reactor.core.publisher.Mono;
 
 import org.springframework.data.repository.query.ExtensionAwareQueryMethodEvaluationContextProvider;
 import org.springframework.expression.EvaluationContext;
-import org.springframework.lang.Nullable;
 
 /**
- * SPI to allow adding a set of properties and function definitions accessible via the root of an
+ * SPI to resolve a {@link EvaluationContextExtension} to make it accessible via the root of an
  * {@link EvaluationContext} provided by a {@link ExtensionAwareQueryMethodEvaluationContextProvider}.
  * <p>
  * Extensions can be ordered by following Spring's {@link org.springframework.core.Ordered} conventions.
  *
- * @author Thomas Darimont
- * @author Oliver Gierke
- * @since 1.9
+ * @author Mark Paluch
+ * @since 2.4
+ * @see EvaluationContextExtension
  * @see org.springframework.core.Ordered
  * @see org.springframework.core.annotation.Order
  */
-public interface EvaluationContextExtension extends ExtensionIdAware {
+public interface ReactiveEvaluationContextExtension extends ExtensionIdAware {
 
 	/**
-	 * Returns the properties exposed by the extension.
+	 * Returns the {@link EvaluationContextExtension} to be consumed during the actual execution. It's strongly
+	 * recommended to declare the most concrete type possible as return type of the implementation method. This will allow
+	 * us to obtain the necessary metadata once and not for every evaluation.
 	 *
-	 * @return the properties
+	 * @return the resolved {@link EvaluationContextExtension}. Publishers emitting no value will be skipped.
 	 */
-	default Map<String, Object> getProperties() {
-		return Collections.emptyMap();
-	}
-
-	/**
-	 * Returns the functions exposed by the extension.
-	 *
-	 * @return the functions
-	 */
-	default Map<String, Function> getFunctions() {
-		return Collections.emptyMap();
-	}
-
-	/**
-	 * Returns the root object to be exposed by the extension. It's strongly recommended to declare the most concrete type
-	 * possible as return type of the implementation method. This will allow us to obtain the necessary metadata once and
-	 * not for every evaluation.
-	 *
-	 * @return
-	 */
-	@Nullable
-	default Object getRootObject() {
-		return null;
-	}
+	Mono<? extends EvaluationContextExtension> getExtension();
 }

--- a/src/main/java/org/springframework/data/spel/spi/ReactiveEvaluationContextExtension.java
+++ b/src/main/java/org/springframework/data/spel/spi/ReactiveEvaluationContextExtension.java
@@ -17,12 +17,12 @@ package org.springframework.data.spel.spi;
 
 import reactor.core.publisher.Mono;
 
-import org.springframework.data.repository.query.ExtensionAwareQueryMethodEvaluationContextProvider;
 import org.springframework.expression.EvaluationContext;
 
 /**
  * SPI to resolve a {@link EvaluationContextExtension} to make it accessible via the root of an
- * {@link EvaluationContext} provided by a {@link ExtensionAwareQueryMethodEvaluationContextProvider}.
+ * {@link EvaluationContext} provided by a
+ * {@link org.springframework.data.repository.query.ExtensionAwareQueryMethodEvaluationContextProvider}.
  * <p>
  * Extensions can be ordered by following Spring's {@link org.springframework.core.Ordered} conventions.
  *

--- a/src/test/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ExtensionAwareEvaluationContextProviderUnitTests.java
@@ -42,6 +42,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
 import org.springframework.data.spel.spi.EvaluationContextExtension;
+import org.springframework.data.spel.spi.ExtensionIdAware;
 import org.springframework.data.spel.spi.Function;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -296,7 +297,7 @@ class ExtensionAwareEvaluationContextProviderUnitTests {
 
 		contextProvider.getEvaluationContext(null);
 
-		verify(beanFactory).getBeansOfType(eq(EvaluationContextExtension.class), anyBoolean(), anyBoolean());
+		verify(beanFactory).getBeansOfType(eq(ExtensionIdAware.class), anyBoolean(), anyBoolean());
 	}
 
 	@Test // DATACMNS-1534
@@ -309,7 +310,7 @@ class ExtensionAwareEvaluationContextProviderUnitTests {
 		contextProvider.getEvaluationContext(null);
 		contextProvider.getEvaluationContext(null);
 
-		verify(beanFactory).getBeansOfType(eq(EvaluationContextExtension.class), anyBoolean(), anyBoolean());
+		verify(beanFactory).getBeansOfType(eq(ExtensionIdAware.class), anyBoolean(), anyBoolean());
 	}
 
 	private static ExtensionAwareQueryMethodEvaluationContextProvider createContextProviderWithOverloads() {

--- a/src/test/java/org/springframework/data/spel/ExpressionDependenciesUnitTests.java
+++ b/src/test/java/org/springframework/data/spel/ExpressionDependenciesUnitTests.java
@@ -30,9 +30,9 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  */
 class ExpressionDependenciesUnitTests {
 
-	SpelExpressionParser PARSER = new SpelExpressionParser();
+	static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
-	@Test
+	@Test // DATACMNS-1108
 	void shouldExtractDependencies() {
 
 		String expression = "hasRole('ROLE_ADMIN') ? '%' : principal.emailAddress";
@@ -46,7 +46,7 @@ class ExpressionDependenciesUnitTests {
 				"principal");
 	}
 
-	@Test
+	@Test // DATACMNS-1108
 	void shouldExtractDependenciesFromMethodCallArgs() {
 
 		String expression = "hasRole(principal.emailAddress)";
@@ -60,7 +60,7 @@ class ExpressionDependenciesUnitTests {
 				"principal");
 	}
 
-	@Test
+	@Test // DATACMNS-1108
 	void shouldExtractFirstMethodAsDependency() {
 
 		String expression = "hello().hasRole(principal.emailAddress, principal.somethingElse).somethingElse()";
@@ -74,4 +74,13 @@ class ExpressionDependenciesUnitTests {
 				"principal");
 	}
 
+	@Test // DATACMNS-1108
+	void shouldMergeDependencies() {
+
+		ExpressionDependencies left = ExpressionDependencies.discover(PARSER.parseExpression("hasRole('ROLE_ADMIN')"));
+		ExpressionDependencies right = ExpressionDependencies.discover(PARSER.parseExpression("principal.somethingElse"));
+
+		assertThat(left.mergeWith(right)).extracting(ExpressionDependencies.ExpressionDependency::getSymbol)
+				.containsOnly("hasRole", "principal");
+	}
 }

--- a/src/test/java/org/springframework/data/spel/ExpressionDependenciesUnitTests.java
+++ b/src/test/java/org/springframework/data/spel/ExpressionDependenciesUnitTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.spel;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.expression.spel.SpelNode;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+/**
+ * Unit tests for {@link ExpressionDependencies}.
+ *
+ * @author Mark Paluch
+ */
+class ExpressionDependenciesUnitTests {
+
+	SpelExpressionParser PARSER = new SpelExpressionParser();
+
+	@Test
+	void shouldExtractDependencies() {
+
+		String expression = "hasRole('ROLE_ADMIN') ? '%' : principal.emailAddress";
+
+		SpelExpression spelExpression = (SpelExpression) PARSER.parseExpression(expression);
+		SpelNode ast = spelExpression.getAST();
+
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(ast, true);
+
+		assertThat(dependencies).extracting(ExpressionDependencies.ExpressionDependency::getSymbol).containsOnly("hasRole",
+				"principal");
+	}
+
+	@Test
+	void shouldExtractDependenciesFromMethodCallArgs() {
+
+		String expression = "hasRole(principal.emailAddress)";
+
+		SpelExpression spelExpression = (SpelExpression) PARSER.parseExpression(expression);
+		SpelNode ast = spelExpression.getAST();
+
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(ast, true);
+
+		assertThat(dependencies).extracting(ExpressionDependencies.ExpressionDependency::getSymbol).containsOnly("hasRole",
+				"principal");
+	}
+
+	@Test
+	void shouldExtractFirstMethodAsDependency() {
+
+		String expression = "hello().hasRole(principal.emailAddress, principal.somethingElse).somethingElse()";
+
+		SpelExpression spelExpression = (SpelExpression) PARSER.parseExpression(expression);
+		SpelNode ast = spelExpression.getAST();
+
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(ast, true);
+
+		assertThat(dependencies).extracting(ExpressionDependencies.ExpressionDependency::getSymbol).containsOnly("hello",
+				"principal");
+	}
+
+}

--- a/src/test/java/org/springframework/data/spel/ExpressionDependenciesUnitTests.java
+++ b/src/test/java/org/springframework/data/spel/ExpressionDependenciesUnitTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.spel;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.expression.spel.SpelNode;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -27,6 +26,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * Unit tests for {@link ExpressionDependencies}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ExpressionDependenciesUnitTests {
 
@@ -72,6 +72,20 @@ class ExpressionDependenciesUnitTests {
 
 		assertThat(dependencies).extracting(ExpressionDependencies.ExpressionDependency::getSymbol).containsOnly("hello",
 				"principal");
+	}
+
+	@Test // DATACMNS-1108
+	void shouldExtractAll() {
+
+		String expression = "hello().hasRole(principal.emailAddress, principal.somethingElse).somethingElse()";
+
+		SpelExpression spelExpression = (SpelExpression) PARSER.parseExpression(expression);
+		SpelNode ast = spelExpression.getAST();
+
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(ast, false);
+
+		assertThat(dependencies).extracting(ExpressionDependencies.ExpressionDependency::getSymbol).containsOnly("hello",
+				"hasRole", "principal", "emailAddress", "somethingElse");
 	}
 
 	@Test // DATACMNS-1108

--- a/src/test/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProviderUnitTests.java
@@ -57,7 +57,7 @@ class ReactiveExtensionAwareEvaluationContextProviderUnitTests {
 		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
 				Arrays.asList(SampleReactiveExtension.INSTANCE, GenericExtension.INSTANCE));
 
-		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+		provider.getEvaluationContextLater(new Object[0], dependencies).map(expression::getValue) //
 				.as(StepVerifier::create) //
 				.expectNext("Walter") //
 				.verifyComplete();
@@ -75,7 +75,7 @@ class ReactiveExtensionAwareEvaluationContextProviderUnitTests {
 		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
 				Arrays.asList(SampleReactiveExtension.INSTANCE, GenericExtension.INSTANCE));
 
-		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+		provider.getEvaluationContextLater(new Object[0], dependencies).map(expression::getValue) //
 				.as(StepVerifier::create) //
 				.expectNext(true) //
 				.verifyComplete();
@@ -93,7 +93,7 @@ class ReactiveExtensionAwareEvaluationContextProviderUnitTests {
 		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
 				Arrays.asList(SampleReactiveExtension.INSTANCE, GenericExtension.INSTANCE));
 
-		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+		provider.getEvaluationContextLater(new Object[0], dependencies).map(expression::getValue) //
 				.as(StepVerifier::create) //
 				.verifyError(SpelEvaluationException.class);
 
@@ -110,7 +110,7 @@ class ReactiveExtensionAwareEvaluationContextProviderUnitTests {
 		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
 				Collections.singletonList(GenericReactiveExtension.INSTANCE));
 
-		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+		provider.getEvaluationContextLater(new Object[0], dependencies).map(expression::getValue) //
 				.as(StepVerifier::create) //
 				.expectNext(2) //
 				.verifyComplete();

--- a/src/test/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProviderUnitTests.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.spel;
+
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.spel.spi.EvaluationContextExtension;
+import org.springframework.data.spel.spi.ReactiveEvaluationContextExtension;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+/**
+ * Unit tests for {@link ReactiveExtensionAwareEvaluationContextProvider}.
+ *
+ * @author Mark Paluch
+ */
+class ReactiveExtensionAwareEvaluationContextProviderUnitTests {
+
+	SpelExpressionParser PARSER = new SpelExpressionParser();
+
+	@BeforeEach
+	void beforeEach() {
+		GenericModelRoot.creationCounter.set(0);
+		SecurityExpressionRoot.creationCounter.set(0);
+	}
+
+	@Test // DATACMNS-1108
+	void shouldResolveExtension() {
+
+		Expression expression = PARSER.parseExpression("hasRole('ROLE_ADMIN') ? '%' : principal.name");
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(expression);
+
+		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
+				Arrays.asList(SampleReactiveExtension.INSTANCE, GenericExtension.INSTANCE));
+
+		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+				.as(StepVerifier::create) //
+				.expectNext("Walter") //
+				.verifyComplete();
+
+		assertThat(GenericModelRoot.creationCounter).hasValue(1);
+		assertThat(SecurityExpressionRoot.creationCounter).hasValue(1);
+	}
+
+	@Test // DATACMNS-1108
+	void shouldLoadGenericExtensionOnly() {
+
+		Expression expression = PARSER.parseExpression("isKnown('FOO')");
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(expression);
+
+		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
+				Arrays.asList(SampleReactiveExtension.INSTANCE, GenericExtension.INSTANCE));
+
+		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+				.as(StepVerifier::create) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		assertThat(GenericModelRoot.creationCounter).hasValue(1);
+		assertThat(SecurityExpressionRoot.creationCounter).hasValue(0);
+	}
+
+	@Test // DATACMNS-1108
+	void unknownMethodShouldLoadGenericExtensionOnly() {
+
+		Expression expression = PARSER.parseExpression("unknown('FOO')");
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(expression);
+
+		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
+				Arrays.asList(SampleReactiveExtension.INSTANCE, GenericExtension.INSTANCE));
+
+		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+				.as(StepVerifier::create) //
+				.verifyError(SpelEvaluationException.class);
+
+		assertThat(GenericModelRoot.creationCounter).hasValue(1);
+		assertThat(SecurityExpressionRoot.creationCounter).hasValue(0);
+	}
+
+	@Test // DATACMNS-1108
+	void genericReactiveExtensionIsAlwaysObtained() {
+
+		Expression expression = PARSER.parseExpression("1+1");
+		ExpressionDependencies dependencies = ExpressionDependencies.discover(expression);
+
+		ReactiveExtensionAwareEvaluationContextProvider provider = new ReactiveExtensionAwareEvaluationContextProvider(
+				Collections.singletonList(GenericReactiveExtension.INSTANCE));
+
+		provider.getEvaluationContext(new Object[0], dependencies).map(expression::getValue) //
+				.as(StepVerifier::create) //
+				.expectNext(2) //
+				.verifyComplete();
+
+		assertThat(GenericModelRoot.creationCounter).hasValue(1);
+	}
+
+	/**
+	 * Sample reactive extension exposing a concrete type.
+	 */
+	enum SampleReactiveExtension implements ReactiveEvaluationContextExtension {
+
+		INSTANCE;
+
+		@Override
+		public Mono<ExpressiveExtension> getExtension() {
+			return Mono.just(ExpressiveExtension.INSTANCE);
+		}
+
+		@Override
+		public String getExtensionId() {
+			return "reactive";
+		}
+	}
+
+	/**
+	 * Sample reactive extension exposing a generic type.
+	 */
+	enum GenericReactiveExtension implements ReactiveEvaluationContextExtension {
+
+		INSTANCE;
+
+		@Override
+		public Mono<EvaluationContextExtension> getExtension() {
+			return Mono.just(GenericExtension.INSTANCE);
+		}
+
+		@Override
+		public String getExtensionId() {
+			return "reactive";
+		}
+	}
+
+	/**
+	 * Extension exposing a concrete root object type.
+	 */
+	enum ExpressiveExtension implements EvaluationContextExtension {
+
+		INSTANCE;
+
+		@Override
+		public String getExtensionId() {
+			return "expressive";
+		}
+
+		@Override
+		public SecurityExpressionRoot getRootObject() {
+			return new SecurityExpressionRoot();
+		}
+	}
+
+	/**
+	 * Extension without exposing a concrete extension type.
+	 */
+	enum GenericExtension implements EvaluationContextExtension {
+
+		INSTANCE;
+
+		@Override
+		public String getExtensionId() {
+			return "generic";
+		}
+
+		@Override
+		public Object getRootObject() {
+			return new GenericModelRoot();
+		}
+	}
+
+	public static class GenericModelRoot {
+
+		static AtomicInteger creationCounter = new AtomicInteger();
+
+		GenericModelRoot() {
+			creationCounter.incrementAndGet();
+		}
+
+		public boolean isKnown(String role) {
+			return role.equals("FOO");
+		}
+	}
+
+	public static class SecurityExpressionRoot {
+
+		static AtomicInteger creationCounter = new AtomicInteger();
+
+		SecurityExpressionRoot() {
+			creationCounter.incrementAndGet();
+		}
+
+		public boolean hasRole(String role) {
+			return role.equals("ADMIN");
+		}
+
+		public Object getPrincipal() {
+			return new MyPrincipal();
+		}
+	}
+
+	static class MyPrincipal {
+
+		public String getName() {
+			return "Walter";
+		}
+	}
+}


### PR DESCRIPTION
We now support reactive SpEL extensions through `ReactiveEvaluationContextExtension` so that reactive query methods can make use of extensions that participate in the reactive flow.

---

Related ticket: DATACMNS-1108