### PR TITLE
Provide class for inspecting nested projections.

### DIFF
--- a/src/main/java/org/springframework/data/mapping/context/PropertyFilterSupport.java
+++ b/src/main/java/org/springframework/data/mapping/context/PropertyFilterSupport.java
@@ -15,19 +15,14 @@
  */
 package org.springframework.data.mapping.context;
 
-import org.springframework.data.mapping.PersistentEntity;
-import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.ProjectionInformation;
-import org.springframework.data.util.TypeInformation;
 
 import java.beans.PropertyDescriptor;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 /**
@@ -36,10 +31,10 @@ import java.util.function.Predicate;
  */
 public class PropertyFilterSupport {
 
-	public static List<PropertyPath> addPropertiesFrom(Class<?> returnType, Class<?> domainType,
-													   ProjectionFactory projectionFactory,
-													   Predicate<Class<?>> simpleTypePredicate,  // TODO SimpleTypeHolder or CustomConversions
-													   MappingContext<?, ?> mappingContext) {
+	public static Map<PropertyPath, Boolean> addPropertiesFrom(Class<?> returnType, Class<?> domainType,
+															   ProjectionFactory projectionFactory,
+															   Predicate<Class<?>> simpleTypePredicate,  // TODO SimpleTypeHolder or CustomConversions
+															   MappingContext<?, ?> mappingContext) {
 
 		ProjectionInformation projectionInformation = projectionFactory.getProjectionInformation(returnType);
 
@@ -49,11 +44,11 @@ public class PropertyFilterSupport {
 
 		if (openProjection || typeFromHierarchy) {
 			// *Mark wants to do something with object checks here
-			return Collections.emptyList();
+			return Collections.emptyMap();
 		}
 		// if ^^ false -> DTO / interface projection
 
-		List<PropertyPath> propertyPaths = new ArrayList<>();
+		Map<PropertyPath, Boolean> propertyPaths = new ConcurrentHashMap<>();
 		for (PropertyDescriptor inputProperty : projectionInformation.getInputProperties()) {
 			addPropertiesFrom(returnType, domainType, projectionFactory, simpleTypePredicate, propertyPaths, inputProperty.getName(), mappingContext);
 		}
@@ -62,7 +57,7 @@ public class PropertyFilterSupport {
 
 	private static void addPropertiesFrom(Class<?> returnedType, Class<?> domainType, ProjectionFactory factory,
 										  Predicate<Class<?>> simpleTypePredicate,
-										  Collection<PropertyPath> filteredProperties, String inputProperty,
+										  Map<PropertyPath, Boolean> filteredProperties, String inputProperty,
 										  MappingContext<?, ?> mappingContext) {
 
 		ProjectionInformation projectionInformation = factory.getProjectionInformation(returnedType);
@@ -82,104 +77,30 @@ public class PropertyFilterSupport {
 		// 2. Something that looks like an entity needs to get processed as such
 		// 3. Embedded projection
 		if (simpleTypePredicate.test(propertyType)) {
-			filteredProperties.add(propertyPath);
+			filteredProperties.put(propertyPath, false);
 		} else if (mappingContext.hasPersistentEntityFor(propertyType)) {
-			// avoid recursion / cycles
-			if (propertyType.equals(domainType)) {
-				return;
-			}
-			processEntity(propertyPath, filteredProperties, simpleTypePredicate, mappingContext);
-
+			filteredProperties.put(propertyPath, true);
 		} else {
 			ProjectionInformation nestedProjectionInformation = factory.getProjectionInformation(propertyType);
-			filteredProperties.add(propertyPath);
 			// Closed projection should get handled as above (recursion)
 			if (nestedProjectionInformation.isClosed()) {
+				filteredProperties.put(propertyPath, false);
 				for (PropertyDescriptor nestedInputProperty : nestedProjectionInformation.getInputProperties()) {
 					PropertyPath nestedPropertyPath = propertyPath.nested(nestedInputProperty.getName());
-					filteredProperties.add(nestedPropertyPath);
+
+					if (propertyPath.hasNext() && (domainType.equals(propertyPath.getLeafProperty().getOwningType().getType())
+							|| returnedType.equals(propertyPath.getLeafProperty().getOwningType().getType()))) {
+						break;
+					}
 					addPropertiesFrom(domainType, returnedType, factory, simpleTypePredicate, filteredProperties,
 							nestedPropertyPath.toDotPath(), mappingContext);
 				}
 			} else {
 				// an open projection at this place needs to get replaced with the matching (real) entity
 				PropertyPath domainTypeBasedPropertyPath = PropertyPath.from(propertyPath.toDotPath(), domainType);
-				processEntity(domainTypeBasedPropertyPath, filteredProperties, simpleTypePredicate, mappingContext);
+				filteredProperties.put(domainTypeBasedPropertyPath, true);
 			}
 		}
 	}
 
-	private static void processEntity(PropertyPath propertyPath, Collection<PropertyPath> filteredProperties,
-									  Predicate<Class<?>> simpleTypePredicate,
-									  MappingContext<?, ?> mappingContext) {
-
-		PropertyPath leafProperty = propertyPath.getLeafProperty();
-		TypeInformation<?> propertyParentType = leafProperty.getOwningType();
-		String inputProperty = leafProperty.getSegment();
-
-		PersistentEntity<?, ?> persistentEntity = mappingContext.getPersistentEntity(propertyParentType);
-		PersistentProperty<?> persistentProperty = persistentEntity.getPersistentProperty(inputProperty);
-		Class<?> propertyEntityType = persistentProperty.getActualType();
-
-		// Use domain type as root type for the property path
-		addPropertiesFromEntity(filteredProperties, propertyPath, simpleTypePredicate, propertyEntityType, mappingContext, new HashSet<>());
-	}
-
-	private static void addPropertiesFromEntity(Collection<PropertyPath> filteredProperties, PropertyPath propertyPath,
-												Predicate<Class<?>> simpleTypePredicate,
-												Class<?> propertyType, MappingContext<?, ?> mappingContext,
-												Collection<PersistentEntity<?, ?>> processedEntities) {
-
-		PersistentEntity<?, ?> persistentEntityFromProperty = mappingContext.getPersistentEntity(propertyType);
-		// break the recursion / cycles
-		if (hasProcessedEntity(persistentEntityFromProperty, processedEntities)) {
-			return;
-		}
-		processedEntities.add(persistentEntityFromProperty);
-
-		// save base/root entity/projection type to avoid recursion later
-		Class<?> pathRootType = propertyPath.getOwningType().getType();
-		if (mappingContext.hasPersistentEntityFor(pathRootType)) {
-			processedEntities.add(mappingContext.getPersistentEntity(pathRootType));
-		}
-
-		takeAllPropertiesFromEntity(filteredProperties, simpleTypePredicate, propertyPath, mappingContext, persistentEntityFromProperty, processedEntities);
-	}
-
-	private static boolean hasProcessedEntity(PersistentEntity<?, ?> persistentEntityFromProperty,
-											  Collection<PersistentEntity<?, ?>> processedEntities) {
-
-		return processedEntities.contains(persistentEntityFromProperty);
-	}
-
-	private static void takeAllPropertiesFromEntity(Collection<PropertyPath> filteredProperties,
-													Predicate<Class<?>> simpleTypePredicate, PropertyPath propertyPath,
-													MappingContext<?, ?> mappingContext,
-													PersistentEntity<?, ?> persistentEntityFromProperty,
-													Collection<PersistentEntity<?, ?>> processedEntities) {
-
-		filteredProperties.add(propertyPath);
-
-		persistentEntityFromProperty.doWithAll(persistentProperty -> {
-			addPropertiesFromEntity(filteredProperties, propertyPath.nested(persistentProperty.getName()), simpleTypePredicate, mappingContext, processedEntities);
-		});
-	}
-
-	private static void addPropertiesFromEntity(Collection<PropertyPath> filteredProperties, PropertyPath propertyPath,
-												Predicate<Class<?>> simpleTypePredicate, MappingContext<?, ?> mappingContext,
-										  		Collection<PersistentEntity<?, ?>> processedEntities) {
-
-		// break the recursion / cycles
-		if (filteredProperties.contains(propertyPath)) {
-			return;
-		}
-		Class<?> propertyType = propertyPath.getLeafType();
-		// simple types can get added directly to the list.
-		if (simpleTypePredicate.test(propertyType)) {
-			filteredProperties.add(propertyPath);
-		// Other types are handled also as entities because there cannot be any nested projection within a real entity.
-		} else if (mappingContext.hasPersistentEntityFor(propertyType)) {
-			addPropertiesFromEntity(filteredProperties, propertyPath, simpleTypePredicate, propertyType, mappingContext, processedEntities);
-		}
-	}
 }

--- a/src/main/java/org/springframework/data/mapping/context/PropertyFilterSupport.java
+++ b/src/main/java/org/springframework/data/mapping/context/PropertyFilterSupport.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2011-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.context;
+
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.ProjectionInformation;
+import org.springframework.data.util.TypeInformation;
+
+import java.beans.PropertyDescriptor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * This class is responsible for creating a List of {@link PropertyPath} entries that contains all reachable
+ * properties (w/o circles).
+ */
+public class PropertyFilterSupport {
+
+	public static List<PropertyPath> addPropertiesFrom(Class<?> returnType, Class<?> domainType,
+													   ProjectionFactory projectionFactory,
+													   Predicate<Class<?>> simpleTypePredicate,  // TODO SimpleTypeHolder or CustomConversions
+													   MappingContext<?, ?> mappingContext) {
+
+		ProjectionInformation projectionInformation = projectionFactory.getProjectionInformation(returnType);
+
+		boolean openProjection = !projectionInformation.isClosed(); // if not closed projection, we would need everything from the entity
+		boolean typeFromHierarchy = returnType.isAssignableFrom(domainType) || // hierarchy
+				domainType.isAssignableFrom(returnType);  // interface domainType is interface
+
+		if (openProjection || typeFromHierarchy) {
+			// *Mark wants to do something with object checks here
+			return Collections.emptyList();
+		}
+		// if ^^ false -> DTO / interface projection
+
+		List<PropertyPath> propertyPaths = new ArrayList<>();
+		for (PropertyDescriptor inputProperty : projectionInformation.getInputProperties()) {
+			addPropertiesFrom(returnType, domainType, projectionFactory, simpleTypePredicate, propertyPaths, inputProperty.getName(), mappingContext);
+		}
+		return propertyPaths;
+	}
+
+	private static void addPropertiesFrom(Class<?> returnedType, Class<?> domainType, ProjectionFactory factory,
+										  Predicate<Class<?>> simpleTypePredicate,
+										  Collection<PropertyPath> filteredProperties, String inputProperty,
+										  MappingContext<?, ?> mappingContext) {
+
+		ProjectionInformation projectionInformation = factory.getProjectionInformation(returnedType);
+		PropertyPath propertyPath;
+
+		// If this is a closed projection we can assume that the return type (possible projection type) contains
+		// only fields accessible with a property path.
+		if (projectionInformation.isClosed()) {
+			propertyPath = PropertyPath.from(inputProperty, returnedType);
+		} else {
+			// otherwise the domain type is used right from the start
+			propertyPath = PropertyPath.from(inputProperty, domainType);
+		}
+
+		Class<?> propertyType = propertyPath.getLeafType();
+		// 1. Simple types can be added directly
+		// 2. Something that looks like an entity needs to get processed as such
+		// 3. Embedded projection
+		if (simpleTypePredicate.test(propertyType)) {
+			filteredProperties.add(propertyPath);
+		} else if (mappingContext.hasPersistentEntityFor(propertyType)) {
+			// avoid recursion / cycles
+			if (propertyType.equals(domainType)) {
+				return;
+			}
+			processEntity(propertyPath, filteredProperties, simpleTypePredicate, mappingContext);
+
+		} else {
+			ProjectionInformation nestedProjectionInformation = factory.getProjectionInformation(propertyType);
+			filteredProperties.add(propertyPath);
+			// Closed projection should get handled as above (recursion)
+			if (nestedProjectionInformation.isClosed()) {
+				for (PropertyDescriptor nestedInputProperty : nestedProjectionInformation.getInputProperties()) {
+					PropertyPath nestedPropertyPath = propertyPath.nested(nestedInputProperty.getName());
+					filteredProperties.add(nestedPropertyPath);
+					addPropertiesFrom(domainType, returnedType, factory, simpleTypePredicate, filteredProperties,
+							nestedPropertyPath.toDotPath(), mappingContext);
+				}
+			} else {
+				// an open projection at this place needs to get replaced with the matching (real) entity
+				PropertyPath domainTypeBasedPropertyPath = PropertyPath.from(propertyPath.toDotPath(), domainType);
+				processEntity(domainTypeBasedPropertyPath, filteredProperties, simpleTypePredicate, mappingContext);
+			}
+		}
+	}
+
+	private static void processEntity(PropertyPath propertyPath, Collection<PropertyPath> filteredProperties,
+									  Predicate<Class<?>> ding,
+									  MappingContext<?, ?> mappingContext) {
+
+		PropertyPath leafProperty = propertyPath.getLeafProperty();
+		TypeInformation<?> propertyParentType = leafProperty.getOwningType();
+		String inputProperty = leafProperty.getSegment();
+
+		PersistentEntity<?, ?> persistentEntity = mappingContext.getPersistentEntity(propertyParentType);
+		PersistentProperty<?> persistentProperty = persistentEntity.getPersistentProperty(inputProperty);
+		Class<?> propertyEntityType = persistentProperty.getActualType();
+
+		// Use domain type as root type for the property path
+		addPropertiesFromEntity(filteredProperties, propertyPath, ding, propertyEntityType, mappingContext, new HashSet<>());
+	}
+
+	private static void addPropertiesFromEntity(Collection<PropertyPath> filteredProperties, PropertyPath propertyPath,
+												Predicate<Class<?>> ding,
+												Class<?> propertyType, MappingContext<?, ?> mappingContext,
+												Collection<PersistentEntity<?, ?>> processedEntities) {
+
+		PersistentEntity<?, ?> persistentEntityFromProperty = mappingContext.getPersistentEntity(propertyType);
+		// break the recursion / cycles
+		if (hasProcessedEntity(persistentEntityFromProperty, processedEntities)) {
+			return;
+		}
+		processedEntities.add(persistentEntityFromProperty);
+
+		// save base/root entity/projection type to avoid recursion later
+		Class<?> pathRootType = propertyPath.getOwningType().getType();
+		if (mappingContext.hasPersistentEntityFor(pathRootType)) {
+			processedEntities.add(mappingContext.getPersistentEntity(pathRootType));
+		}
+
+		takeAllPropertiesFromEntity(filteredProperties, ding, propertyPath, mappingContext, persistentEntityFromProperty, processedEntities);
+	}
+
+	private static boolean hasProcessedEntity(PersistentEntity<?, ?> persistentEntityFromProperty,
+											  Collection<PersistentEntity<?, ?>> processedEntities) {
+
+		return processedEntities.contains(persistentEntityFromProperty);
+	}
+
+	private static void takeAllPropertiesFromEntity(Collection<PropertyPath> filteredProperties,
+													Predicate<Class<?>> ding, PropertyPath propertyPath,
+													MappingContext<?, ?> mappingContext,
+													PersistentEntity<?, ?> persistentEntityFromProperty,
+													Collection<PersistentEntity<?, ?>> processedEntities) {
+
+		filteredProperties.add(propertyPath);
+
+		persistentEntityFromProperty.doWithAll(persistentProperty -> {
+			addPropertiesFromEntity(filteredProperties, propertyPath.nested(persistentProperty.getName()), ding, mappingContext, processedEntities);
+		});
+	}
+
+	private static void addPropertiesFromEntity(Collection<PropertyPath> filteredProperties, PropertyPath propertyPath,
+												Predicate<Class<?>> ding, MappingContext<?, ?> mappingContext,
+										  		Collection<PersistentEntity<?, ?>> processedEntities) {
+
+		// break the recursion / cycles
+		if (filteredProperties.contains(propertyPath)) {
+			return;
+		}
+		Class<?> propertyType = propertyPath.getLeafType();
+		// simple types can get added directly to the list.
+		if (ding.test(propertyType)) {
+			filteredProperties.add(propertyPath);
+		// Other types are handled also as entities because there cannot be any nested projection within a real entity.
+		} else if (mappingContext.hasPersistentEntityFor(propertyType)) {
+			addPropertiesFromEntity(filteredProperties, propertyPath, ding, propertyType, mappingContext, processedEntities);
+		}
+	}
+}


### PR DESCRIPTION
As a result there will be a `Map<PropertyPath, Boolean>`, indicating if the property path "ends" in an entity or not, that can get used as input for a selection/mapping filter in the dedicated store modules.
Maybe it might makes sense to wrap the `Map<PropertyPath, Boolean>` into an own class. For us it is sufficient right now to use the map.