### PR TITLE
Improve error message if store module doesn't support a well-known fragment interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-2341-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 
@@ -339,7 +339,7 @@
 			<version>0.1.4</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.jmolecules.integrations</groupId>
 			<artifactId>jmolecules-spring</artifactId>

--- a/src/main/java/org/springframework/data/repository/core/RepositoryCreationException.java
+++ b/src/main/java/org/springframework/data/repository/core/RepositoryCreationException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core;
+
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+
+/**
+ * Exception thrown in the context of repository creation.
+ *
+ * @author Mark Paluch
+ * @since 2.5
+ */
+@SuppressWarnings("serial")
+public class RepositoryCreationException extends InvalidDataAccessApiUsageException {
+
+	private final Class<?> repositoryInterface;
+
+	/**
+	 * Constructor for RepositoryCreationException.
+	 *
+	 * @param msg the detail message.
+	 * @param repositoryInterface the repository interface.
+	 */
+	public RepositoryCreationException(String msg, Class<?> repositoryInterface) {
+		super(msg);
+		this.repositoryInterface = repositoryInterface;
+	}
+
+	/**
+	 * Constructor for RepositoryException.
+	 *
+	 * @param msg the detail message.
+	 * @param cause the root cause from the data access API in use.
+	 * @param repositoryInterface the repository interface.
+	 */
+	public RepositoryCreationException(String msg, Throwable cause, Class<?> repositoryInterface) {
+		super(msg, cause);
+		this.repositoryInterface = repositoryInterface;
+	}
+
+	public Class<?> getRepositoryInterface() {
+		return repositoryInterface;
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/FragmentNotImplementedException.java
+++ b/src/main/java/org/springframework/data/repository/core/support/FragmentNotImplementedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import org.springframework.data.repository.core.RepositoryCreationException;
+
+/**
+ * Exception thrown during repository creation or repository method invocation when invoking a repository method on a
+ * fragment without an implementation.
+ *
+ * @author Mark Paluch
+ * @since 2.5
+ */
+@SuppressWarnings("serial")
+public class FragmentNotImplementedException extends RepositoryCreationException {
+
+	private final RepositoryFragment<?> fragment;
+
+	/**
+	 * Constructor for FragmentNotImplementedException.
+	 *
+	 * @param msg the detail message.
+	 * @param repositoryInterface the repository interface.
+	 * @param fragment the offending repository fragment.
+	 */
+	public FragmentNotImplementedException(String msg, Class<?> repositoryInterface, RepositoryFragment<?> fragment) {
+		super(msg, repositoryInterface);
+		this.fragment = fragment;
+	}
+
+	public RepositoryFragment<?> getFragment() {
+		return fragment;
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/IncompleteRepositoryCompositionException.java
+++ b/src/main/java/org/springframework/data/repository/core/support/IncompleteRepositoryCompositionException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import org.springframework.data.repository.core.RepositoryCreationException;
+
+/**
+ * Exception thrown during repository creation when a the repository has custom methods that are not backed by a
+ * fragment or if no fragment could be found for a repository method invocation.
+ *
+ * @author Mark Paluch
+ * @since 2.5
+ */
+@SuppressWarnings("serial")
+public class IncompleteRepositoryCompositionException extends RepositoryCreationException {
+
+	/**
+	 * Constructor for IncompleteRepositoryCompositionException.
+	 *
+	 * @param msg the detail message.
+	 * @param repositoryInterface the repository interface.
+	 */
+	public IncompleteRepositoryCompositionException(String msg, Class<?> repositoryInterface) {
+		super(msg, repositoryInterface);
+	}
+}

--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptor.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.RepositoryInvocationMulticaster.DefaultRepositoryInvocationMulticaster;
 import org.springframework.data.repository.core.support.RepositoryInvocationMulticaster.NoOpRepositoryInvocationMulticaster;
+import org.springframework.data.repository.query.QueryCreationException;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
@@ -97,7 +98,13 @@ class QueryExecutorMethodInterceptor implements MethodInterceptor {
 
 	private Pair<Method, RepositoryQuery> lookupQuery(Method method, RepositoryInformation information,
 			QueryLookupStrategy strategy, ProjectionFactory projectionFactory) {
-		return Pair.of(method, strategy.resolveQuery(method, information, projectionFactory, namedQueries));
+		try {
+			return Pair.of(method, strategy.resolveQuery(method, information, projectionFactory, namedQueries));
+		} catch (QueryCreationException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			throw QueryCreationException.create(e.getMessage(), e, information.getRepositoryInterface(), method);
+		}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryComposition.java
@@ -316,8 +316,12 @@ public class RepositoryComposition {
 	public void validateImplementation() {
 
 		fragments.stream().forEach(it -> it.getImplementation() //
-				.orElseThrow(() -> new IllegalStateException(String.format("Fragment %s has no implementation.",
-						ClassUtils.getQualifiedName(it.getSignatureContributor())))));
+				.orElseThrow(() -> {
+					Class<?> repositoryInterface = metadata != null ? metadata.getRepositoryInterface() : Object.class;
+					return new FragmentNotImplementedException(String.format("Fragment %s used in %s has no implementation.",
+							ClassUtils.getQualifiedName(it.getSignatureContributor()),
+							ClassUtils.getQualifiedName(repositoryInterface)), repositoryInterface, it);
+				}));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/repository/core/support/UnsupportedFragmentException.java
+++ b/src/main/java/org/springframework/data/repository/core/support/UnsupportedFragmentException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import org.springframework.data.repository.core.RepositoryCreationException;
+
+/**
+ * Exception thrown during repository creation when a well-known fragment interface is not supported by the repository
+ * factory.
+ *
+ * @author Mark Paluch
+ * @since 2.5
+ */
+@SuppressWarnings("serial")
+public class UnsupportedFragmentException extends RepositoryCreationException {
+
+	private final Class<?> fragmentInterface;
+
+	/**
+	 * Constructor for UnsupportedFragmentException.
+	 *
+	 * @param msg the detail message.
+	 * @param repositoryInterface the repository interface.
+	 * @param fragmentInterface the offending fragment interface.
+	 */
+	public UnsupportedFragmentException(String msg, Class<?> repositoryInterface, Class<?> fragmentInterface) {
+		super(msg, repositoryInterface);
+		this.fragmentInterface = fragmentInterface;
+	}
+
+	public Class<?> getFragmentInterface() {
+		return fragmentInterface;
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/QueryCreationException.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryCreationException.java
@@ -15,24 +15,39 @@
  */
 package org.springframework.data.repository.query;
 
+import java.lang.reflect.Method;
+
+import org.springframework.data.repository.core.RepositoryCreationException;
+
 /**
- * Exception to be thrown if a query cannot be created from a {@link QueryMethod}.
+ * Exception to be thrown if a query cannot be created from a {@link Method}.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
-public final class QueryCreationException extends RuntimeException {
+public final class QueryCreationException extends RepositoryCreationException {
 
 	private static final long serialVersionUID = -1238456123580L;
 	private static final String MESSAGE_TEMPLATE = "Could not create query for method %s! Could not find property %s on domain class %s.";
 
+	private final Method method;
+
 	/**
 	 * Creates a new {@link QueryCreationException}.
-	 *
-	 * @param method
 	 */
-	private QueryCreationException(String message) {
+	private QueryCreationException(String message, QueryMethod method) {
 
-		super(message);
+		super(message, method.getMetadata().getRepositoryInterface());
+		this.method = method.getMethod();
+	}
+
+	/**
+	 * Creates a new {@link QueryCreationException}.
+	 */
+	private QueryCreationException(String message, Throwable cause, Class<?> repositoryInterface, Method method) {
+
+		super(message, cause, repositoryInterface);
+		this.method = method;
 	}
 
 	/**
@@ -45,7 +60,7 @@ public final class QueryCreationException extends RuntimeException {
 	public static QueryCreationException invalidProperty(QueryMethod method, String propertyName) {
 
 		return new QueryCreationException(String.format(MESSAGE_TEMPLATE, method, propertyName, method.getDomainClass()
-				.getName()));
+				.getName()), method);
 	}
 
 	/**
@@ -57,7 +72,8 @@ public final class QueryCreationException extends RuntimeException {
 	 */
 	public static QueryCreationException create(QueryMethod method, String message) {
 
-		return new QueryCreationException(String.format("Could not create query for %s! Reason: %s", method, message));
+		return new QueryCreationException(String.format("Could not create query for %s! Reason: %s", method, message),
+				method);
 	}
 
 	/**
@@ -68,7 +84,29 @@ public final class QueryCreationException extends RuntimeException {
 	 * @return
 	 */
 	public static QueryCreationException create(QueryMethod method, Throwable cause) {
+		return new QueryCreationException(cause.getMessage(), cause, method.getMetadata().getRepositoryInterface(),
+				method.getMethod());
+	}
 
-		return create(method, cause.getMessage());
+	/**
+	 * Creates a new {@link QueryCreationException} for the given {@link QueryMethod} and {@link Throwable} as cause.
+	 *
+	 * @param method
+	 * @param cause
+	 * @return
+	 * @since 2.5
+	 */
+	public static QueryCreationException create(String message, Throwable cause, Class<?> repositoryInterface,
+			Method method) {
+		return new QueryCreationException(String.format("Could not create query for %s! Reason: %s", method, message),
+				cause, repositoryInterface, method);
+	}
+
+	/**
+	 * @return
+	 * @since 2.5
+	 */
+	public Method getMethod() {
+		return method;
 	}
 }

--- a/src/main/java/org/springframework/data/repository/query/QueryMethod.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethod.java
@@ -241,6 +241,14 @@ public class QueryMethod {
 		return resultProcessor;
 	}
 
+	RepositoryMetadata getMetadata() {
+		return metadata;
+	}
+
+	Method getMethod() {
+		return method;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryCompositionUnitTests.java
@@ -136,16 +136,17 @@ class RepositoryCompositionUnitTests {
 		assertThat(barFoo.invoke(barFoo.findMethod(getString).get())).isEqualTo("bar");
 	}
 
-	@Test // DATACMNS-102
+	@Test // DATACMNS-102, GH-2341
 	void shouldValidateStructuralFragments() {
 
 		RepositoryComposition mixed = RepositoryComposition.of(RepositoryFragment.structural(QueryByExampleExecutor.class),
 				RepositoryFragment.implemented(backingRepo));
 
-		assertThatIllegalStateException() //
+		assertThatExceptionOfType(FragmentNotImplementedException.class) //
 				.isThrownBy(mixed::validateImplementation) //
 				.withMessageContaining(
-						"Fragment org.springframework.data.repository.query.QueryByExampleExecutor has no implementation.");
+						"Fragment org.springframework.data.repository.query.QueryByExampleExecutor")
+				.withMessageContaining("has no implementation");
 	}
 
 	@Test // DATACMNS-102


### PR DESCRIPTION
We now throw a `RepositoryCreationException` (or subclass) when a repository cannot be created due to a missing fragment, a fragment without implementation or if a well-known fragment is not supported by the repository factory.

Closes #2341