### PR TITLE
[Documentation][Fix] Streamable example using RequiredArgConstructor

### DIFF
--- a/src/main/asciidoc/repositories.adoc
+++ b/src/main/asciidoc/repositories.adoc
@@ -650,7 +650,7 @@ class Product {                                         <1>
 @RequiredArgConstructor(staticName = "of")
 class Products implements Streamable<Product> {         <2>
 
-  private Streamable<Product> streamable;
+  private final Streamable<Product> streamable;
 
   public MonetaryAmount getTotal() {                    <3>
     return streamable.stream()


### PR DESCRIPTION
Example of Streamable using @RequiredArgConstructor(staticName = "of") won't generate a static "of" waiting a Streamable if the field is not final or at least with @lombok.NonNull.
Based on Lombok documentation : https://projectlombok.org/features/constructor

Without a static constructor "of" containing the Streamable it will throw an : 
```
java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class [...] Products
```
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
