### PR TITLE
Throw UnsupportedOperationException when a projected value cannot be returned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-2290-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
@@ -222,8 +222,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 			return null;
 		}
 
-		TypeInformation<?> type = property.getTypeInformation().getRequiredActualType();
-		return Pair.of(path.append(property), iterator.hasNext() ? context.getRequiredPersistentEntity(type) : entity);
+		return Pair.of(path.append(property), iterator.hasNext() ? context.getRequiredPersistentEntity(property) : entity);
 	}
 
 	private <T> Collection<PersistentPropertyPath<P>> from(TypeInformation<T> type, Predicate<? super P> filter,
@@ -236,6 +235,12 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 		}
 
 		E entity = context.getRequiredPersistentEntity(actualType);
+		return from(entity, filter, traversalGuard, basePath);
+	}
+
+	private Collection<PersistentPropertyPath<P>> from(E entity, Predicate<? super P> filter, Predicate<P> traversalGuard,
+			DefaultPersistentPropertyPath<P> basePath) {
+
 		Set<PersistentPropertyPath<P>> properties = new HashSet<>();
 
 		PropertyHandler<P> propertyTester = persistentProperty -> {
@@ -254,7 +259,7 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 			}
 
 			if (traversalGuard.and(IS_ENTITY).test(persistentProperty)) {
-				properties.addAll(from(typeInformation, filter, traversalGuard, currentPath));
+				properties.addAll(from(context.getPersistentEntity(persistentProperty), filter, traversalGuard, currentPath));
 			}
 		};
 

--- a/src/test/java/org/springframework/data/projection/ProjectingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/ProjectingMethodInterceptorUnitTests.java
@@ -43,6 +43,7 @@ import org.springframework.core.convert.support.DefaultConversionService;
  * @author Oliver Gierke
  * @author Saulo Medeiros de Araujo
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @ExtendWith(MockitoExtension.class)
 class ProjectingMethodInterceptorUnitTests {
@@ -96,7 +97,7 @@ class ProjectingMethodInterceptorUnitTests {
 		verify(factory, times(0)).createProjection((Class<?>) any(), any());
 	}
 
-	@Test // #2290
+	@Test // GH-2290
 	void failsForNonConvertibleTypes() throws Throwable {
 
 		MethodInterceptor methodInterceptor = new ProjectingMethodInterceptor(factory, interceptor, conversionService);
@@ -106,7 +107,6 @@ class ProjectingMethodInterceptorUnitTests {
 
 		assertThatThrownBy(() -> methodInterceptor.invoke(invocation)) //
 				.isInstanceOf(UnsupportedOperationException.class) //
-				.hasMessageContaining("'1'") //
 				.hasMessageContaining("BigInteger") //
 				.hasMessageContaining("boolean");
 	}


### PR DESCRIPTION
We now throw `UnsupportedOperationException` when a projected value cannot be returned because it cannot be brought into the target type, either via conversion or projection.

This exception improves the error message by avoiding throwing `IllegalArgumentException`: Projection type must be an interface from the last branch that falls back into projections.

Closes #2290.

---


Could be backported into 2.3.x and 2.4.x branches.