### PR TITLE
Address the issue of missing sort criteria in the case of Entity class (TypedSort)

### DIFF
--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -738,14 +738,10 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 		 */
 		@Override
 		public String toString() {
-			System.out.println("REcord: "+ recorded.getPropertyPath() //
-					.map(Sort::by));
-			String s = recorded.getPropertyPath() //
+			return recorded.getPropertyPath() //
 					.map(Sort::by) //
 					.orElseGet(Sort::unsorted) //
 					.toString();
-			System.out.println("S: " + s);
-			return s;
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Hiufung Kwok
  */
 public class Sort implements Streamable<org.springframework.data.domain.Sort.Order>, Serializable {
 
@@ -48,7 +49,6 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 	private static final Sort UNSORTED = Sort.by(new Order[0]);
 
 	public static final Direction DEFAULT_DIRECTION = Direction.ASC;
-
 
 	private final List<Order> orders;
 
@@ -188,6 +188,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 	public Sort and(Sort sort) {
 
 		Assert.notNull(sort, "Sort must not be null!");
+
 		ArrayList<Order> these = new ArrayList<>(this.getOrders());
 
 		for (Order order : sort) {

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -728,6 +728,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 
 		@Override
 		public List<Order> getOrders() {
+
 			return recorded.getPropertyPath() //
 					.map(Sort::by) //
 					.orElseGet(Sort::unsorted).getOrders();

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -740,6 +740,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 		 */
 		@Override
 		public String toString() {
+
 			return recorded.getPropertyPath() //
 					.map(Sort::by) //
 					.orElseGet(Sort::unsorted) //

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -49,6 +49,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 
 	public static final Direction DEFAULT_DIRECTION = Direction.ASC;
 
+
 	private final List<Order> orders;
 
 	protected Sort(List<Order> orders) {
@@ -187,8 +188,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 	public Sort and(Sort sort) {
 
 		Assert.notNull(sort, "Sort must not be null!");
-
-		ArrayList<Order> these = new ArrayList<>(this.orders);
+		ArrayList<Order> these = new ArrayList<>(this.getOrders());
 
 		for (Order order : sort) {
 			these.add(order);
@@ -262,6 +262,10 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 	@Override
 	public String toString() {
 		return orders.isEmpty() ? "UNSORTED" : StringUtils.collectionToCommaDelimitedString(orders);
+	}
+
+	public List<Order> getOrders() {
+		return orders;
 	}
 
 	/**
@@ -721,17 +725,27 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 
 		}
 
+		@Override
+		public List<Order> getOrders() {
+			return recorded.getPropertyPath() //
+					.map(Sort::by) //
+					.orElseGet(Sort::unsorted).getOrders();
+		}
+
 		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.domain.Sort#toString()
 		 */
 		@Override
 		public String toString() {
-
-			return recorded.getPropertyPath() //
+			System.out.println("REcord: "+ recorded.getPropertyPath() //
+					.map(Sort::by));
+			String s = recorded.getPropertyPath() //
 					.map(Sort::by) //
 					.orElseGet(Sort::unsorted) //
 					.toString();
+			System.out.println("S: " + s);
+			return s;
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/domain/SortUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/SortUnitTests.java
@@ -97,20 +97,6 @@ class SortUnitTests {
 		assertThat(sort).containsExactly(Order.by("foo"), Order.by("bar"));
 	}
 
-
-	public class test_class {
-		public String prop_1;
-		public String prop_2;
-
-		public String getProp_1() {
-			return prop_1;
-		}
-
-		public String getProp_2() {
-			return prop_2;
-		}
-	}
-
 	@Test //DATACMNS-1704
 	void allowsCombiningTypedSorts() {
 		Sort sort = Sort.sort(Circle.class).by(Circle::getCenter)

--- a/src/test/java/org/springframework/data/domain/SortUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/SortUnitTests.java
@@ -36,6 +36,7 @@ import org.springframework.data.geo.Circle;
  * @author Kevin Raymond
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Hiufung Kwok
  */
 class SortUnitTests {
 

--- a/src/test/java/org/springframework/data/domain/SortUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/SortUnitTests.java
@@ -20,11 +20,14 @@ import static org.springframework.data.domain.Sort.NullHandling.*;
 
 import lombok.Getter;
 
+import java.math.BigInteger;
 import java.util.Collection;
+import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.geo.Circle;
 
 /**
  * Unit test for {@link Sort}.
@@ -92,6 +95,27 @@ class SortUnitTests {
 
 		Sort sort = Sort.by("foo").and(Sort.by("bar"));
 		assertThat(sort).containsExactly(Order.by("foo"), Order.by("bar"));
+	}
+
+
+	public class test_class {
+		public String prop_1;
+		public String prop_2;
+
+		public String getProp_1() {
+			return prop_1;
+		}
+
+		public String getProp_2() {
+			return prop_2;
+		}
+	}
+
+	@Test //DATACMNS-1704
+	void allowsCombiningTypedSorts() {
+		Sort sort = Sort.sort(Circle.class).by(Circle::getCenter)
+				.and(Sort.sort(Circle.class).by(Circle::getRadius));
+		assertThat(sort).containsExactly(Order.by("center"), Order.by("radius"));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/domain/SortUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/SortUnitTests.java
@@ -20,9 +20,7 @@ import static org.springframework.data.domain.Sort.NullHandling.*;
 
 import lombok.Getter;
 
-import java.math.BigInteger;
 import java.util.Collection;
-import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort.Direction;


### PR DESCRIPTION
Closes https://github.com/spring-projects/spring-data-commons/issues/2103
This is a Pull Request to address the issue reported on DATACMNS-1704, to add a getter method for property `orders` on both classes `Sort` and its child class `TypedSort` in order to handle the case that the user invokes multiple sort orders with custom entity class.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
