### PR TITLE
DATACMNS-1762 - Support JDK Optional as return type in projections

### DIFF
--- a/src/main/java/org/springframework/data/projection/ProjectingMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/projection/ProjectingMethodInterceptor.java
@@ -16,11 +16,7 @@
 package org.springframework.data.projection;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import javax.annotation.Nonnull;
@@ -69,12 +65,15 @@ class ProjectingMethodInterceptor implements MethodInterceptor {
 
 		Object result = delegate.invoke(invocation);
 
-		if (result == null) {
-			return null;
-		}
-
 		TypeInformation<?> type = ClassTypeInformation.fromReturnTypeOf(invocation.getMethod());
 		Class<?> rawType = type.getType();
+
+		if (result == null) {
+			if(rawType == Optional.class ) {
+				return Optional.empty();
+			}
+			return null;
+		}
 
 		if (type.isCollectionLike() && !ClassUtils.isPrimitiveArray(rawType)) {
 			return projectCollectionElements(asCollection(result), type);

--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
@@ -27,7 +27,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.GenericConversionService;
-import org.springframework.data.repository.util.NullableWrapper;
+import org.springframework.data.util.NullableWrapper;
 import org.springframework.data.repository.util.QueryExecutionConverters;
 import org.springframework.data.repository.util.ReactiveWrapperConverters;
 import org.springframework.data.util.Streamable;

--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -366,7 +366,7 @@ public abstract class QueryExecutionConverters {
 		public Set<ConvertiblePair> getConvertibleTypes() {
 
 			return Streamable.of(wrapperTypes)//
-					.map(it -> new ConvertiblePair(NullableWrapper.class, it))//
+					.map(it -> new ConvertiblePair(org.springframework.data.util.NullableWrapper.class, it))//
 					.stream().collect(StreamUtils.toUnmodifiableSet());
 		}
 
@@ -382,7 +382,7 @@ public abstract class QueryExecutionConverters {
 				return null;
 			}
 
-			NullableWrapper wrapper = (NullableWrapper) source;
+			org.springframework.data.util.NullableWrapper wrapper = (org.springframework.data.util.NullableWrapper) source;
 			Object value = wrapper.getValue();
 
 			// TODO: Add Recursive conversion once we move to Spring 4

--- a/src/main/java/org/springframework/data/util/NullableWrapper.java
+++ b/src/main/java/org/springframework/data/util/NullableWrapper.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.util;
+package org.springframework.data.util;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.repository.util.QueryExecutionConverters;
+import org.springframework.lang.Nullable;
 
 /**
  * Simple value object to wrap a nullable delegate. Used to be able to write {@link Converter} implementations that
@@ -24,17 +26,39 @@ import org.springframework.core.convert.converter.Converter;
  * @author Oliver Gierke
  * @since 1.8
  * @see QueryExecutionConverters
- * @deprecated use {@link org.springframework.data.util.NullableWrapper} instead.
  */
-@Deprecated
-public class NullableWrapper extends org.springframework.data.util.NullableWrapper {
+public class NullableWrapper {
+
+	private final @Nullable Object value;
 
 	/**
 	 * Creates a new {@link NullableWrapper} for the given value.
 	 *
 	 * @param value can be {@literal null}.
 	 */
-	public NullableWrapper(Object value) {
-		super(value);
+	public NullableWrapper(@Nullable Object value) {
+		this.value = value;
+	}
+
+	/**
+	 * Returns the type of the contained value. WIll fall back to {@link Object} in case the value is {@literal null}.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	public Class<?> getValueType() {
+
+		Object value = this.value;
+
+		return value == null ? Object.class : value.getClass();
+	}
+
+	/**
+	 * Returns the backing value.
+	 *
+	 * @return the value can be {@literal null}.
+	 */
+	@Nullable
+	public Object getValue() {
+		return value;
 	}
 }

--- a/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
@@ -131,20 +131,20 @@ class QueryExecutionConvertersUnitTests {
 
 	@Test // DATACMNS-483
 	void turnsNullIntoGuavaOptional() {
-		assertThat(conversionService.convert(new NullableWrapper(null), Optional.class)).isEqualTo(Optional.absent());
+		assertThat(conversionService.convert(new org.springframework.data.util.NullableWrapper(null), Optional.class)).isEqualTo(Optional.absent());
 	}
 
 	@Test // DATACMNS-483
 	@SuppressWarnings("unchecked")
 	void turnsNullIntoJdk8Optional() {
-		assertThat(conversionService.convert(new NullableWrapper(null), java.util.Optional.class)).isEmpty();
+		assertThat(conversionService.convert(new org.springframework.data.util.NullableWrapper(null), java.util.Optional.class)).isEmpty();
 	}
 
 	@Test // DATACMNS-714
 	@SuppressWarnings("unchecked")
 	void turnsNullIntoCompletableFutureForNull() throws Exception {
 
-		CompletableFuture<Object> result = conversionService.convert(new NullableWrapper(null), CompletableFuture.class);
+		CompletableFuture<Object> result = conversionService.convert(new org.springframework.data.util.NullableWrapper(null), CompletableFuture.class);
 
 		assertThat(result).isNotNull();
 		assertThat(result.isDone()).isTrue();
@@ -173,7 +173,7 @@ class QueryExecutionConvertersUnitTests {
 
 	@Test // DATACMNS-795
 	void turnsNullIntoScalaOptionEmpty() {
-		assertThat(conversionService.convert(new NullableWrapper(null), Option.class)).isEqualTo(Option.empty());
+		assertThat(conversionService.convert(new org.springframework.data.util.NullableWrapper(null), Option.class)).isEqualTo(Option.empty());
 	}
 
 	@Test // DATACMNS-795


### PR DESCRIPTION
This commit adds 3 unit tests for using a JDK Optional as return
type in a projection. 2 of them are working with a minimal change
to ProjectingMethodInterceptor although I wonder if the change is
ok like that, or if the Optional creation should be delegated to
the conversionService.

1 unit test is failing: if the Optional is typed to another projection,
the Optional does not contain the projection, leading to a ClassCastException.

Could somebody give a tip where to best fix that Optional-with-projection fail?

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


