### PR TITLE
GH-2247 - Add repository initialization metrics.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-DATACMNS-1832</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -57,6 +57,7 @@ import org.springframework.util.StopWatch;
  * @author Oliver Gierke
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class RepositoryConfigurationDelegate {
 
@@ -148,8 +149,9 @@ public class RepositoryConfigurationDelegate {
 
 		ApplicationStartup startup = getStartup(registry);
 		StartupStep repoScan = startup.start("spring.data.repository.scanning");
-		repoScan.tag("data-module", extension.getModuleName());
-		repoScan.tag("packages", configurationSource.getBasePackages().stream().collect(Collectors.joining(", ")));
+		repoScan.tag("dataModule", extension.getModuleName());
+		repoScan.tag("basePackages",
+				() -> configurationSource.getBasePackages().stream().collect(Collectors.joining(", ")));
 
 		watch.start();
 
@@ -263,18 +265,14 @@ public class RepositoryConfigurationDelegate {
 		return multipleModulesFound;
 	}
 
-	ApplicationStartup getStartup(BeanDefinitionRegistry registry) {
+	private static ApplicationStartup getStartup(BeanDefinitionRegistry registry) {
 
-		if(ConfigurableBeanFactory.class.isInstance(registry)) {
-			return ((ConfigurableBeanFactory)registry).getApplicationStartup();
+		if (registry instanceof ConfigurableBeanFactory) {
+			return ((ConfigurableBeanFactory) registry).getApplicationStartup();
 		}
 
-		if (DefaultListableBeanFactory.class.isInstance(registry)) {
-			return ((DefaultListableBeanFactory)registry).getBeanProvider(ApplicationStartup.class).getIfAvailable(() -> ApplicationStartup.DEFAULT);
-		}
-
-		if(GenericApplicationContext.class.isInstance(registry)) {
-			return ((GenericApplicationContext)registry).getDefaultListableBeanFactory().getApplicationStartup();
+		if (registry instanceof GenericApplicationContext) {
+			return ((GenericApplicationContext) registry).getDefaultListableBeanFactory().getApplicationStartup();
 		}
 
 		return ApplicationStartup.DEFAULT;

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
@@ -364,6 +364,7 @@ public class RepositoryComposition {
 	 * Value object representing an ordered list of {@link RepositoryFragment fragments}.
 	 *
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 */
 	public static class RepositoryFragments implements Streamable<RepositoryFragment<?>> {
 
@@ -548,6 +549,16 @@ public class RepositoryComposition {
 			}
 
 			return null;
+		}
+
+		/**
+		 * Returns the number of {@link RepositoryFragment fragments} available.
+		 *
+		 * @return the number of {@link RepositoryFragment fragments}.
+		 * @since 2.5
+		 */
+		public int size() {
+			return fragments.size();
 		}
 
 		/*

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -277,28 +277,52 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 		ApplicationStartup applicationStartup = getStartup();
 
-		StartupStep repositoryInit = applicationStartup.start("spring.data.repository.init");
-		repositoryInit.tag("repository", () -> repositoryInterface.getName());
+		StartupStep repositoryInit = onEvent(applicationStartup, "spring.data.repository.init", repositoryInterface);
 
-		StartupStep repositoryMetadataStep = applicationStartup.start("spring.data.repository.metadata");
+		repositoryBaseClass.ifPresent(it -> repositoryInit.tag("baseClass", it.getName()));
+
+		StartupStep repositoryMetadataStep = onEvent(applicationStartup, "spring.data.repository.metadata",
+				repositoryInterface);
 		RepositoryMetadata metadata = getRepositoryMetadata(repositoryInterface);
 		repositoryMetadataStep.end();
 
-		StartupStep repositoryCompositionStep = applicationStartup.start("spring.data.repository.composition");
-		repositoryCompositionStep.tag("fragment.count", () -> String.valueOf(fragments.size()));
+		StartupStep repositoryCompositionStep = onEvent(applicationStartup, "spring.data.repository.composition",
+				repositoryInterface);
+		repositoryCompositionStep.tag("fragment.count", String.valueOf(fragments.size()));
 
 		RepositoryComposition composition = getRepositoryComposition(metadata, fragments);
 		RepositoryInformation information = getRepositoryInformation(metadata, composition);
+
+		repositoryCompositionStep.tag("fragments", () -> {
+
+			StringBuilder fragmentsTag = new StringBuilder();
+
+			for (RepositoryFragment<?> fragment : composition.getFragments()) {
+
+				if (fragmentsTag.length() > 0) {
+					fragmentsTag.append(";");
+				}
+
+				fragmentsTag.append(fragment.getSignatureContributor().getName());
+				fragmentsTag.append(fragment.getImplementation().map(it -> ":" + it.getClass().getName()).orElse(""));
+			}
+
+			return fragmentsTag.toString();
+		});
+
 		repositoryCompositionStep.end();
 
 		validate(information, composition);
 
-		StartupStep repositoryTargetStep = applicationStartup.start("spring.data.repository.target");
+		StartupStep repositoryTargetStep = onEvent(applicationStartup, "spring.data.repository.target",
+				repositoryInterface);
 		Object target = getTargetRepository(information);
+
+		repositoryTargetStep.tag("target", target.getClass().getName());
 		repositoryTargetStep.end();
 
 		// Create proxy
-		StartupStep repositoryProxyStep = applicationStartup.start("spring.data.repository.proxy");
+		StartupStep repositoryProxyStep = onEvent(applicationStartup, "spring.data.repository.proxy", repositoryInterface);
 		ProxyFactory result = new ProxyFactory();
 		result.setTarget(target);
 		result.setInterfaces(repositoryInterface, Repository.class, TransactionalProxy.class);
@@ -309,30 +333,33 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 		result.addAdvisor(ExposeInvocationInterceptor.ADVISOR);
 
-		StartupStep repositoryPostprocessorsStep = applicationStartup.start("spring.data.repository.postprocessors");
-		postProcessors.forEach(processor -> {
+		if (!postProcessors.isEmpty()) {
+			StartupStep repositoryPostprocessorsStep = onEvent(applicationStartup, "spring.data.repository.postprocessors",
+					repositoryInterface);
+			postProcessors.forEach(processor -> {
 
-			StartupStep singlePostProcessor = applicationStartup.start("spring.data.repository.postprocessor");
-			singlePostProcessor.tag("type", processor.getClass().getName());
-			processor.postProcess(result, information);
-			singlePostProcessor.end();
-		});
-		repositoryPostprocessorsStep.end();
+				StartupStep singlePostProcessor = onEvent(applicationStartup, "spring.data.repository.postprocessor",
+						repositoryInterface);
+				singlePostProcessor.tag("type", processor.getClass().getName());
+				processor.postProcess(result, information);
+				singlePostProcessor.end();
+			});
+			repositoryPostprocessorsStep.end();
+		}
 
 		if (DefaultMethodInvokingMethodInterceptor.hasDefaultMethods(repositoryInterface)) {
 			result.addAdvice(new DefaultMethodInvokingMethodInterceptor());
 		}
 
-		StartupStep queryExecutorsStep = applicationStartup.start("spring.data.repository.queryexecutors");
 		ProjectionFactory projectionFactory = getProjectionFactory(classLoader, beanFactory);
 		Optional<QueryLookupStrategy> queryLookupStrategy = getQueryLookupStrategy(queryLookupStrategyKey,
 				evaluationContextProvider);
 		result.addAdvice(new QueryExecutorMethodInterceptor(information, projectionFactory, queryLookupStrategy,
 				namedQueries, queryPostProcessors, methodInvocationListeners));
-		queryExecutorsStep.end();
 
-		composition = composition.append(RepositoryFragment.implemented(target));
-		result.addAdvice(new ImplementationMethodExecutionInterceptor(information, composition, methodInvocationListeners));
+		RepositoryComposition compositionToUse = composition.append(RepositoryFragment.implemented(target));
+		result.addAdvice(
+				new ImplementationMethodExecutionInterceptor(information, compositionToUse, methodInvocationListeners));
 
 		T repository = (T) result.getProxy(classLoader);
 		repositoryProxyStep.end();
@@ -357,6 +384,12 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		} catch (NoSuchBeanDefinitionException e) {
 			return ApplicationStartup.DEFAULT;
 		}
+	}
+
+	private StartupStep onEvent(ApplicationStartup applicationStartup, String name, Class<?> repositoryInterface) {
+
+		StartupStep step = applicationStartup.start(name);
+		return step.tag("repository", repositoryInterface.getName());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -373,25 +373,6 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 		return repository;
 	}
 
-	ApplicationStartup getStartup() {
-
-		try {
-
-			ApplicationStartup applicationStartup = beanFactory != null ? beanFactory.getBean(ApplicationStartup.class)
-					: ApplicationStartup.DEFAULT;
-
-			return applicationStartup != null ? applicationStartup : ApplicationStartup.DEFAULT;
-		} catch (NoSuchBeanDefinitionException e) {
-			return ApplicationStartup.DEFAULT;
-		}
-	}
-
-	private StartupStep onEvent(ApplicationStartup applicationStartup, String name, Class<?> repositoryInterface) {
-
-		StartupStep step = applicationStartup.start(name);
-		return step.tag("repository", repositoryInterface.getName());
-	}
-
 	/**
 	 * Returns the {@link ProjectionFactory} to be used with the repository instances created.
 	 *
@@ -571,6 +552,25 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 				.orElseThrow(() -> new IllegalStateException(String.format(
 						"No suitable constructor found on %s to match the given arguments: %s. Make sure you implement a constructor taking these",
 						baseClass, Arrays.stream(constructorArguments).map(Object::getClass).collect(Collectors.toList()))));
+	}
+
+	private ApplicationStartup getStartup() {
+
+		try {
+
+			ApplicationStartup applicationStartup = beanFactory != null ? beanFactory.getBean(ApplicationStartup.class)
+					: ApplicationStartup.DEFAULT;
+
+			return applicationStartup != null ? applicationStartup : ApplicationStartup.DEFAULT;
+		} catch (NoSuchBeanDefinitionException e) {
+			return ApplicationStartup.DEFAULT;
+		}
+	}
+
+	private StartupStep onEvent(ApplicationStartup applicationStartup, String name, Class<?> repositoryInterface) {
+
+		StartupStep step = applicationStartup.start(name);
+		return step.tag("repository", repositoryInterface.getName());
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -405,6 +405,13 @@ class RepositoryFactorySupportUnitTests {
 		assertThatThrownBy(repository::getFindRouteQuery).isInstanceOf(EmptyResultDataAccessException.class);
 	}
 
+	@Test // DATACMNS-1832
+	void callsApplicationStartupOnRepositoryIntialization() {
+
+		factory.getRepository(ObjectRepository.class, backingRepo);
+		verify(factory.getApplicationStartup()).start("spring.data.repository.init");
+	}
+
 	private ConvertingRepository prepareConvertingRepository(final Object expectedValue) {
 
 		when(factory.queryOne.execute(any(Object[].class))).then(invocation -> {

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -42,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.metrics.ApplicationStartup;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -406,10 +408,19 @@ class RepositoryFactorySupportUnitTests {
 	}
 
 	@Test // DATACMNS-1832
-	void callsApplicationStartupOnRepositoryIntialization() {
+	void callsApplicationStartupOnRepositoryInitialization() {
 
 		factory.getRepository(ObjectRepository.class, backingRepo);
-		verify(factory.getApplicationStartup()).start("spring.data.repository.init");
+
+		ApplicationStartup startup = factory.getApplicationStartup();
+
+		InOrder orderedInvocation = Mockito.inOrder(startup);
+		orderedInvocation.verify(startup).start("spring.data.repository.init");
+		orderedInvocation.verify(startup).start("spring.data.repository.metadata");
+		orderedInvocation.verify(startup).start("spring.data.repository.composition");
+		orderedInvocation.verify(startup).start("spring.data.repository.target");
+		orderedInvocation.verify(startup).start("spring.data.repository.proxy");
+		orderedInvocation.verify(startup).start("spring.data.repository.postprocessors");
 	}
 
 	private ConvertingRepository prepareConvertingRepository(final Object expectedValue) {

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -420,7 +420,6 @@ class RepositoryFactorySupportUnitTests {
 		orderedInvocation.verify(startup).start("spring.data.repository.composition");
 		orderedInvocation.verify(startup).start("spring.data.repository.target");
 		orderedInvocation.verify(startup).start("spring.data.repository.proxy");
-		orderedInvocation.verify(startup).start("spring.data.repository.postprocessors");
 	}
 
 	private ConvertingRepository prepareConvertingRepository(final Object expectedValue) {


### PR DESCRIPTION
Add support for collecting data repository startup metrics using core framework `ApplicationStartup` and `StartupStep`.
Collected metrics can be stored with Java Flight Recorder when using a `FlightRecorderApplicationStartup` or exposed via Spring Boot `startup` Actuator endpoint `http POST :/actuator/startup`

Metrics are collected under `spring.data.repository` and contain the overall `init` time, as well as information about post processing, metadata collection, etc.
Specifics about the number of repository fragments or the repository interface type are provided via `tags` as shown in the snippet below. 

```json
{
  "startupStep": {
    "name": "spring.data.repository.init",
    "id": 120,
    "parentId": 98,
    "tags": [
      {
        "key": "repository",
        "value": "com.example.demo.PersonRepo"
      }
    ]
  },
  "startTime": "2021-01-14T12:31:45.461911319Z",
  "endTime": "2021-01-14T12:31:45.481086739Z",
  "duration": "PT0.01917542S"
}
```

Closes #2247