### PR TITLE
DATACMNS-1836 - Adds JSR310 converters to the converters used for projections.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-DATAJDBC-1836-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
+++ b/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
@@ -28,6 +28,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.convert.Jsr310Converters;
 import org.springframework.data.util.NullableWrapperConverters;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -43,6 +44,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Jens Schauder
  * @see SpelAwareProxyProjectionFactory
  * @since 1.10
  */
@@ -51,6 +53,7 @@ class ProxyProjectionFactory implements ProjectionFactory, BeanClassLoaderAware 
 	final static GenericConversionService CONVERSION_SERVICE = new DefaultConversionService();
 
 	static {
+		Jsr310Converters.getConvertersToRegister().forEach(CONVERSION_SERVICE::addConverter);
 		NullableWrapperConverters.registerConvertersIn(CONVERSION_SERVICE);
 		CONVERSION_SERVICE.removeConvertible(Object.class, Object.class);
 	}


### PR DESCRIPTION
Similar converters where removed because they clashed with the support for nullable wrappers. This adds them back as dedicated converters that does not clash with conversions for nullable wrappers.

See bd3992d#diff-96f7084777a2a702d85f5c600e542b10123d6c3332ed3d3f8e329ca7061faab0R55

See DATACMNS-1836