### PR TITLE
DATACMNS-1806 - Prevent returning null from Lazy due to concurrency problem.

### DIFF
--- a/src/main/java/org/springframework/data/util/Lazy.java
+++ b/src/main/java/org/springframework/data/util/Lazy.java
@@ -30,6 +30,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Henning Rohlfs
  * @since 2.0
  */
 public class Lazy<T> implements Supplier<T> {
@@ -39,7 +40,7 @@ public class Lazy<T> implements Supplier<T> {
 	private final Supplier<? extends T> supplier;
 
 	private @Nullable T value = null;
-	private boolean resolved = false;
+	private volatile boolean resolved = false;
 
 	public Lazy(Supplier<? extends T> supplier) {
 		this.supplier = supplier;
@@ -207,18 +208,14 @@ public class Lazy<T> implements Supplier<T> {
 	@Nullable
 	public T getNullable() {
 
-		T value = this.value;
-
 		if (this.resolved) {
-			return value;
+			return this.value;
 		}
 
-		value = supplier.get();
-
-		this.value = value;
+		this.value = supplier.get();
 		this.resolved = true;
 
-		return value;
+		return this.value;
 	}
 
 	/*


### PR DESCRIPTION
When accessed concurrently from multiple threads, Lazy.getNullable() could return null unexpectedly.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

No test case provided in code as due to the nature of concurrency issues it is problematic to quickly test the issue. There's a test setup provided in the jira ticket.