### PR TITLE
Fix `EvaluationContextExtension` filter fall-through in `ReactiveExtensionAwareEvaluationContextProvider`

### DIFF
--- a/src/main/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProvider.java
@@ -125,6 +125,8 @@ public class ReactiveExtensionAwareEvaluationContextProvider implements Reactive
 				if (extensionFilter.test(information)) {
 					return Mono.just(extension);
 				}
+
+				return Mono.empty();
 			}
 
 			if (it instanceof ReactiveEvaluationContextExtension) {


### PR DESCRIPTION
When a ReactiveMongoRepository uses an @Query annotation, I get a java.lang.IllegalStateException: Unsupported extension type: org.springframework.data.jpa.repository.support.JpaEvaluationContextExtension thrown by ReactiveExtensionAwareEvaluationContextProvider after upgrading to spring-data-commons 2.4x+. It appears that the if (it instanceof EvaluationContextExtension) { clause is missing a return Mono.empty(); when extensionFilter.test(information) returns false like if (it instanceof ReactiveEvaluationContextExtension) { has. This allows it to fall through and return the Mono.error(...).

Closes #2392