### PR TITLE
Collect constructor type information via Constructor.getParameters()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-2313-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -175,14 +176,10 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 
 		Assert.notNull(constructor, "Constructor must not be null!");
 
-		Type[] types = constructor.getGenericParameterTypes();
-		List<TypeInformation<?>> result = new ArrayList<>(types.length);
-
-		for (Type parameterType : types) {
-			result.add(createInfo(parameterType));
-		}
-
-		return result;
+		return Arrays.stream(constructor.getParameters())
+				.map(Parameter::getParameterizedType)
+				.map(this::createInfo)
+				.collect(Collectors.toList());
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -176,10 +176,11 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 
 		Assert.notNull(constructor, "Constructor must not be null!");
 
-		return Arrays.stream(constructor.getParameters())
-				.map(Parameter::getParameterizedType)
-				.map(this::createInfo)
-				.collect(Collectors.toList());
+		List<TypeInformation<?>> parameterTypes = new ArrayList<>(constructor.getParameterCount());
+		for(Parameter parameter : constructor.getParameters()) {
+			parameterTypes.add(createInfo(parameter.getParameterizedType()));
+		}
+		return parameterTypes;
 	}
 
 	/*


### PR DESCRIPTION
This PR fixes an issue where we fail to detect all type arguments from a given `Constructor`. 
As calling `getGenericParameterTypes()` in some cases does not include all `Type`s, we now explicitly iterate over the parameters and extract the parameterized type that is used for creating the `TypeInformation`.

Closes: #2313 