### PR TITLE
DATACMNS-1142 - Consider @Primary repository in Repositories if context is given.

### DIFF
--- a/src/main/java/org/springframework/data/repository/support/Repositories.java
+++ b/src/main/java/org/springframework/data/repository/support/Repositories.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.core.EntityInformation;
@@ -46,6 +47,7 @@ import org.springframework.util.ClassUtils;
  * @author Thomas Darimont
  * @author Thomas Eizinger
  * @author Christoph Strobl
+ * @author Jan Zeppenfeld
  */
 public class Repositories implements Iterable<Class<?>> {
 
@@ -276,9 +278,16 @@ public class Repositories implements Iterable<Class<?>> {
 
 		if (repositoryBeanNames.containsKey(type)) {
 
-			Boolean presentAndPrimary = beanFactory //
+			ConfigurableListableBeanFactory configurableListableBeanFactory = beanFactory
 					.filter(ConfigurableListableBeanFactory.class::isInstance) //
 					.map(ConfigurableListableBeanFactory.class::cast) //
+					.orElse(beanFactory //
+							.filter(ConfigurableApplicationContext.class::isInstance) //
+							.map(ConfigurableApplicationContext.class::cast) //
+							.map(ConfigurableApplicationContext::getBeanFactory) //
+							.orElse(null));
+
+			Boolean presentAndPrimary = Optional.ofNullable(configurableListableBeanFactory)
 					.map(it -> it.getBeanDefinition(name)) //
 					.map(BeanDefinition::isPrimary) //
 					.orElse(false);

--- a/src/test/java/org/springframework/data/repository/support/RepositoriesUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/support/RepositoriesUnitTests.java
@@ -56,6 +56,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Jan Zeppenfeld
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -177,6 +178,28 @@ class RepositoriesUnitTests {
 		context.refresh();
 
 		Repositories repositories = new Repositories(beanFactory);
+
+		assertThat(repositories.getRepositoryFor(SomeEntity.class)).hasValueSatisfying(it -> {
+			assertThat(it).isInstanceOf(PrimaryRepository.class);
+		});
+	}
+
+	@Test // DATAREST-923, DATACMNS-1142
+	void keepsPrimaryRepositoryInCaseOfMultipleOnesIfContextIsNotAConfigurableListableBeanFactory() {
+
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("first", getRepositoryBeanDefinition(FirstRepository.class));
+
+		AbstractBeanDefinition definition = getRepositoryBeanDefinition(PrimaryRepository.class);
+		definition.setPrimary(true);
+
+		beanFactory.registerBeanDefinition("primary", definition);
+		beanFactory.registerBeanDefinition("third", getRepositoryBeanDefinition(ThirdRepository.class));
+
+		context = new GenericApplicationContext(beanFactory);
+		context.refresh();
+
+		Repositories repositories = new Repositories(context);
 
 		assertThat(repositories.getRepositoryFor(SomeEntity.class)).hasValueSatisfying(it -> {
 			assertThat(it).isInstanceOf(PrimaryRepository.class);


### PR DESCRIPTION
In most of the current cases an ApplicationContext is passed to the Repositories constructor which is a ListableBeanFactory but not a ConfigurableListableBeanFactory. We now check whether the given ListableBeanFactory is of type ConfigurableApplicationContext as well because all current contexts implement this interface and therefore can return a ConfigurableListableBeanFactory. This way we can retrieve the bean definition for a repository and can check whether it has been marked as a primary one.

Related tickets: DATACMNS-1448, DATACMNS-1591, DATAREST-923.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
