### PR TITLE
Deprecate ChainedTransactionManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-2232-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 


### PR DESCRIPTION
We recommend to not use `ChainedTransactionManager` as it emulates distributed transactions without providing consistency guarantees that can end up in partially committed transactions. To attach to commit/rollback operations we recommend registering `TransactionSynchronization` instead.

Closes #2232.