### PR TITLE
Add support for providing default Querydsl bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-206-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -1667,6 +1667,8 @@ interface UserRepository extends CrudRepository<User, String>,
 <5> Exclude the `password` property from `Predicate` resolution.
 ====
 
+Additionally, you can register a `DefaultQuerydslBinderCustomizer` bean to apply default Querydsl bindings before applying specific bindings from the repository or `@QuerydslPredicate`.
+
 [[core.repository-populators]]
 === Repository Populators
 

--- a/src/main/java/org/springframework/data/querydsl/binding/DefaultQuerydslBinderCustomizer.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/DefaultQuerydslBinderCustomizer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.querydsl.binding;
+
+import com.querydsl.core.types.EntityPath;
+
+/**
+ * A component for {@link QuerydslBindings} customization acting as default customizer the given entity path regardless
+ * of the domain type. Instances can be registered with the application context to be applied.
+ *
+ * @author Mark Paluch
+ * @since 2.5
+ */
+public interface DefaultQuerydslBinderCustomizer extends QuerydslBinderCustomizer<EntityPath<?>> {}


### PR DESCRIPTION
We now consider default Querydsl bindings when registering a `DefaultQuerydslBinderCustomizer` bean. The default bindings are applied before applying type-specific bindings.

Closes #206.