### PR TITLE
Clarify javadoc for deleteAll()

### DIFF
--- a/src/main/java/org/springframework/data/repository/CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/CrudRepository.java
@@ -128,7 +128,7 @@ public interface CrudRepository<T, ID> extends Repository<T, ID> {
 	void deleteAll(Iterable<? extends T> entities);
 
 	/**
-	 * Deletes all entities managed by the repository.
+	 * Deletes all entities from the table.
 	 */
 	void deleteAll();
 }


### PR DESCRIPTION
Word `managed` in JPA world has concrete meaning. The word should be avoided when not refers to entity managed by persistence context

This PR solves https://github.com/spring-projects/spring-data-commons/issues/2230