### PR TITLE
Fix broken link to Spring framework docs.

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -1,4 +1,4 @@
-:spring-framework-docs: https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference
+:spring-framework-docs: https://docs.spring.io/spring-framework/docs/{springVersion}/reference/html
 :spring-framework-javadoc: https://docs.spring.io/spring/docs/{springVersion}/javadoc-api
 
 [[repositories]]


### PR DESCRIPTION
Quick fix for the broken link to Spring framework docs.