### PR TITLE
DATACMNS-1814 - link fix

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -749,6 +749,7 @@ Each Spring Data module includes a `repositories` element that lets you define a
 
 In the preceding example, Spring is instructed to scan `com.acme.repositories` and all its sub-packages for interfaces extending `Repository` or one of its sub-interfaces. For each interface found, the infrastructure registers the persistence technology-specific `FactoryBean` to create the appropriate proxies that handle invocations of the query methods. Each bean is registered under a bean name that is derived from the interface name, so an interface of `UserRepository` would be registered under `userRepository`. The `base-package` attribute allows wildcards so that you can define a pattern of scanned packages.
 
+[[repositories.using-filters]]
 ==== Using filters
 By default, the infrastructure picks up every interface extending the persistence technology-specific `Repository` sub-interface located under the configured base package and creates a bean instance for it. However, you might want more fine-grained control over which interfaces have bean instances created for them. To do so, use `<include-filter />` and `<exclude-filter />` elements inside the `<repositories />` element. The semantics are exactly equivalent to the elements in Spring's context namespace. For details, see the link:{spring-framework-docs}/core.html#beans-scanning-filters[Spring reference documentation] for these elements.
 
@@ -942,6 +943,7 @@ interface PersonRepository extends CrudRepository<Person, Long>, CustomizedSave<
 ----
 ====
 
+[[repositories.configuration]]
 ==== Configuration
 If you use namespace configuration, the repository infrastructure tries to autodetect custom implementation fragments by scanning for classes below the package in which it found a repository. These classes need to follow the naming convention of appending the namespace element's `repository-impl-postfix` attribute to the fragment interface name. This postfix defaults to `Impl`. The following example shows a repository that uses the default postfix and a repository that sets a custom value for the postfix:
 


### PR DESCRIPTION
Fixes the problem of the "Using filters" link jumping to the top of
the document. There was another of these ("Configuration") later in
the document, and this commit fixes that one, too.

See: DATACMNS-1814.