### PR TITLE
DATACMNS-1780 - PersistentEntities allows in flight metadata creation if the associated mapping context can be identified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATACMNS-1780-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/test/java/org/springframework/data/auditing/IsNewAwareAuditingHandlerUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/IsNewAwareAuditingHandlerUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.auditing;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
@@ -101,6 +102,19 @@ class IsNewAwareAuditingHandlerUnitTests extends AuditingHandlerUnitTests {
 	@Test // DATACMNS-957
 	void skipsEntityWithoutIdentifier() {
 		getHandler().markAudited(Optional.of(new EntityWithoutId()));
+	}
+
+	@Test // DATACMNS-1780
+	void singleContextAllowsInFlightMetadataCreationForUnknownPersistentEntities() {
+
+		SampleMappingContext mappingContext = spy(new SampleMappingContext());
+		mappingContext.afterPropertiesSet();
+
+		AuditedUser user = new AuditedUser();
+		user.id = 1L;
+
+		new IsNewAwareAuditingHandler(PersistentEntities.of(mappingContext)).markAudited(user);
+		verify(mappingContext).getPersistentEntity(AuditedUser.class);
 	}
 
 	static class Domain {


### PR DESCRIPTION
Use a more lenient approach, that allows metadata creation, when looking up persistent entities. This allows eg. a configured `AuditingHandler` to kick in without having to register an initial entity set in first place.