### PR TITLE
DATACMNS-1762 - Support Optional wrapping for projection getters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATACMNS-1762-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/asciidoc/repository-projections.adoc
+++ b/src/main/asciidoc/repository-projections.adoc
@@ -197,6 +197,30 @@ interface NamesOnly {
 
 Again, for more complex expressions, you should use a Spring bean and let the expression invoke a method, as described  <<projections.interfaces.open.bean-reference,earlier>>.
 
+[[projections.interfaces.nullable-wrappers]]
+=== Nullable Wrappers
+
+Getters in projection interfaces can make use of nullable wrappers for improved null-safety. Currently supported wrapper types are:
+
+* `java.util.Optional`
+* `com.google.common.base.Optional`
+* `scala.Option`
+* `io.vavr.control.Option`
+
+.A projection interface using nullable wrappers
+====
+[source, java]
+----
+interface NamesOnly {
+
+  Optional<String> getFirstname();
+}
+----
+====
+
+If the underlying projection value is not `null`, then values are returned using the present-representation of the wrapper type.
+In case the backing value is `null`, then the getter method returns the empty representation of the used wrapper type.
+
 [[projections.dtos]]
 == Class-based Projections (DTOs)
 

--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -27,6 +27,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.CrudMethods;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.util.QueryExecutionConverters;
+import org.springframework.data.repository.util.ReactiveWrapperConverters;
 import org.springframework.data.repository.util.ReactiveWrappers;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.KotlinReflectionUtils;
@@ -105,7 +106,14 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	 * @see org.springframework.data.repository.core.RepositoryMetadata#getReturnedDomainClass(java.lang.reflect.Method)
 	 */
 	public Class<?> getReturnedDomainClass(Method method) {
-		return QueryExecutionConverters.unwrapWrapperTypes(getReturnType(method)).getType();
+
+		TypeInformation<?> returnType = getReturnType(method);
+
+		if (ReactiveWrapperConverters.supports(returnType.getType())) {
+			return ReactiveWrapperConverters.unwrapWrapperTypes(returnType).getType();
+		}
+
+		return QueryExecutionConverters.unwrapWrapperTypes(returnType).getType();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/repository/core/support/MethodLookups.java
+++ b/src/main/java/org/springframework/data/repository/core/support/MethodLookups.java
@@ -38,6 +38,7 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.MethodLookup.MethodPredicate;
 import org.springframework.data.repository.util.QueryExecutionConverters;
 import org.springframework.data.repository.util.ReactiveWrapperConverters;
+import org.springframework.data.repository.util.ReactiveWrappers;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -299,8 +300,7 @@ interface MethodLookups {
 
 			Assert.notNull(parameterType, "Parameter type must not be null!");
 
-			return QueryExecutionConverters.supports(parameterType)
-					&& !QueryExecutionConverters.supportsUnwrapping(parameterType);
+			return ReactiveWrappers.supports(parameterType);
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutionResultHandler.java
@@ -27,9 +27,9 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.GenericConversionService;
-import org.springframework.data.repository.util.NullableWrapper;
 import org.springframework.data.repository.util.QueryExecutionConverters;
 import org.springframework.data.repository.util.ReactiveWrapperConverters;
+import org.springframework.data.util.NullableWrapper;
 import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 

--- a/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/QueryExecutionConverters.java
@@ -168,10 +168,6 @@ public abstract class QueryExecutionConverters {
 				}
 			}
 
-			if (ReactiveWrappers.supports(type)) {
-				return true;
-			}
-
 			return false;
 		});
 	}

