### PR TITLE
Don't create PersistentEntity for Nullable wrapper type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-GH-2390-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -34,7 +34,6 @@ import java.util.stream.StreamSupport;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
@@ -116,7 +115,8 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 		this.persistentPropertyPathFactory = new PersistentPropertyPathFactory<>(this);
 
 		EntityInstantiators instantiators = new EntityInstantiators();
-		PersistentPropertyAccessorFactory accessorFactory = NativeDetector.inNativeImage() ? BeanWrapperPropertyAccessorFactory.INSTANCE
+		PersistentPropertyAccessorFactory accessorFactory = NativeDetector.inNativeImage()
+				? BeanWrapperPropertyAccessorFactory.INSTANCE
 				: new ClassGeneratingPropertyAccessorFactory();
 
 		this.persistentPropertyAccessorFactory = new InstantiationAwarePropertyAccessorFactory(accessorFactory,
@@ -485,7 +485,8 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 		if (simpleTypeHolder.isSimpleType(type.getType())) {
 			return false;
 		}
-		if(NullableWrapperConverters.supports(type.getType())) {
+
+		if (NullableWrapperConverters.supports(type.getType())) {
 			return false;
 		}
 
@@ -564,6 +565,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			if (shouldSkipOverrideProperty(property)) {
 				return;
 			}
+
 			entity.addPersistentProperty(property);
 
 			if (property.isAssociation()) {
@@ -574,18 +576,8 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 				return;
 			}
 
-			StreamSupport.stream(property.getPersistentEntityTypes().spliterator(), false)
-					.map(it -> {
-						if(it.isNullableWrapper()) {
-							return it.getActualType();
-						}
-						return it;
-					})
-					.filter(it -> {
-
-						boolean shouldCreate = AbstractMappingContext.this.shouldCreatePersistentEntityFor(it);
-						return shouldCreate;
-					})
+			StreamSupport.stream(property.getPersistentEntityTypes().spliterator(), false) //
+					.filter(AbstractMappingContext.this::shouldCreatePersistentEntityFor) //
 					.forEach(AbstractMappingContext.this::addPersistentEntity);
 		}
 
@@ -667,7 +659,6 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 			return persistentProperty.getType();
 		}
 	}
-
 
 	/**
 	 * Filter rejecting static fields as well as artificially introduced ones. See

--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -309,6 +309,10 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 			return getComponentType();
 		}
 
+		if (isNullableWrapper()) {
+			return getComponentType();
+		}
+
 		return this;
 	}
 
@@ -382,6 +386,10 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 
 		if (Iterable.class.isAssignableFrom(rawType)) {
 			return getTypeArgument(Iterable.class, 0);
+		}
+
+		if(isNullableWrapper()) {
+			return getTypeArgument(rawType, 0);
 		}
 
 		List<TypeInformation<?>> arguments = getTypeArguments();

--- a/src/main/java/org/springframework/data/util/TypeInformation.java
+++ b/src/main/java/org/springframework/data/util/TypeInformation.java
@@ -274,6 +274,11 @@ public interface TypeInformation<S> {
 		return !type.equals(getType()) && type.isAssignableFrom(getType());
 	}
 
+	/**
+	 * Returns whether the current type is considered a {@literal null} value wrapper or not.
+	 *
+	 * @return {@literal true} if the type is considered to be a {@literal null} value wrapper such as {@link java.util.Optional}.
+	 */
 	default boolean isNullableWrapper() {
 		return NullableWrapperConverters.supports(getType());
 	}

--- a/src/main/java/org/springframework/data/util/TypeInformation.java
+++ b/src/main/java/org/springframework/data/util/TypeInformation.java
@@ -273,4 +273,9 @@ public interface TypeInformation<S> {
 	default boolean isSubTypeOf(Class<?> type) {
 		return !type.equals(getType()) && type.isAssignableFrom(getType());
 	}
+
+	default boolean isNullableWrapper() {
+		return NullableWrapperConverters.supports(getType());
+	}
+
 }

--- a/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
@@ -26,11 +26,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
@@ -272,6 +275,36 @@ class AbstractMappingContextUnitTests {
 		});
 	}
 
+	@Test // GH-2390
+	void shouldNotCreatePersistentEntityForOptionalButItsGenericTypeArgument() {
+
+		context.getPersistentEntity(WithOptionals.class);
+
+		assertThat(context.getPersistentEntities()).map(it -> (Class) it.getType())
+				.contains(WithOptionals.class, Person.class, Base.class)
+				.doesNotContain(Optional.class, List.class, ArrayList.class);
+	}
+
+	@Test // GH-2390
+	void shouldNotCreatePersistentEntityForListButItsGenericTypeArgument() {
+
+		context.getPersistentEntity(WithNestedLists.class);
+
+		assertThat(context.getPersistentEntities()).map(it -> (Class) it.getType())
+				.contains(Base.class)
+				.doesNotContain(List.class, ArrayList.class);
+	}
+
+	@Test // GH-2390
+	void shouldNotCreatePersistentEntityForMapButItsGenericTypeArguments() {
+
+		context.getPersistentEntity(WithMap.class);
+
+		assertThat(context.getPersistentEntities()).map(it -> (Class) it.getType())
+				.contains(Base.class, Person.class, MapKey.class)
+				.doesNotContain(List.class, Map.class, String.class, Integer.class);
+	}
+
 	private static void assertHasEntityFor(Class<?> type, SampleMappingContext context, boolean expected) {
 
 		boolean found = false;
@@ -430,6 +463,28 @@ class AbstractMappingContextUnitTests {
 		ShadowingPropertyAssignable(Integer value) {
 			this.value = value;
 		}
+	}
+
+	class WithOptionals {
+
+		Optional<String> optionalOfString;
+		Optional<Person> optionalOfPerson;
+		List<Optional<Base>> listOfOptionalOfBase;
+	}
+
+	class WithNestedLists {
+		ArrayList<List<Base>> arrayListOfOptionalOfBase;
+	}
+
+	class MapKey {
+
+	}
+
+	class WithMap {
+
+		Map<String, List<Base>> mapOfStringToList;
+		Map<String, Person> mapOfStringToPerson;
+		Map<MapKey, Integer> mapOfKeyToPerson;
 	}
 
 }


### PR DESCRIPTION
Detect a _nullable_ wrapper type (like `java.util.Optional`) and avoid creating an entity for it. 
Also updates entity detection for properties that nest the target type deep within the generic structure as well as map key types.

delivers-input-to: spring-projects/spring-data-mongodb#3656

Tested against Modules for: JPA, MongoDB, Redis