### PR TITLE
DATACMNS-800 - Adds deleteAllById to (Reactive)CrudRepository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATACMNS-800-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/CrudRepository.java
@@ -119,11 +119,11 @@ public interface CrudRepository<T, ID> extends Repository<T, ID> {
 	void deleteAll(Iterable<? extends T> entities);
 
 	/**
-	 * Deletes the given entities.
+	 * Deletes all instances of the type {@code T} with the given IDs.
 	 *
 	 * @param ids must not be {@literal null}. Must not contain {@literal null} elements.
 	 * @throws IllegalArgumentException in case the given {@literal ids} or one of its elements is {@literal null}.
-	 * @since 3.0
+	 * @since 2.5
 	 */
 	void deleteAllById(Iterable<? extends ID> ids);
 

--- a/src/main/java/org/springframework/data/repository/CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/CrudRepository.java
@@ -22,6 +22,7 @@ import java.util.Optional;
  *
  * @author Oliver Gierke
  * @author Eberhard Wolff
+ * @author Jens Schauder
  */
 @NoRepositoryBean
 public interface CrudRepository<T, ID> extends Repository<T, ID> {
@@ -116,6 +117,15 @@ public interface CrudRepository<T, ID> extends Repository<T, ID> {
 	 * @throws IllegalArgumentException in case the given {@literal entities} or one of its entities is {@literal null}.
 	 */
 	void deleteAll(Iterable<? extends T> entities);
+
+	/**
+	 * Deletes the given entities.
+	 *
+	 * @param ids must not be {@literal null}. Must not contain {@literal null} elements.
+	 * @throws IllegalArgumentException in case the given {@literal ids} or one of its elements is {@literal null}.
+	 * @since 3.0
+	 */
+	void deleteAllById(Iterable<? extends ID> ids);
 
 	/**
 	 * Deletes all entities managed by the repository.

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
@@ -181,13 +181,13 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	Mono<Void> deleteAll(Iterable<? extends T> entities);
 
 	/**
-	 * Deletes the given entities matching the given ids.
+	 * Deletes all instances of the type {@code T} with the given IDs.
 	 *
 	 * @param ids must not be {@literal null}.
 	 * @return {@link Mono} signaling when operation has completed.
-	 * @throws IllegalArgumentException in case the given {@link Iterable entities} or one of its entities is
+	 * @throws IllegalArgumentException in case the given {@literal ids} or one of its elements is {@literal null}.
 	 *           {@literal null}.
-	 * @since 3.0
+	 * @since 2.5
 	 */
 	Mono<Void> deleteAllById(Iterable<? extends ID> ids);
 

--- a/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/reactive/ReactiveCrudRepository.java
@@ -28,6 +28,7 @@ import org.springframework.data.repository.Repository;
  *
  * @author Mark Paluch
  * @author Christph Strobl
+ * @author Jens Schauder
  * @since 2.0
  * @see Mono
  * @see Flux
@@ -178,6 +179,17 @@ public interface ReactiveCrudRepository<T, ID> extends Repository<T, ID> {
 	 *           {@literal null}.
 	 */
 	Mono<Void> deleteAll(Iterable<? extends T> entities);
+
+	/**
+	 * Deletes the given entities matching the given ids.
+	 *
+	 * @param ids must not be {@literal null}.
+	 * @return {@link Mono} signaling when operation has completed.
+	 * @throws IllegalArgumentException in case the given {@link Iterable entities} or one of its entities is
+	 *           {@literal null}.
+	 * @since 3.0
+	 */
+	Mono<Void> deleteAllById(Iterable<? extends ID> ids);
 
 	/**
 	 * Deletes the given entities supplied by a {@link Publisher}.


### PR DESCRIPTION
Merge with the PR for all the dependent issues.

Related:
* https://github.com/spring-projects/spring-data-cassandra/pull/181
* https://github.com/spring-projects/spring-data-couchbase/pull/279
* https://github.com/spring-projects/spring-data-elasticsearch/pull/554
* https://github.com/spring-projects/spring-data-geode/pull/45
* https://github.com/spring-projects/spring-data-neo4j/pull/554
* https://github.com/spring-projects/spring-data-jpa/pull/435
* https://github.com/spring-projects/spring-data-keyvalue/pull/52
* https://github.com/spring-projects/spring-data-ldap/pull/20
* https://github.com/spring-projects/spring-data-mongodb/pull/892
* https://github.com/spring-projects/spring-data-jdbc/pull/252