### PR TITLE
Set repository FactoryBean.OBJECT_TYPE_ATTRIBUTE as Class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.5.5-SNAPSHOT</version>
+	<version>2.5.x-GH-2455-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/config/ConfigurationUtils.java
+++ b/src/main/java/org/springframework/data/config/ConfigurationUtils.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.config;
 
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.XmlReaderContext;
 import org.springframework.core.io.ResourceLoader;
@@ -100,5 +101,13 @@ public interface ConfigurationUtils {
 		}
 
 		return result;
+	}
+
+	static Class<?> getFactoryBeanObjectType(BeanDefinition beanDefinition) {
+
+		if(!beanDefinition.hasAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE)) {
+			return null;
+		}
+		return Class.class.cast(beanDefinition.getAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE));
 	}
 }

--- a/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
@@ -333,6 +333,11 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 		return String.format("@%s declared on %s", annoationClassName, simpleClassName);
 	}
 
+	@Override
+	public ResourceLoader getResourceLoader() {
+		return resourceLoader;
+	}
+
 	private Streamable<TypeFilter> parseFilters(String attributeName) {
 
 		AnnotationAttributes[] filters = attributes.getAnnotationArray(attributeName);

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -95,6 +95,21 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 		return ConfigurationUtils.getRequiredBeanClassName(definition);
 	}
 
+	public Class<?> getRepositoryInterfaceType() {
+
+		Class<?> target = ConfigurationUtils.getFactoryBeanObjectType(definition);
+		if(target != null) {
+			return target;
+		}
+
+		try {
+			return ClassUtils.forName(getRepositoryInterface(), ConfigurationUtils.getRequiredClassLoader(this.getConfigurationSource().getResourceLoader()));
+		} catch (ClassNotFoundException e) {
+
+		}
+		return null;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.config.RepositoryConfiguration#getConfigSource()

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -53,6 +53,8 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 */
 	String getRepositoryInterface();
 
+	Class<?> getRepositoryInterfaceType();
+
 	/**
 	 * Returns the key to resolve a {@link QueryLookupStrategy} from eventually.
 	 *

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.DependencyDescriptor;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
@@ -46,6 +47,7 @@ import org.springframework.core.metrics.StartupStep;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.StopWatch;
 
 /**
@@ -64,8 +66,6 @@ public class RepositoryConfigurationDelegate {
 	private static final String REPOSITORY_REGISTRATION = "Spring Data %s - Registering repository: %s - Interface: %s - Factory: %s";
 	private static final String MULTIPLE_MODULES = "Multiple Spring Data modules found, entering strict repository configuration mode!";
 	private static final String NON_DEFAULT_AUTOWIRE_CANDIDATE_RESOLVER = "Non-default AutowireCandidateResolver (%s) detected. Skipping the registration of LazyRepositoryInjectionPointResolver. Lazy repository injection will not be working!";
-
-	static final String FACTORY_BEAN_OBJECT_TYPE = "factoryBeanObjectType";
 
 	private static final Log logger = LogFactory.getLog(RepositoryConfigurationDelegate.class);
 
@@ -182,9 +182,16 @@ public class RepositoryConfigurationDelegate {
 			if (logger.isTraceEnabled()) {
 				logger.trace(LogMessage.format(REPOSITORY_REGISTRATION, extension.getModuleName(), beanName, configuration.getRepositoryInterface(),
 						configuration.getRepositoryFactoryBeanClassName()));
-			}
 
-			beanDefinition.setAttribute(FACTORY_BEAN_OBJECT_TYPE, configuration.getRepositoryInterface());
+			}
+			{
+				Class<?> repositoryInterfaceType = configuration.getRepositoryInterfaceType();
+				if(repositoryInterfaceType != null) {
+					beanDefinition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, repositoryInterfaceType);
+				} else {
+					beanDefinition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, configuration.getRepositoryInterface());
+				}
+			}
 
 			registry.registerBeanDefinition(beanName, beanDefinition);
 			definitions.add(new BeanComponentDefinition(beanDefinition, beanName));

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
@@ -180,4 +180,6 @@ public interface RepositoryConfigurationSource {
 	 */
 	@Nullable
 	String getResourceDescription();
+
+	ResourceLoader getResourceLoader();
 }

--- a/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.support.DefaultBeanNameGenerator;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.config.ConfigurationUtils;
 import org.springframework.data.config.TypeFilterParser;
@@ -272,5 +273,10 @@ public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSou
 		return generator == null || DefaultBeanNameGenerator.class.equals(generator.getClass()) //
 				? new AnnotationBeanNameGenerator() //
 				: generator;
+	}
+
+	@Override
+	public ResourceLoader getResourceLoader() {
+		return context.getReaderContext().getResourceLoader();
 	}
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationDelegateUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationDelegateUnitTests.java
@@ -24,9 +24,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.Advised;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
@@ -37,7 +37,6 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.metrics.ApplicationStartup;
-import org.springframework.core.metrics.StartupStep;
 import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.data.repository.config.RepositoryConfigurationDelegate.LazyRepositoryInjectionPointResolver;
 import org.springframework.data.repository.sample.AddressRepository;
@@ -56,8 +55,8 @@ class RepositoryConfigurationDelegateUnitTests {
 
 	@Mock RepositoryConfigurationExtension extension;
 
-	@Test // DATACMNS-892
-	void registersRepositoryBeanNameAsAttribute() {
+	@Test // DATACMNS-892, GH-2455
+	void registersRepositoryBeanTargetTypeAsAttribute() {
 
 		StandardEnvironment environment = new StandardEnvironment();
 		GenericApplicationContext context = new GenericApplicationContext();
@@ -72,8 +71,10 @@ class RepositoryConfigurationDelegateUnitTests {
 
 			BeanDefinition beanDefinition = definition.getBeanDefinition();
 
-			assertThat(beanDefinition.getAttribute(RepositoryConfigurationDelegate.FACTORY_BEAN_OBJECT_TYPE).toString())
-					.endsWith("Repository");
+			assertThat(beanDefinition.getAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE)).satisfies(it -> {
+					assertThat(it).isInstanceOf(Class.class);
+					assertThat(it.toString()).endsWith("Repository");
+			});
 		}
 	}
 


### PR DESCRIPTION
We should set the repository type as type hint for the bean container if we can. We should introduce a control mechanism whether we can provide such a hint as the type hint triggers class loading. In some arrangements (e.g. EclipseLink with load-time weaving) we must defer class loading as much as possible.

See also https://github.com/spring-projects-experimental/spring-native/blob/main/spring-aot/src/main/java/org/springframework/data/RepositoryFactoryBeanPostProcessor.java

for further details.