### PR TITLE
DATACMNS-1827 - Pageable and Sort arguments with empty qualifier value shouldn't be prefixed with delimiter.

### DIFF
--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverSupport.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverSupport.java
@@ -230,7 +230,7 @@ public abstract class PageableHandlerMethodArgumentResolverSupport {
 
 		Qualifier qualifier = parameter == null ? null : parameter.getParameterAnnotation(Qualifier.class);
 
-		if (qualifier != null) {
+		if (qualifier != null && StringUtils.hasLength(qualifier.value())) {
 			builder.append(qualifier.value());
 			builder.append(qualifierDelimiter);
 		}

--- a/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolverSupport.java
+++ b/src/main/java/org/springframework/data/web/SortHandlerMethodArgumentResolverSupport.java
@@ -186,8 +186,9 @@ public abstract class SortHandlerMethodArgumentResolverSupport {
 
 		Qualifier qualifier = parameter != null ? parameter.getParameterAnnotation(Qualifier.class) : null;
 
-		if (qualifier != null) {
-			builder.append(qualifier.value()).append(qualifierDelimiter);
+		if (qualifier != null && StringUtils.hasLength(qualifier.value())) {
+			builder.append(qualifier.value());
+			builder.append(qualifierDelimiter);
 		}
 
 		return builder.append(sortParameter).toString();

--- a/src/test/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverUnitTests.java
@@ -35,6 +35,7 @@ import org.springframework.web.context.request.ServletWebRequest;
  *
  * @author Oliver Gierke
  * @author Nick Williams
+ * @author Vedran Pavic
  */
 class PageableHandlerMethodArgumentResolverUnitTests extends PageableDefaultUnitTests {
 
@@ -244,6 +245,18 @@ class PageableHandlerMethodArgumentResolverUnitTests extends PageableDefaultUnit
 		assertThat(resolver.isFallbackPageable(PageRequest.of(0, 10))).isFalse();
 	}
 
+	@Test // DATACMNS-1827
+	void emptyQualifierIsUsedInParameterLookup() throws Exception {
+
+		MethodParameter parameter = new MethodParameter(Sample.class.getMethod("emptyQualifier", Pageable.class), 0);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("page", "2");
+		request.addParameter("size", "10");
+
+		assertSupportedAndResult(parameter, PageRequest.of(2, 10), request);
+	}
+
 	@Override
 	protected PageableHandlerMethodArgumentResolver getResolver() {
 		PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
@@ -283,5 +296,7 @@ class PageableHandlerMethodArgumentResolverUnitTests extends PageableDefaultUnit
 		void validQualifier(@Qualifier("foo") Pageable pageable);
 
 		void noQualifiers(Pageable first, Pageable second);
+
+		void emptyQualifier(@Qualifier Pageable pageable);
 	}
 }

--- a/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SortHandlerMethodArgumentResolverUnitTests.java
@@ -45,6 +45,7 @@ import org.springframework.web.context.request.ServletWebRequest;
  * @author Thomas Darimont
  * @author Nick Williams
  * @author Mark Paluch
+ * @author Vedran Pavic
  */
 class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitTests {
 
@@ -241,6 +242,15 @@ class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitTests {
 		});
 	}
 
+	@Test // DATACMNS-1827
+	void emptyQualifierIsUsedInParameterLookup() {
+
+		MethodParameter parameter = getParameterOfMethod("emptyQualifier");
+		Sort reference = Sort.by("bar", "foo");
+
+		assertSupportedAndResolvedTo(getRequestWithSort(reference, ""), parameter, reference);
+	}
+
 	private static Sort resolveSort(HttpServletRequest request, MethodParameter parameter) throws Exception {
 
 		SortHandlerMethodArgumentResolver resolver = new SortHandlerMethodArgumentResolver();
@@ -306,5 +316,7 @@ class SortHandlerMethodArgumentResolverUnitTests extends SortDefaultUnitTests {
 		void containeredDefault(@SortDefaults(@SortDefault({ "foo", "bar" })) Sort sort);
 
 		void invalid(@SortDefaults(@SortDefault({ "foo", "bar" })) @SortDefault({ "bar", "foo" }) Sort sort);
+
+		void emptyQualifier(@Qualifier Sort sort);
 	}
 }


### PR DESCRIPTION
This resolves [DATACMNS-1827](https://jira.spring.io/browse/DATACMNS-1827).

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATACMNS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
