### PR TITLE
Support for jMolecules' Association type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,13 @@
 			<version>0.1.4</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.jmolecules.integrations</groupId>
+			<artifactId>jmolecules-spring</artifactId>
+			<version>${jmolecules-integration}</version>
+			<optional>true</optional>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -78,6 +78,7 @@ public class CustomConversions {
 		defaults.addAll(JodaTimeConverters.getConvertersToRegister());
 		defaults.addAll(Jsr310Converters.getConvertersToRegister());
 		defaults.addAll(ThreeTenBackPortConverters.getConvertersToRegister());
+		defaults.addAll(JMoleculesConverters.getConvertersToRegister());
 
 		DEFAULT_CONVERTERS = Collections.unmodifiableList(defaults);
 	}

--- a/src/main/java/org/springframework/data/convert/JMoleculesConverters.java
+++ b/src/main/java/org/springframework/data/convert/JMoleculesConverters.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.jmolecules.spring.AssociationToPrimitivesConverter;
+import org.jmolecules.spring.IdentifierToPrimitivesConverter;
+import org.jmolecules.spring.PrimitivesToAssociationConverter;
+import org.jmolecules.spring.PrimitivesToIdentifierConverter;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Registers jMolecules converter implementations with {@link CustomConversions} if the former is on the classpath.
+ *
+ * @author Oliver Drotbohm
+ * @since 2.5
+ */
+public class JMoleculesConverters {
+
+	private static final boolean JMOLECULES_PRESENT = ClassUtils.isPresent(
+			"org.jmolecules.spring.IdentifierToPrimitivesConverter",
+			JMoleculesConverters.class.getClassLoader());
+
+	/**
+	 * Returns all jMolecules-specific converters to be registered.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	public static Collection<Object> getConvertersToRegister() {
+
+		if (!JMOLECULES_PRESENT) {
+			return Collections.emptyList();
+		}
+
+		List<Object> converters = new ArrayList<>();
+
+		Supplier<ConversionService> conversionService = () -> DefaultConversionService.getSharedInstance();
+
+		IdentifierToPrimitivesConverter toPrimitives = new IdentifierToPrimitivesConverter(conversionService);
+		PrimitivesToIdentifierConverter toIdentifier = new PrimitivesToIdentifierConverter(conversionService);
+
+		converters.add(toPrimitives);
+		converters.add(toIdentifier);
+		converters.add(new AssociationToPrimitivesConverter<>(toPrimitives));
+		converters.add(new PrimitivesToAssociationConverter<>(toIdentifier));
+
+		return converters;
+	}
+}

--- a/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
@@ -43,9 +43,13 @@ import org.springframework.util.Assert;
 public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>> implements PersistentProperty<P> {
 
 	private static final Field CAUSE_FIELD;
+	private static final Class<?> ASSOCIATION_TYPE;
 
 	static {
+
 		CAUSE_FIELD = ReflectionUtils.findRequiredField(Throwable.class, "cause");
+		ASSOCIATION_TYPE = ReflectionUtils.loadIfPresent("org.jmolecules.ddd.types.Association",
+				AbstractPersistentProperty.class.getClassLoader());
 	}
 
 	private final String name;
@@ -241,7 +245,8 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 	 */
 	@Override
 	public boolean isAssociation() {
-		return isAnnotationPresent(Reference.class);
+		return isAnnotationPresent(Reference.class) //
+				|| ASSOCIATION_TYPE != null && ASSOCIATION_TYPE.isAssignableFrom(rawType);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/mapping/model/AnnotationBasedPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AnnotationBasedPersistentProperty.java
@@ -70,7 +70,8 @@ public abstract class AnnotationBasedPersistentProperty<P extends PersistentProp
 
 	private final Lazy<Boolean> isWritable = Lazy
 			.of(() -> !isTransient() && !isAnnotationPresent(ReadOnlyProperty.class));
-	private final Lazy<Boolean> isReference = Lazy.of(() -> !isTransient() && isAnnotationPresent(Reference.class));
+	private final Lazy<Boolean> isReference = Lazy.of(() -> !isTransient() //
+			&& (isAnnotationPresent(Reference.class) || super.isAssociation()));
 	private final Lazy<Boolean> isId = Lazy.of(() -> isAnnotationPresent(Id.class));
 	private final Lazy<Boolean> isVersion = Lazy.of(() -> isAnnotationPresent(Version.class));
 

--- a/src/main/java/org/springframework/data/util/ReflectionUtils.java
+++ b/src/main/java/org/springframework/data/util/ReflectionUtils.java
@@ -475,4 +475,21 @@ public final class ReflectionUtils {
 		throw new IllegalArgumentException(String.format("Primitive type %s not supported!", type));
 	}
 
+	/**
+	 * Loads the class with the given name using the given {@link ClassLoader}.
+	 *
+	 * @param name the name of the class to be loaded.
+	 * @param classLoader the {@link ClassLoader} to use to load the class.
+	 * @return the {@link Class} or {@literal null} in case the class can't be loaded for any reason.
+	 * @since 2.5
+	 */
+	@Nullable
+	public static Class<?> loadIfPresent(String name, ClassLoader classLoader) {
+
+		try {
+			return ClassUtils.forName(name, classLoader);
+		} catch (Exception o_O) {
+			return null;
+		}
+	}
 }

--- a/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.convert;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.text.DateFormat;
@@ -28,6 +29,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import org.jmolecules.ddd.types.Association;
+import org.jmolecules.ddd.types.Identifier;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.framework.ProxyFactory;
@@ -270,6 +273,24 @@ class CustomConversionsUnitTests {
 		new CustomConversions(config).registerConvertersIn(registry);
 
 		verify(registry).addConverter(any(LocalDateTimeToDateConverter.class));
+	}
+
+	@Test // GH-2315
+	void addsAssociationConvertersByDefault() {
+
+		CustomConversions conversions = new CustomConversions(StoreConversions.NONE, Collections.emptyList());
+
+		assertThat(conversions.hasCustomWriteTarget(Association.class)).isTrue();
+		assertThat(conversions.hasCustomReadTarget(Object.class, Association.class)).isTrue();
+	}
+
+	@Test // GH-2315
+	void addsIdentifierConvertersByDefault() {
+
+		CustomConversions conversions = new CustomConversions(StoreConversions.NONE, Collections.emptyList());
+
+		assertThat(conversions.hasCustomWriteTarget(Identifier.class)).isTrue();
+		assertThat(conversions.hasCustomReadTarget(String.class, Identifier.class)).isTrue();
 	}
 
 	private static Class<?> createProxyTypeFor(Class<?> type) {

--- a/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
@@ -224,6 +224,14 @@ public class AbstractPersistentPropertyUnitTests {
 		assertThat(property.getGetter()).isNotNull();
 	}
 
+	@Test // GH-2315
+	void detectsJMoleculesAssociation() {
+
+		SamplePersistentProperty property = getProperty(JMolecules.class, "association");
+
+		assertThat(property.isAssociation()).isTrue();
+	}
+
 	private <T> BasicPersistentEntity<T, SamplePersistentProperty> getEntity(Class<T> type) {
 		return new BasicPersistentEntity<>(ClassTypeInformation.from(type));
 	}
@@ -345,11 +353,6 @@ public class AbstractPersistentPropertyUnitTests {
 		}
 
 		@Override
-		public boolean isAssociation() {
-			return false;
-		}
-
-		@Override
 		protected Association<SamplePersistentProperty> createAssociation() {
 			return null;
 		}
@@ -386,5 +389,9 @@ public class AbstractPersistentPropertyUnitTests {
 
 	class TreeMapWrapper {
 		TreeMap<String, TreeMap<String, String>> map;
+	}
+
+	class JMolecules {
+		org.jmolecules.ddd.types.Association association;
 	}
 }

--- a/src/test/java/org/springframework/data/mapping/model/AnnotationBasedPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/AnnotationBasedPersistentPropertyUnitTests.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.jmolecules.ddd.types.Association;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.annotation.AliasFor;
@@ -293,6 +294,11 @@ public class AnnotationBasedPersistentPropertyUnitTests<P extends AnnotationBase
 				.withMessageContaining(NoField.class.getName());
 	}
 
+	@Test // GH-2315
+	void detectesJMoleculesAssociation() {
+		assertThat(getProperty(JMolecules.class, "association").isAssociation()).isTrue();
+	}
+
 	@SuppressWarnings("unchecked")
 	private Map<Class<? extends Annotation>, Annotation> getAnnotationCache(SamplePersistentProperty property) {
 		return (Map<Class<? extends Annotation>, Annotation>) ReflectionTestUtils.getField(property, "annotationCache");
@@ -414,8 +420,7 @@ public class AnnotationBasedPersistentPropertyUnitTests<P extends AnnotationBase
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(value = { FIELD, METHOD, ANNOTATION_TYPE })
 	@Id
-	public @interface MyId {
-	}
+	public @interface MyId {}
 
 	static class FieldAccess {
 		String name;
@@ -476,5 +481,9 @@ public class AnnotationBasedPersistentPropertyUnitTests<P extends AnnotationBase
 	interface NoField {
 
 		String getFirstname();
+	}
+
+	static class JMolecules {
+		Association association;
 	}
 }


### PR DESCRIPTION
We no recognize properties of type `org.jmolecules.ddd.types.Association` as associations in our `PersistentProperty` model.

Also, we now register JMolecules' `Converter` implementations for `Association` and `Identifier` in `CustomConversions` so that they can persisted like their embedded primitive value out of the box.

Fixes #2315.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