--- a/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
@@ -44,6 +44,7 @@ import org.springframework.core.convert.converter.ConverterFactory;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.repository.util.ReactiveWrappers.ReactiveLibrary;
+import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -147,6 +148,21 @@ public abstract class ReactiveWrapperConverters {
 	public static boolean supports(Class<?> type) {
 		return RegistryHolder.REACTIVE_ADAPTER_REGISTRY != null
 				&& RegistryHolder.REACTIVE_ADAPTER_REGISTRY.getAdapter(type) != null;
+	}
+
+	/**
+	 * Recursively unwraps well known wrapper types from the given {@link TypeInformation}.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return will never be {@literal null}.
+	 */
+	public static TypeInformation<?> unwrapWrapperTypes(TypeInformation<?> type) {
+
+		Assert.notNull(type, "type must not be null");
+
+		Class<?> rawType = type.getType();
+
+		return supports(rawType) ? unwrapWrapperTypes(type.getRequiredComponentType()) : type;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
+++ b/src/main/java/org/springframework/data/repository/util/ReactiveWrapperConverters.java
@@ -155,6 +155,7 @@ public abstract class ReactiveWrapperConverters {
 	 *
 	 * @param type must not be {@literal null}.
 	 * @return will never be {@literal null}.
+	 * @since 2.4
 	 */
 	public static TypeInformation<?> unwrapWrapperTypes(TypeInformation<?> type) {
 

--- a/src/main/java/org/springframework/data/util/NullableWrapper.java
+++ b/src/main/java/org/springframework/data/util/NullableWrapper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.util;
+package org.springframework.data.util;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.Nullable;
@@ -24,12 +24,12 @@ import org.springframework.lang.Nullable;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
- * @since 1.8
- * @see QueryExecutionConverters
- * @deprecated since 2.4, use {@link org.springframework.data.util.NullableWrapper} instead.
+ * @since 2.4
+ * @see NullableWrapperConverters
  */
-@Deprecated
-public class NullableWrapper extends org.springframework.data.util.NullableWrapper {
+public class NullableWrapper {
+
+	private final @Nullable Object value;
 
 	/**
 	 * Creates a new {@link NullableWrapper} for the given value.
@@ -37,6 +37,28 @@ public class NullableWrapper extends org.springframework.data.util.NullableWrapp
 	 * @param value can be {@literal null}.
 	 */
 	public NullableWrapper(@Nullable Object value) {
-		super(value);
+		this.value = value;
+	}
+
+	/**
+	 * Returns the type of the contained value. WIll fall back to {@link Object} in case the value is {@literal null}.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	public Class<?> getValueType() {
+
+		Object value = this.value;
+
+		return value == null ? Object.class : value.getClass();
+	}
+
+	/**
+	 * Returns the backing value.
+	 *
+	 * @return the value can be {@literal null}.
+	 */
+	@Nullable
+	public Object getValue() {
+		return value;
 	}
 }

--- a/src/main/java/org/springframework/data/util/NullableWrapperConverters.java
+++ b/src/main/java/org/springframework/data/util/NullableWrapperConverters.java
@@ -494,7 +494,7 @@ public abstract class NullableWrapperConverters {
 		}
 	}
 
-	public static final class WrapperType {
+	private static final class WrapperType {
 
 		private WrapperType(Class<?> type, Cardinality cardinality) {
 			this.type = type;

--- a/src/main/java/org/springframework/data/util/NullableWrapperConverters.java
+++ b/src/main/java/org/springframework/data/util/NullableWrapperConverters.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.util;
+
+import scala.Function0;
+import scala.Option;
+import scala.runtime.AbstractFunction0;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterRegistry;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ObjectUtils;
+
+import com.google.common.base.Optional;
+
+/**
+ * Converters to wrap and unwrap nullable wrapper types potentially being available on the classpath. Currently
+ * supported:
+ * <ul>
+ * <li>{@code java.util.Optional}</li>
+ * <li>{@code com.google.common.base.Optional}</li>
+ * <li>{@code scala.Option}</li>
+ * <li>{@code javaslang.control.Option}</li>
+ * <li>{@code io.vavr.control.Option}</li>
+ * </ul>
+ *
+ * @author Oliver Gierke
+ * @author Mark Paluch
+ * @author Christoph Strobl
+ * @author Maciek Opała
+ * @author Jens Schauder
+ * @since 2.4
+ */
+public abstract class NullableWrapperConverters {
+
+	private static final boolean GUAVA_PRESENT = ClassUtils.isPresent("com.google.common.base.Optional",
+			NullableWrapperConverters.class.getClassLoader());
+	private static final boolean SCALA_PRESENT = ClassUtils.isPresent("scala.Option",
+			NullableWrapperConverters.class.getClassLoader());
+	private static final boolean VAVR_PRESENT = ClassUtils.isPresent("io.vavr.control.Option",
+			NullableWrapperConverters.class.getClassLoader());
+
+	private static final Set<WrapperType> WRAPPER_TYPES = new HashSet<WrapperType>();
+	private static final Set<WrapperType> UNWRAPPER_TYPES = new HashSet<WrapperType>();
+	private static final Set<Converter<Object, Object>> UNWRAPPERS = new HashSet<Converter<Object, Object>>();
+	private static final Map<Class<?>, Boolean> supportsCache = new ConcurrentReferenceHashMap<>();
+
+	static {
+
+		WRAPPER_TYPES.add(NullableWrapperToJdk8OptionalConverter.getWrapperType());
+		UNWRAPPER_TYPES.add(NullableWrapperToJdk8OptionalConverter.getWrapperType());
+		UNWRAPPERS.add(Jdk8OptionalUnwrapper.INSTANCE);
+
+		if (GUAVA_PRESENT) {
+			WRAPPER_TYPES.add(NullableWrapperToGuavaOptionalConverter.getWrapperType());
+			UNWRAPPER_TYPES.add(NullableWrapperToGuavaOptionalConverter.getWrapperType());
+			UNWRAPPERS.add(GuavaOptionalUnwrapper.INSTANCE);
+		}
+
+		if (SCALA_PRESENT) {
+			WRAPPER_TYPES.add(NullableWrapperToScalaOptionConverter.getWrapperType());
+			UNWRAPPER_TYPES.add(NullableWrapperToScalaOptionConverter.getWrapperType());
+			UNWRAPPERS.add(ScalOptionUnwrapper.INSTANCE);
+		}
+
+		if (VAVR_PRESENT) {
+			WRAPPER_TYPES.add(NullableWrapperToVavrOptionConverter.getWrapperType());
+			UNWRAPPERS.add(VavrOptionUnwrapper.INSTANCE);
+		}
+	}
+
+	private NullableWrapperConverters() {}
+
+	/**
+	 * Returns whether the given type is a supported wrapper type.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return
+	 */
+	public static boolean supports(Class<?> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+
+		return supportsCache.computeIfAbsent(type, key -> {
+
+			for (WrapperType candidate : WRAPPER_TYPES) {
+				if (candidate.getType().isAssignableFrom(key)) {
+					return true;
+				}
+			}
+
+			return false;
+		});
+	}
+
+	/**
+	 * Returns whether the given wrapper type supports unwrapping.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return
+	 */
+	public static boolean supportsUnwrapping(Class<?> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+
+		for (WrapperType candidate : UNWRAPPER_TYPES) {
+			if (candidate.getType().isAssignableFrom(type)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static boolean isSingleValue(Class<?> type) {
+
+		for (WrapperType candidate : WRAPPER_TYPES) {
+			if (candidate.getType().isAssignableFrom(type)) {
+				return candidate.isSingleValue();
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Registers converters for wrapper types found on the classpath.
+	 *
+	 * @param registry must not be {@literal null}.
+	 */
+	public static void registerConvertersIn(ConverterRegistry registry) {
+
+		Assert.notNull(registry, "ConversionService must not be null!");
+
+		registry.addConverter(NullableWrapperToJdk8OptionalConverter.INSTANCE);
+
+		if (GUAVA_PRESENT) {
+			registry.addConverter(NullableWrapperToGuavaOptionalConverter.INSTANCE);
+		}
+
+		if (SCALA_PRESENT) {
+			registry.addConverter(NullableWrapperToScalaOptionConverter.INSTANCE);
+		}
+
+		if (VAVR_PRESENT) {
+			registry.addConverter(NullableWrapperToVavrOptionConverter.INSTANCE);
+		}
+	}
+
+	/**
+	 * Unwraps the given source value in case it's one of the currently supported wrapper types detected at runtime.
+	 *
+	 * @param source can be {@literal null}.
+	 * @return
+	 */
+	@Nullable
+	public static Object unwrap(@Nullable Object source) {
+
+		if (source == null || !supports(source.getClass())) {
+			return source;
+		}
+
+		for (Converter<Object, Object> converter : UNWRAPPERS) {
+
+			Object result = converter.convert(source);
+
+			if (result != source) {
+				return result;
+			}
+		}
+
+		return source;
+	}
+
+	/**
+	 * Recursively unwraps well known wrapper types from the given {@link TypeInformation}.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @return will never be {@literal null}.
+	 */
+	public static TypeInformation<?> unwrapActualType(TypeInformation<?> type) {
+
+		Assert.notNull(type, "type must not be null");
+
+		Class<?> rawType = type.getType();
+
+		boolean needToUnwrap = supports(rawType) //
+				|| Stream.class.isAssignableFrom(rawType);
+
+		return needToUnwrap ? unwrapActualType(type.getRequiredComponentType()) : type;
+	}
+
+	/**
+	 * Base class for converters that create instances of wrapper types such as Google Guava's and JDK 8's
+	 * {@code Optional} types.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private static abstract class AbstractWrapperTypeConverter implements GenericConverter {
+
+		private final Object nullValue;
+		private final Iterable<Class<?>> wrapperTypes;
+
+		/**
+		 * Creates a new {@link AbstractWrapperTypeConverter} using the given wrapper type.
+		 *
+		 * @param conversionService must not be {@literal null}.
+		 * @param nullValue must not be {@literal null}.
+		 */
+		protected AbstractWrapperTypeConverter(Object nullValue) {
+
+			Assert.notNull(nullValue, "Null value must not be null!");
+
+			this.nullValue = nullValue;
+			this.wrapperTypes = Collections.singleton(nullValue.getClass());
+		}
+
+		public AbstractWrapperTypeConverter(Object nullValue, Iterable<Class<?>> wrapperTypes) {
+			this.nullValue = nullValue;
+			this.wrapperTypes = wrapperTypes;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.GenericConverter#getConvertibleTypes()
+		 */
+		@Override
+		public Set<ConvertiblePair> getConvertibleTypes() {
+
+			return Streamable.of(wrapperTypes)//
+					.map(it -> new ConvertiblePair(NullableWrapper.class, it))//
+					.stream().collect(StreamUtils.toUnmodifiableSet());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.GenericConverter#convert(java.lang.Object, org.springframework.core.convert.TypeDescriptor, org.springframework.core.convert.TypeDescriptor)
+		 */
+		@Nullable
+		@Override
+		public final Object convert(@Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+
+			if (source == null) {
+				return null;
+			}
+
+			NullableWrapper wrapper = (NullableWrapper) source;
+			Object value = wrapper.getValue();
+
+			return value == null ? nullValue : wrap(value);
+		}
+
+		/**
+		 * Wrap the given, non-{@literal null} value into the wrapper type.
+		 *
+		 * @param source will never be {@literal null}.
+		 * @return must not be {@literal null}.
+		 */
+		protected abstract Object wrap(Object source);
+	}
+
+	/**
+	 * A Spring {@link Converter} to support JDK 8's {@link java.util.Optional}.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private static class NullableWrapperToJdk8OptionalConverter extends AbstractWrapperTypeConverter {
+
+		public static final NullableWrapperToJdk8OptionalConverter INSTANCE = new NullableWrapperToJdk8OptionalConverter();
+
+		private NullableWrapperToJdk8OptionalConverter() {
+			super(java.util.Optional.empty());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.util.QueryExecutionConverters.AbstractWrapperTypeConverter#wrap(java.lang.Object)
+		 */
+		@Override
+		protected Object wrap(Object source) {
+			return java.util.Optional.of(source);
+		}
+
+		public static WrapperType getWrapperType() {
+			return WrapperType.singleValue(java.util.Optional.class);
+		}
+	}
+
+	/**
+	 * A Spring {@link Converter} to support Google Guava's {@link Optional}.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private static class NullableWrapperToGuavaOptionalConverter extends AbstractWrapperTypeConverter {
+
+		public static final NullableWrapperToGuavaOptionalConverter INSTANCE = new NullableWrapperToGuavaOptionalConverter();
+
+		private NullableWrapperToGuavaOptionalConverter() {
+			super(Optional.absent(), Collections.singleton(Optional.class));
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.util.QueryExecutionConverters.AbstractWrapperTypeConverter#wrap(java.lang.Object)
+		 */
+		@Override
+		protected Object wrap(Object source) {
+			return Optional.of(source);
+		}
+
+		public static WrapperType getWrapperType() {
+			return WrapperType.singleValue(Optional.class);
+		}
+
+	}
+
+	/**
+	 * A Spring {@link Converter} to support Scala's {@link Option}.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private static class NullableWrapperToScalaOptionConverter extends AbstractWrapperTypeConverter {
+
+		public static final NullableWrapperToScalaOptionConverter INSTANCE = new NullableWrapperToScalaOptionConverter();
+
+		private NullableWrapperToScalaOptionConverter() {
+			super(Option.empty(), Collections.singleton(Option.class));
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.util.QueryExecutionConverters.AbstractWrapperTypeConverter#wrap(java.lang.Object)
+		 */
+		@Override
+		protected Object wrap(Object source) {
+			return Option.apply(source);
+		}
+
+		public static WrapperType getWrapperType() {
+			return WrapperType.singleValue(Option.class);
+		}
+	}
+
+	/**
+	 * Converter to convert from {@link NullableWrapper} into JavaSlang's {@link io.vavr.control.Option}.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private static class NullableWrapperToVavrOptionConverter extends AbstractWrapperTypeConverter {
+
+		public static final NullableWrapperToVavrOptionConverter INSTANCE = new NullableWrapperToVavrOptionConverter();
+
+		private NullableWrapperToVavrOptionConverter() {
+			super(io.vavr.control.Option.none(), Collections.singleton(io.vavr.control.Option.class));
+		}
+
+		public static WrapperType getWrapperType() {
+			return WrapperType.singleValue(io.vavr.control.Option.class);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.repository.util.QueryExecutionConverters.AbstractWrapperTypeConverter#wrap(java.lang.Object)
+		 */
+		@Override
+		protected Object wrap(Object source) {
+			return io.vavr.control.Option.of(source);
+		}
+	}
+
+	/**
+	 * A {@link Converter} to unwrap Guava {@link Optional} instances.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private enum GuavaOptionalUnwrapper implements Converter<Object, Object> {
+
+		INSTANCE;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+		 */
+		@Nullable
+		@Override
+		public Object convert(Object source) {
+			return source instanceof Optional ? ((Optional<?>) source).orNull() : source;
+		}
+	}
+
+	/**
+	 * A {@link Converter} to unwrap JDK 8 {@link java.util.Optional} instances.
+	 *
+	 * @author Oliver Gierke
+	 */
+	private enum Jdk8OptionalUnwrapper implements Converter<Object, Object> {
+
+		INSTANCE;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+		 */
+		@Nullable
+		@Override
+		public Object convert(Object source) {
+			return source instanceof java.util.Optional ? ((java.util.Optional<?>) source).orElse(null) : source;
+		}
+	}
+
+	/**
+	 * A {@link Converter} to unwrap a Scala {@link Option} instance.
+	 *
+	 * @author Oliver Gierke
+	 * @author Mark Paluch
+	 * @since 1.12
+	 */
+	private enum ScalOptionUnwrapper implements Converter<Object, Object> {
+
+		INSTANCE;
+
+		private final Function0<Object> alternative = new AbstractFunction0<Object>() {
+
+			/*
+			 * (non-Javadoc)
+			 * @see scala.Function0#apply()
+			 */
+			@Nullable
+			@Override
+			public Option<Object> apply() {
+				return null;
+			}
+		};
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+		 */
+		@Nullable
+		@Override
+		public Object convert(Object source) {
+			return source instanceof Option ? ((Option<?>) source).getOrElse(alternative) : source;
+		}
+	}
+
+	/**
+	 * Converter to unwrap Vavr {@link io.vavr.control.Option} instances.
+	 *
+	 * @author Oliver Gierke
+	 * @since 2.0
+	 */
+	private enum VavrOptionUnwrapper implements Converter<Object, Object> {
+
+		INSTANCE;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
+		 */
+		@Nullable
+		@Override
+		@SuppressWarnings("unchecked")
+		public Object convert(Object source) {
+
+			if (source instanceof io.vavr.control.Option) {
+				return ((io.vavr.control.Option<Object>) source).getOrElse(() -> null);
+			}
+
+			return source;
+		}
+	}
+
+	public static final class WrapperType {
+
+		private WrapperType(Class<?> type, Cardinality cardinality) {
+			this.type = type;
+			this.cardinality = cardinality;
+		}
+
+		public Class<?> getType() {
+			return this.type;
+		}
+
+		public Cardinality getCardinality() {
+			return cardinality;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
+		@Override
+		public boolean equals(Object o) {
+
+			if (this == o) {
+				return true;
+			}
+
+			if (!(o instanceof WrapperType)) {
+				return false;
+			}
+
+			WrapperType that = (WrapperType) o;
+
+			if (!ObjectUtils.nullSafeEquals(type, that.type)) {
+				return false;
+			}
+
+			return cardinality == that.cardinality;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
+		@Override
+		public int hashCode() {
+			int result = ObjectUtils.nullSafeHashCode(type);
+			result = 31 * result + ObjectUtils.nullSafeHashCode(cardinality);
+			return result;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return "WrapperType(type=" + this.getType() + ", cardinality=" + this.getCardinality() + ")";
+		}
+
+		enum Cardinality {
+			NONE, SINGLE, MULTI;
+		}
+
+		private final Class<?> type;
+		private final Cardinality cardinality;
+
+		public static WrapperType singleValue(Class<?> type) {
+			return new WrapperType(type, Cardinality.SINGLE);
+		}
+
+		public static WrapperType multiValue(Class<?> type) {
+			return new WrapperType(type, Cardinality.MULTI);
+		}
+
+		public static WrapperType noValue(Class<?> type) {
+			return new WrapperType(type, Cardinality.NONE);
+		}
+
+		public boolean isSingleValue() {
+			return cardinality.equals(Cardinality.SINGLE);
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/projection/ProjectingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProjectingMethodInterceptorUnitTests.java
@@ -74,12 +74,11 @@ class ProjectingMethodInterceptorUnitTests {
 		assertThat(methodInterceptor.invoke(invocation)).isEqualTo("Foo");
 	}
 
-	@Test // DATAREST-221
+	@Test // DATAREST-221, DATACMNS-1762
 	void returnsNullAsIs() throws Throwable {
 
 		MethodInterceptor methodInterceptor = new ProjectingMethodInterceptor(factory, interceptor, conversionService);
-
-		when(interceptor.invoke(invocation)).thenReturn(null);
+		mockInvocationOf("getString", null);
 
 		assertThat(methodInterceptor.invoke(invocation)).isNull();
 	}

--- a/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
@@ -225,7 +225,6 @@ class ProxyProjectionFactoryUnitTests {
 	void supportsOptionalAsReturnTypeIfEmpty() {
 
 		Customer customer = new Customer();
-
 		customer.picture = null;
 
 		CustomerWithOptional excerpt = factory.createProjection(CustomerWithOptional.class, customer);
@@ -237,7 +236,6 @@ class ProxyProjectionFactoryUnitTests {
 	void supportsOptionalAsReturnTypeIfPresent() {
 
 		Customer customer = new Customer();
-
 		customer.picture = new byte[] { 1, 2, 3 };
 
 		CustomerWithOptional excerpt = factory.createProjection(CustomerWithOptional.class, customer);

--- a/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProxyProjectionFactoryUnitTests.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.Advisor;
@@ -34,6 +35,8 @@ import org.springframework.test.util.ReflectionTestUtils;
  * Unit tests for {@link ProxyProjectionFactory}.
  *
  * @author Oliver Gierke
+ * @author Wim Deblauwe
+ * @author Mark Paluch
  */
 class ProxyProjectionFactoryUnitTests {
 
@@ -218,6 +221,63 @@ class ProxyProjectionFactoryUnitTests {
 		assertThat(factory.createProjection(Contact.class, customer)).isSameAs(customer);
 	}
 
+	@Test // DATACMNS-1762
+	void supportsOptionalAsReturnTypeIfEmpty() {
+
+		Customer customer = new Customer();
+
+		customer.picture = null;
+
+		CustomerWithOptional excerpt = factory.createProjection(CustomerWithOptional.class, customer);
+
+		assertThat(excerpt.getPicture()).isEmpty();
+	}
+
+	@Test // DATACMNS-1762
+	void supportsOptionalAsReturnTypeIfPresent() {
+
+		Customer customer = new Customer();
+
+		customer.picture = new byte[] { 1, 2, 3 };
+
+		CustomerWithOptional excerpt = factory.createProjection(CustomerWithOptional.class, customer);
+
+		assertThat(excerpt.getPicture()).hasValueSatisfying(bytes -> {
+			assertThat(bytes).isEqualTo(new byte[] { 1, 2, 3 });
+		});
+	}
+
+	@Test // DATACMNS-1762
+	void supportsOptionalBackedByOptional() {
+
+		Customer customer = new Customer();
+		customer.optional = Optional.of("foo");
+
+		CustomerWithOptional excerpt = factory.createProjection(CustomerWithOptional.class, customer);
+
+		assertThat(excerpt.getOptional()).hasValue("foo");
+	}
+
+	@Test // DATACMNS-1762
+	void supportsOptionalWithProjectionAsReturnTypeIfPresent() {
+
+		Customer customer = new Customer();
+		customer.firstname = "Dave";
+		customer.lastname = "Matthews";
+
+		customer.address = new Address();
+		customer.address.city = "New York";
+		customer.address.zipCode = "ZIP";
+
+		CustomerWithOptionalHavingProjection excerpt = factory.createProjection(CustomerWithOptionalHavingProjection.class,
+				customer);
+
+		assertThat(excerpt.getFirstname()).isEqualTo("Dave");
+		assertThat(excerpt.getAddress()).hasValueSatisfying(addressExcerpt -> {
+			assertThat(addressExcerpt.getZipCode()).isEqualTo("ZIP");
+		});
+	}
+
 	interface Contact {}
 
 	static class Customer implements Contact {
@@ -228,6 +288,7 @@ class ProxyProjectionFactoryUnitTests {
 		byte[] picture;
 		Address[] shippingAddresses;
 		Map<String, Object> data;
+		Optional<String> optional;
 	}
 
 	static class Address {
@@ -260,5 +321,21 @@ class ProxyProjectionFactoryUnitTests {
 		String getFirstname();
 
 		void setFirstname(String firstname);
+	}
+
+	interface CustomerWithOptional {
+
+		String getFirstname();
+
+		Optional<byte[]> getPicture();
+
+		Optional<String> getOptional();
+	}
+
+	interface CustomerWithOptionalHavingProjection {
+
+		String getFirstname();
+
+		Optional<AddressExcerpt> getAddress();
 	}
 }

--- a/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/util/QueryExecutionConvertersUnitTests.java
@@ -83,22 +83,6 @@ class QueryExecutionConvertersUnitTests {
 	}
 
 	@Test // DATACMNS-836
-	void registersReactiveWrapperTypes() {
-
-		assertThat(QueryExecutionConverters.supports(Publisher.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(Mono.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(Flux.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(Single.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(Completable.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(Observable.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(io.reactivex.Single.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(io.reactivex.Maybe.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(io.reactivex.Completable.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(io.reactivex.Flowable.class)).isTrue();
-		assertThat(QueryExecutionConverters.supports(io.reactivex.Observable.class)).isTrue();
-	}
-
-	@Test // DATACMNS-836
 	void registersUnwrapperTypes() {
 
 		assertThat(QueryExecutionConverters.supportsUnwrapping(Optional.class)).isTrue();

--- a/src/test/java/org/springframework/data/util/NullableWrapperConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/util/NullableWrapperConvertersUnitTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import scala.Option;
+
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.util.concurrent.ListenableFuture;
+
+import com.google.common.base.Optional;
+
+/**
+ * Unit tests for {@link NullableWrapperConverters}.
+ *
+ * @author Oliver Gierke
+ * @author Mark Paluch
+ * @author Maciek Opała
+ */
+class NullableWrapperConvertersUnitTests {
+
+	DefaultConversionService conversionService;
+
+	@BeforeEach
+	void setUp() {
+
+		this.conversionService = new DefaultConversionService();
+		NullableWrapperConverters.registerConvertersIn(conversionService);
+	}
+
+	@Test // DATACMNS-714, DATACMNS-1762
+	void registersWrapperTypes() {
+
+		assertThat(NullableWrapperConverters.supports(Optional.class)).isTrue();
+		assertThat(NullableWrapperConverters.supports(java.util.Optional.class)).isTrue();
+		assertThat(NullableWrapperConverters.supports(Future.class)).isFalse();
+		assertThat(NullableWrapperConverters.supports(ListenableFuture.class)).isFalse();
+		assertThat(NullableWrapperConverters.supports(Option.class)).isTrue();
+		assertThat(NullableWrapperConverters.supports(io.vavr.control.Option.class)).isTrue();
+	}
+
+	@Test // DATACMNS-836, DATACMNS-1762
+	void registersUnwrapperTypes() {
+
+		assertThat(NullableWrapperConverters.supportsUnwrapping(Optional.class)).isTrue();
+		assertThat(NullableWrapperConverters.supportsUnwrapping(java.util.Optional.class)).isTrue();
+		assertThat(NullableWrapperConverters.supportsUnwrapping(Future.class)).isFalse();
+		assertThat(NullableWrapperConverters.supportsUnwrapping(ListenableFuture.class)).isFalse();
+		assertThat(NullableWrapperConverters.supportsUnwrapping(Option.class)).isTrue();
+	}
+
+	@Test // DATACMNS-483, DATACMNS-1762
+	void turnsNullIntoGuavaOptional() {
+		assertThat(conversionService.convert(new NullableWrapper(null), Optional.class)).isEqualTo(Optional.absent());
+	}
+
+	@Test // DATACMNS-483, DATACMNS-1762
+	@SuppressWarnings("unchecked")
+	void turnsNullIntoJdk8Optional() {
+		assertThat(conversionService.convert(new NullableWrapper(null), java.util.Optional.class)).isEmpty();
+	}
+
+	@Test // DATACMNS-768, DATACMNS-1762
+	void unwrapsJdk8Optional() {
+		assertThat(NullableWrapperConverters.unwrap(java.util.Optional.of("Foo"))).isEqualTo("Foo");
+	}
+
+	@Test // DATACMNS-768, DATACMNS-1762
+	void unwrapsGuava8Optional() {
+		assertThat(NullableWrapperConverters.unwrap(Optional.of("Foo"))).isEqualTo("Foo");
+	}
+
+	@Test // DATACMNS-768, DATACMNS-1762
+	void unwrapsNullToNull() {
+		assertThat(NullableWrapperConverters.unwrap(null)).isNull();
+	}
+
+	@Test // DATACMNS-768, DATACMNS-1762
+	void unwrapsNonWrapperTypeToItself() {
+		assertThat(NullableWrapperConverters.unwrap("Foo")).isEqualTo("Foo");
+	}
+
+	@Test // DATACMNS-795, DATACMNS-1762
+	void turnsNullIntoScalaOptionEmpty() {
+		assertThat(conversionService.convert(new NullableWrapper(null), Option.class)).isEqualTo(Option.empty());
+	}
+
+	@Test // DATACMNS-795, DATACMNS-1762
+	void unwrapsScalaOption() {
+		assertThat(NullableWrapperConverters.unwrap(Option.apply("foo"))).isEqualTo("foo");
+	}
+
+	@Test // DATACMNS-874, DATACMNS-1762
+	void unwrapsEmptyScalaOption() {
+		assertThat(NullableWrapperConverters.unwrap(Option.empty())).isNull();
+	}
+
+	@Test // DATACMNS-1065, DATACMNS-1762
+	void unwrapsEmptyVavrOption() {
+		assertThat(NullableWrapperConverters.unwrap(io.vavr.control.Option.none())).isNull();
+	}
+
+	@Test // DATACMNS-1065, DATACMNS-1762
+	void unwrapsVavrOption() {
+		assertThat(NullableWrapperConverters.unwrap(io.vavr.control.Option.of("string"))).isEqualTo("string");
+	}
+
+}


### PR DESCRIPTION
We now support nullable wrappers for projection interfaces. Getters are inspected whether their return type is a supported nullable wrapper. If so, then the value can be wrapped into that type. Null values default in that case to their corresponding empty wrapper representation.

```java
class Customer {

	Long id;
	String firstname, lastname;
	Address address;
}

interface CustomerProjection {

	Optional<String> getFirstname();

	Optional<AddressExcerpt> getAddress();
}


Customer customer = new Customer();
customer.firstname = "Walter";

CustomerProjection projection = …;

assertThat(projection.getFirstname()).hasValue("Walter");


customer.firstname = null;
assertThat(projection.getFirstname()).isEmpty();
```

Also, extracted `NullableWrapperConverters` from `QueryExecutionConverters` and removed `ReactiveWrappers` from `QueryExecutionConverters `.

---

We should reconsider the package for `NullableWrapperConverters` as further extensions (`Iterable -> Streamable`) might be future enhancements.

Related ticket: DATACMNS-1762
Previous pull request: #457.