### PR TITLE
DATACMNS-1788 - Allow usage of arrow.core.Option in Repositories.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<vavr>0.10.3</vavr>
 		<scala>2.11.7</scala>
 		<xmlbeam>1.4.16</xmlbeam>
+		<arrow-core>0.10.4</arrow-core>
 
 		<java-module-name>spring.data.commons</java-module-name>
 	</properties>
@@ -207,6 +208,13 @@
 			<groupId>io.vavr</groupId>
 			<artifactId>vavr</artifactId>
 			<version>${vavr}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.arrow-kt</groupId>
+			<artifactId>arrow-core</artifactId>
+			<version>${arrow-core}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -587,6 +587,7 @@ Besides that, Spring Data supports returning the following wrapper types on quer
 * `com.google.common.base.Optional`
 * `scala.Option`
 * `io.vavr.control.Option`
+* `arrow.core.Option`
 
 Alternatively, query methods can choose not to use a wrapper type at all.
 The absence of a query result is then indicated by returning `null`.


### PR DESCRIPTION
This changes adds the infrastructure necessary to allow the usage of the `arrow.core.Option` Nullable Wrapper Type.

`arrow.core.Option` is a abstract class and instances can be created via `Option#ofNullable`. Instances will either be of type `arrow.core.Some` for non null values or `arrow.core.None` for null values. 
`arrow.core.Option` is a [Kotlin sealed class](https://kotlinlang.org/docs/reference/sealed-classes.html)

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
