### PR TITLE
DATACMNS-1754 - Support implementation lookup for nested repositories and fragments

### DIFF
--- a/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Kyrylo Merzlikin
  * @since 2.1
  */
 class DefaultImplementationLookupConfiguration implements ImplementationLookupConfiguration {
@@ -55,8 +56,7 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 
 		this.config = config;
 		this.interfaceName = interfaceName;
-		this.beanName = Introspector
-				.decapitalize(ClassUtils.getShortName(interfaceName).concat(config.getImplementationPostfix()));
+		this.beanName = Introspector.decapitalize(getLocalName(interfaceName).concat(config.getImplementationPostfix()));
 	}
 
 	/*
@@ -110,7 +110,7 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 	 */
 	@Override
 	public String getImplementationClassName() {
-		return ClassUtils.getShortName(interfaceName).concat(getImplementationPostfix());
+		return getLocalName(interfaceName).concat(getImplementationPostfix());
 	}
 
 	/*
@@ -141,11 +141,16 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 		}
 
 		String beanPackage = ClassUtils.getPackageName(beanClassName);
-		String shortName = ClassUtils.getShortName(beanClassName);
-		String localName = shortName.substring(shortName.lastIndexOf('.') + 1);
+		String localName = getLocalName(beanClassName);
 
 		return localName.equals(getImplementationClassName()) //
 				&& getBasePackages().stream().anyMatch(it -> beanPackage.startsWith(it));
+	}
+
+	private String getLocalName(String className) {
+
+		String shortName = ClassUtils.getShortName(className);
+		return shortName.substring(shortName.lastIndexOf('.') + 1);
 	}
 
 	private boolean isExcluded(String beanClassName, Streamable<TypeFilter> filters) {

--- a/src/test/java/org/springframework/data/repository/cdi/CdiRepositoryBeanUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/cdi/CdiRepositoryBeanUnitTests.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.config.CustomRepositoryImplementationDetector;
@@ -58,6 +57,7 @@ import org.springframework.data.repository.query.RepositoryQuery;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Ariel Carrera
+ * @author Kyrylo Merzlikin
  */
 @ExtendWith(MockitoExtension.class)
 class CdiRepositoryBeanUnitTests {
@@ -171,8 +171,8 @@ class CdiRepositoryBeanUnitTests {
 
 		ImplementationLookupConfiguration configuration = captor.getValue();
 
-		assertThat(configuration.getImplementationBeanName()).isEqualTo("cdiRepositoryBeanUnitTests.SampleRepositoryImpl");
-		assertThat(configuration.getImplementationClassName()).isEqualTo("CdiRepositoryBeanUnitTests.SampleRepositoryImpl");
+		assertThat(configuration.getImplementationBeanName()).isEqualTo("sampleRepositoryImpl");
+		assertThat(configuration.getImplementationClassName()).isEqualTo("SampleRepositoryImpl");
 	}
 
 	@Test // DATACMNS-1233

--- a/src/test/java/org/springframework/data/repository/cdi/NestedFragmentInterfaceImpl.java
+++ b/src/test/java/org/springframework/data/repository/cdi/NestedFragmentInterfaceImpl.java
@@ -15,18 +15,13 @@
  */
 package org.springframework.data.repository.cdi;
 
-import java.io.Serializable;
-
-import org.springframework.data.repository.Repository;
-
 /**
- * @author Mark Paluch
  * @author Kyrylo Merzlikin
  */
-interface ComposedRepository extends Repository<Object, Serializable>, FragmentInterface, AnotherFragmentInterface,
-		RepositoryFragments.NestedFragmentInterface {
+public class NestedFragmentInterfaceImpl implements RepositoryFragments.NestedFragmentInterface {
 
-	// duplicate method shadowed by AnotherFragmentInterfaceImpl. The legacy custom implementation comes last, after all
-	// other fragments.
-	int getShadowed();
+	@Override
+	public String getKey() {
+		return "NestedFragmentImpl";
+	}
 }

--- a/src/test/java/org/springframework/data/repository/cdi/RepositoryFragments.java
+++ b/src/test/java/org/springframework/data/repository/cdi/RepositoryFragments.java
@@ -15,18 +15,13 @@
  */
 package org.springframework.data.repository.cdi;
 
-import java.io.Serializable;
-
-import org.springframework.data.repository.Repository;
-
 /**
- * @author Mark Paluch
  * @author Kyrylo Merzlikin
  */
-interface ComposedRepository extends Repository<Object, Serializable>, FragmentInterface, AnotherFragmentInterface,
-		RepositoryFragments.NestedFragmentInterface {
+public interface RepositoryFragments {
 
-	// duplicate method shadowed by AnotherFragmentInterfaceImpl. The legacy custom implementation comes last, after all
-	// other fragments.
-	int getShadowed();
+	interface NestedFragmentInterface {
+
+		String getKey();
+	}
 }

--- a/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link DefaultImplementationLookupConfigurationUnitTests}.
  *
  * @author Mark Paluch
+ * @author Kyrylo Merzlikin
  */
 class DefaultImplementationLookupConfigurationUnitTests {
 
@@ -35,6 +36,18 @@ class DefaultImplementationLookupConfigurationUnitTests {
 
 		assertThat(getImplementationBeanName(idcMock, "com.acme.UDPRepository")).isEqualTo("UDPRepositoryImpl");
 		assertThat(getImplementationBeanName(idcMock, "com.acme.UdpRepository")).isEqualTo("udpRepositoryImpl");
+	}
+
+	@Test // DATACMNS-1754
+	void shouldUseSimpleClassNameWhenDefiningImplementationNames() {
+
+		ImplementationDetectionConfiguration idcMock = mock(ImplementationDetectionConfiguration.class);
+		when(idcMock.getImplementationPostfix()).thenReturn("Impl");
+
+		DefaultImplementationLookupConfiguration lookupConfiguration = new DefaultImplementationLookupConfiguration(idcMock,
+				"com.acme.Repositories$NestedRepository");
+		assertThat(lookupConfiguration.getImplementationBeanName()).isEqualTo("nestedRepositoryImpl");
+		assertThat(lookupConfiguration.getImplementationClassName()).isEqualTo("NestedRepositoryImpl");
 	}
 
 	private static String getImplementationBeanName(ImplementationDetectionConfiguration idcMock, String interfaceName) {


### PR DESCRIPTION
**Problem:** while repository and fragment interfaces are discovered correctly (provided that considerNestedRepositories=true), their implementations are not found/registered despite proper class naming.

**Cause:** `DefaultImplementationLookupConfiguration` works in such way that for nested interface (i.e. one whose class name includes name of the enclosing class) expected implementation class name is built including that enclosing class name. In the same time actual implementation class names are always "localized" (i.e. stripped from enclosing class name, if any) before matching. This makes matching implementation classes against nested interface impossible.

**Solution:** when building expected implementation class name, use "local" interface class name, so that it can match any implementation class that follows naming convention "SimpleInterfaceName" + "ImplemenetationPostfix". 
Also for consistency expected implementation bean name now uses "local" interface class name (which additionally allows to avoid having "." in the bean name).

**Results**:
- nothing changes for top-level (not nested) repositories and fragments (because "localizing" their class names doesn't do anything);
- nothing changes in terms of discovery for nested repository and fragment _interfaces_ (because `DefaultImplementationLookupConfiguration` handles already discovered interfaces and implementation classes);
- _implementations_ can now be discovered and registered for nested repository and fragment interfaces.