### PR TITLE
Consider repository bean name for custom implementation and fragment bean names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-GH-2487-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.repository.config;
 
-import java.beans.Introspector;
 import java.io.IOException;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -42,22 +41,16 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 	private final String interfaceName;
 	private final String beanName;
 
-	/**
-	 * Creates a new {@link DefaultImplementationLookupConfiguration} for the given
-	 * {@link ImplementationDetectionConfiguration} and interface name.
-	 *
-	 * @param config must not be {@literal null}.
-	 * @param interfaceName must not be {@literal null} or empty.
-	 */
-	DefaultImplementationLookupConfiguration(ImplementationDetectionConfiguration config, String interfaceName) {
+	DefaultImplementationLookupConfiguration(ImplementationDetectionConfiguration config, String interfaceName,
+			String beanName) {
 
 		Assert.notNull(config, "ImplementationDetectionConfiguration must not be null");
 		Assert.hasText(interfaceName, "Interface name must not be null or empty");
+		Assert.hasText(beanName, "Bean name must not be null or empty!");
 
 		this.config = config;
 		this.interfaceName = interfaceName;
-		this.beanName = Introspector
-				.decapitalize(ClassUtils.getShortName(interfaceName).concat(config.getImplementationPostfix()));
+		this.beanName = beanName;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.data.config.ConfigurationUtils;
 import org.springframework.data.repository.query.QueryLookupStrategy.Key;
+import org.springframework.data.util.Lazy;
 import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -45,6 +46,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	private final T configurationSource;
 	private final BeanDefinition definition;
 	private final RepositoryConfigurationExtension extension;
+	private final Lazy<String> beanName;
 
 	public DefaultRepositoryConfiguration(T configurationSource, BeanDefinition definition,
 			RepositoryConfigurationExtension extension) {
@@ -52,6 +54,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 		this.configurationSource = configurationSource;
 		this.definition = definition;
 		this.extension = extension;
+		this.beanName = Lazy.of(() -> configurationSource.generateBeanName(definition));
 	}
 
 	public String getBeanId() {
@@ -90,7 +93,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	}
 
 	public String getImplementationBeanName() {
-		return configurationSource.generateBeanName(definition)
+		return beanName.get()
 				+ configurationSource.getRepositoryImplementationPostfix().orElse("Impl");
 	}
 
@@ -115,6 +118,11 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 
 		return configurationSource.getRepositoryFactoryBeanClassName()
 				.orElseGet(extension::getRepositoryFactoryBeanClassName);
+	}
+
+	@Override
+	public String getRepositoryBeanName() {
+		return beanName.get();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -93,8 +93,7 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 	}
 
 	public String getImplementationBeanName() {
-		return beanName.get()
-				+ configurationSource.getRepositoryImplementationPostfix().orElse("Impl");
+		return beanName.get() + configurationSource.getRepositoryImplementationPostfix().orElse("Impl");
 	}
 
 	@Nullable

--- a/src/main/java/org/springframework/data/repository/config/ImplementationDetectionConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/ImplementationDetectionConfiguration.java
@@ -90,7 +90,8 @@ public interface ImplementationDetectionConfiguration {
 
 		Assert.hasText(fragmentInterfaceName, "Fragment interface name must not be null or empty");
 
-		return new DefaultImplementationLookupConfiguration(this, fragmentInterfaceName);
+		return new DefaultImplementationLookupConfiguration(this, fragmentInterfaceName,
+				Introspector.decapitalize(ClassUtils.getShortName(fragmentInterfaceName).concat(getImplementationPostfix())));
 	}
 
 	/**
@@ -103,7 +104,8 @@ public interface ImplementationDetectionConfiguration {
 
 		Assert.notNull(config, "RepositoryConfiguration must not be null");
 
-		return new DefaultImplementationLookupConfiguration(this, config.getRepositoryInterface()) {
+		return new DefaultImplementationLookupConfiguration(this, config.getRepositoryInterface(),
+				config.getImplementationBeanName()) {
 
 			@Override
 			public Streamable<String> getBasePackages() {

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -30,7 +30,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
-
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
@@ -148,7 +147,7 @@ class RepositoryBeanDefinitionBuilder {
 
 		List<RepositoryFragmentConfiguration> repositoryFragmentConfigurationStream = fragmentMetadata
 				.getFragmentInterfaces(configuration.getRepositoryInterface()) //
-				.map(it -> detectRepositoryFragmentConfiguration(it, config)) //
+				.map(it -> detectRepositoryFragmentConfiguration(it, config, configuration)) //
 				.flatMap(Optionals::toStream).toList();
 
 		if (repositoryFragmentConfigurationStream.isEmpty()) {

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
+
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
@@ -183,26 +184,42 @@ class RepositoryBeanDefinitionBuilder {
 
 		ImplementationLookupConfiguration lookup = configuration.toLookupConfiguration(metadataReaderFactory);
 
-		String beanName = lookup.getImplementationBeanName();
+		String configurationBeanName = lookup.getImplementationBeanName();
 
 		// Already a bean configured?
-		if (registry.containsBeanDefinition(beanName)) {
-			return Optional.of(beanName);
+		if (registry.containsBeanDefinition(configurationBeanName)) {
+
+			if (logger.isDebugEnabled()) {
+				logger.debug(String.format("Custom repository implementation already registered: %s", configurationBeanName));
+			}
+
+			return Optional.of(configurationBeanName);
 		}
 
 		Optional<AbstractBeanDefinition> beanDefinition = implementationDetector.detectCustomImplementation(lookup);
 
 		return beanDefinition.map(it -> {
 
-			if (logger.isDebugEnabled()) {
-				logger.debug("Registering custom repository implementation: " + lookup.getImplementationBeanName() + " "
-						+ it.getBeanClassName());
+			String scannedBeanName = configuration.getConfigurationSource().generateBeanName(it);
+			it.setSource(configuration.getSource());
+
+			if (registry.containsBeanDefinition(scannedBeanName)) {
+
+				if (logger.isDebugEnabled()) {
+					logger.debug(String.format("Custom repository implementation already registered: %s %s", scannedBeanName,
+							it.getBeanClassName()));
+				}
+			} else {
+
+				if (logger.isDebugEnabled()) {
+					logger.debug(String.format("Registering custom repository implementation: %s %s", scannedBeanName,
+							it.getBeanClassName()));
+				}
+
+				registry.registerBeanDefinition(scannedBeanName, it);
 			}
 
-			it.setSource(configuration.getSource());
-			registry.registerBeanDefinition(beanName, it);
-
-			return beanName;
+			return scannedBeanName;
 		});
 	}
 
@@ -232,19 +249,20 @@ class RepositoryBeanDefinitionBuilder {
 				.toImplementationDetectionConfiguration(metadataReaderFactory);
 
 		return fragmentMetadata.getFragmentInterfaces(configuration.getRepositoryInterface()) //
-				.map(it -> detectRepositoryFragmentConfiguration(it, config)) //
+				.map(it -> detectRepositoryFragmentConfiguration(it, config, configuration)) //
 				.flatMap(Optionals::toStream) //
 				.peek(it -> potentiallyRegisterFragmentImplementation(configuration, it)) //
 				.peek(it -> potentiallyRegisterRepositoryFragment(configuration, it));
 	}
 
 	private Optional<RepositoryFragmentConfiguration> detectRepositoryFragmentConfiguration(String fragmentInterface,
-			ImplementationDetectionConfiguration config) {
+			ImplementationDetectionConfiguration config, RepositoryConfiguration<?> configuration) {
 
 		ImplementationLookupConfiguration lookup = config.forFragment(fragmentInterface);
 		Optional<AbstractBeanDefinition> beanDefinition = implementationDetector.detectCustomImplementation(lookup);
 
-		return beanDefinition.map(bd -> new RepositoryFragmentConfiguration(fragmentInterface, bd));
+		return beanDefinition.map(bd -> new RepositoryFragmentConfiguration(fragmentInterface, bd,
+				configuration.getConfigurationSource().generateBeanName(bd)));
 	}
 
 	private void potentiallyRegisterFragmentImplementation(RepositoryConfiguration<?> repositoryConfiguration,
@@ -254,15 +272,20 @@ class RepositoryBeanDefinitionBuilder {
 
 		// Already a bean configured?
 		if (registry.containsBeanDefinition(beanName)) {
+
+			if (logger.isDebugEnabled()) {
+				logger.debug(String.format("Repository fragment implementation already registered: %s", beanName));
+			}
+
 			return;
 		}
 
-		if (logger.isDebugEnabled()) {
-			logger.debug(String.format("Registering repository fragment implementation: %s %s", beanName,
-					fragmentConfiguration.getClassName()));
-		}
-
 		fragmentConfiguration.getBeanDefinition().ifPresent(bd -> {
+
+			if (logger.isDebugEnabled()) {
+				logger.debug(String.format("Registering repository fragment implementation: %s %s", beanName,
+						fragmentConfiguration.getClassName()));
+			}
 
 			bd.setSource(repositoryConfiguration.getSource());
 			registry.registerBeanDefinition(beanName, bd);
@@ -276,11 +299,16 @@ class RepositoryBeanDefinitionBuilder {
 
 		// Already a bean configured?
 		if (registry.containsBeanDefinition(beanName)) {
+
+			if (logger.isDebugEnabled()) {
+				logger.debug(String.format("RepositoryFragment already registered: %s", beanName));
+			}
+
 			return;
 		}
 
 		if (logger.isDebugEnabled()) {
-			logger.debug("Registering repository fragment: " + beanName);
+			logger.debug(String.format("Registering RepositoryFragment: %s", beanName));
 		}
 
 		BeanDefinitionBuilder fragmentBuilder = BeanDefinitionBuilder.rootBeanDefinition(RepositoryFragment.class,

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -85,6 +85,22 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	String getRepositoryFactoryBeanClassName();
 
 	/**
+	 * Returns the custom implementation bean name to be used.
+	 *
+	 * @return
+	 * @since 2.6
+	 */
+	String getImplementationBeanName();
+
+	/**
+	 * Returns the bean name of the repository to be used.
+	 *
+	 * @return
+	 * @since 2.6
+	 */
+	String getRepositoryBeanName();
+
+	/**
 	 * Returns the source of the {@link RepositoryConfiguration}.
 	 *
 	 * @return

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -88,7 +88,7 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 * Returns the custom implementation bean name to be used.
 	 *
 	 * @return
-	 * @since 2.6
+	 * @since 3.0
 	 */
 	String getImplementationBeanName();
 
@@ -96,7 +96,7 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	 * Returns the bean name of the repository to be used.
 	 *
 	 * @return
-	 * @since 2.6
+	 * @since 3.0
 	 */
 	String getRepositoryBeanName();
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationAdapter.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationAdapter.java
@@ -76,6 +76,16 @@ class RepositoryConfigurationAdapter<T extends RepositoryConfigurationSource>
 	}
 
 	@Override
+	public String getImplementationBeanName() {
+		return repositoryConfiguration.getImplementationBeanName();
+	}
+
+	@Override
+	public String getRepositoryBeanName() {
+		return repositoryConfiguration.getRepositoryBeanName();
+	}
+
+	@Override
 	@Nullable
 	public Object getSource() {
 		return repositoryConfiguration.getSource();

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
@@ -46,7 +46,7 @@ public final class RepositoryFragmentConfiguration {
 	 * @param className must not be {@literal null} or empty.
 	 */
 	public RepositoryFragmentConfiguration(String interfaceName, String className) {
-		this(interfaceName, className, null, generateBeanName(className));
+		this(interfaceName, className, Optional.empty(), generateBeanName(className));
 	}
 
 	/**
@@ -65,11 +65,6 @@ public final class RepositoryFragmentConfiguration {
 		this.className = ConfigurationUtils.getRequiredBeanClassName(beanDefinition);
 		this.beanDefinition = Optional.of(beanDefinition);
 		this.beanName = generateBeanName();
-	}
-
-	public RepositoryFragmentConfiguration(String interfaceName, String className,
-			Optional<AbstractBeanDefinition> beanDefinition) {
-		this(interfaceName, className, beanDefinition, generateBeanName(className));
 	}
 
 	RepositoryFragmentConfiguration(String interfaceName, AbstractBeanDefinition beanDefinition, String beanName) {

--- a/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryFragmentConfiguration.java
@@ -36,6 +36,7 @@ public final class RepositoryFragmentConfiguration {
 	private final String interfaceName;
 	private final String className;
 	private final Optional<AbstractBeanDefinition> beanDefinition;
+	private final String beanName;
 
 	/**
 	 * Creates a {@link RepositoryFragmentConfiguration} given {@code interfaceName} and {@code className} of the
@@ -45,13 +46,7 @@ public final class RepositoryFragmentConfiguration {
 	 * @param className must not be {@literal null} or empty.
 	 */
 	public RepositoryFragmentConfiguration(String interfaceName, String className) {
-
-		Assert.hasText(interfaceName, "Interface name must not be null or empty");
-		Assert.hasText(className, "Class name must not be null or empty");
-
-		this.interfaceName = interfaceName;
-		this.className = className;
-		this.beanDefinition = Optional.empty();
+		this(interfaceName, className, null, generateBeanName(className));
 	}
 
 	/**
@@ -69,20 +64,45 @@ public final class RepositoryFragmentConfiguration {
 		this.interfaceName = interfaceName;
 		this.className = ConfigurationUtils.getRequiredBeanClassName(beanDefinition);
 		this.beanDefinition = Optional.of(beanDefinition);
+		this.beanName = generateBeanName();
 	}
 
 	public RepositoryFragmentConfiguration(String interfaceName, String className,
 			Optional<AbstractBeanDefinition> beanDefinition) {
+		this(interfaceName, className, beanDefinition, generateBeanName(className));
+	}
+
+	RepositoryFragmentConfiguration(String interfaceName, AbstractBeanDefinition beanDefinition, String beanName) {
+		this(interfaceName, ConfigurationUtils.getRequiredBeanClassName(beanDefinition), Optional.of(beanDefinition),
+				beanName);
+	}
+
+	private RepositoryFragmentConfiguration(String interfaceName, String className,
+			Optional<AbstractBeanDefinition> beanDefinition, String beanName) {
+
+		Assert.hasText(interfaceName, "Interface name must not be null or empty!");
+		Assert.notNull(beanDefinition, "Bean definition must not be null!");
+		Assert.notNull(beanName, "Bean name must not be null!");
+
 		this.interfaceName = interfaceName;
 		this.className = className;
 		this.beanDefinition = beanDefinition;
+		this.beanName = beanName;
+	}
+
+	private String generateBeanName() {
+		return generateBeanName(getClassName());
+	}
+
+	private static String generateBeanName(String className) {
+		return Introspector.decapitalize(ClassUtils.getShortName(className));
 	}
 
 	/**
 	 * @return name of the implementation bean.
 	 */
 	public String getImplementationBeanName() {
-		return Introspector.decapitalize(ClassUtils.getShortName(getClassName()));
+		return this.beanName;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetectorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/CustomRepositoryImplementationDetectorUnitTests.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.beans.Introspector;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,8 +66,7 @@ class CustomRepositoryImplementationDetectorUnitTests {
 		RepositoryConfiguration<?> mock = mock(RepositoryConfiguration.class);
 		when(mock.getImplementationBeanName()).thenReturn("NoImplementationRepositoryImpl");
 
-		var lookup = configuration
-				.forRepositoryConfiguration(configFor(NoImplementationRepository.class));
+		var lookup = configuration.forRepositoryConfiguration(configFor(NoImplementationRepository.class));
 
 		var beanDefinition = detector.detectCustomImplementation(lookup);
 
@@ -78,8 +76,7 @@ class CustomRepositoryImplementationDetectorUnitTests {
 	@Test // DATACMNS-764, DATACMNS-1371
 	void returnsBeanDefinitionWhenOneImplementationIsFound() {
 
-		var lookup = configuration
-				.forRepositoryConfiguration(configFor(SingleSampleRepository.class));
+		var lookup = configuration.forRepositoryConfiguration(configFor(SingleSampleRepository.class));
 
 		var beanDefinition = detector.detectCustomImplementation(lookup);
 
@@ -98,9 +95,7 @@ class CustomRepositoryImplementationDetectorUnitTests {
 			return className.contains("$First$") ? "canonicalSampleRepositoryTestImpl" : "otherBeanName";
 		});
 
-
-		var lookup = configuration
-				.forRepositoryConfiguration(configFor(CanonicalSampleRepository.class));
+		var lookup = configuration.forRepositoryConfiguration(configFor(CanonicalSampleRepository.class));
 
 		assertThat(detector.detectCustomImplementation(lookup)) //
 				.hasValueSatisfying(

--- a/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
@@ -53,21 +53,20 @@ class DefaultImplementationLookupConfigurationUnitTests {
 	@Test // DATACMNS-1754
 	void shouldUseSimpleClassNameWhenDefiningImplementationNames() {
 
-		ImplementationLookupConfiguration lookupConfiguration = idcMock
-				.forFragment("com.acme.Repositories$NestedRepository");
+		var lookupConfiguration = idcMock.forFragment("com.acme.Repositories$NestedRepository");
 		assertThat(lookupConfiguration.getImplementationBeanName()).isEqualTo("repositories.NestedRepositoryImpl");
 		assertThat(lookupConfiguration.getImplementationClassName()).isEqualTo("NestedRepositoryImpl");
 	}
 
 	private static String getImplementationBeanName(ImplementationDetectionConfiguration idcMock, String interfaceName) {
 
-		RepositoryConfigurationSource source = mock(RepositoryConfigurationSource.class);
+		var source = mock(RepositoryConfigurationSource.class);
 		when(source.generateBeanName(any())).thenReturn(Introspector.decapitalize(ClassUtils.getShortName(interfaceName)));
 
 		RepositoryConfiguration<?> repoConfig = new DefaultRepositoryConfiguration<>(source,
 				BeanDefinitionBuilder.rootBeanDefinition(interfaceName).getBeanDefinition(), null);
 
-		ImplementationLookupConfiguration configuration = idcMock.forRepositoryConfiguration(repoConfig);
+		var configuration = idcMock.forRepositoryConfiguration(repoConfig);
 		return configuration.getImplementationBeanName();
 	}
 }

--- a/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/DefaultImplementationLookupConfigurationUnitTests.java
@@ -18,7 +18,13 @@ package org.springframework.data.repository.config;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.beans.Introspector;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.util.ClassUtils;
 
 /**
  * Unit tests for {@link DefaultImplementationLookupConfigurationUnitTests}.
@@ -28,11 +34,17 @@ import org.junit.jupiter.api.Test;
  */
 class DefaultImplementationLookupConfigurationUnitTests {
 
+	ImplementationDetectionConfiguration idcMock = mock(ImplementationDetectionConfiguration.class);
+
+	@BeforeEach
+	void setUp() {
+		when(idcMock.getImplementationPostfix()).thenReturn("Impl");
+		when(idcMock.forRepositoryConfiguration(any())).thenCallRealMethod();
+		when(idcMock.forFragment(any())).thenCallRealMethod();
+	}
+
 	@Test // DATACMNS-1439
 	void shouldConsiderBeanNameDecapitalization() {
-
-		var idcMock = mock(ImplementationDetectionConfiguration.class);
-		when(idcMock.getImplementationPostfix()).thenReturn("Impl");
 
 		assertThat(getImplementationBeanName(idcMock, "com.acme.UDPRepository")).isEqualTo("UDPRepositoryImpl");
 		assertThat(getImplementationBeanName(idcMock, "com.acme.UdpRepository")).isEqualTo("udpRepositoryImpl");
@@ -41,19 +53,21 @@ class DefaultImplementationLookupConfigurationUnitTests {
 	@Test // DATACMNS-1754
 	void shouldUseSimpleClassNameWhenDefiningImplementationNames() {
 
-		var idcMock = mock(ImplementationDetectionConfiguration.class);
-		when(idcMock.getImplementationPostfix()).thenReturn("Impl");
-
-		var lookupConfiguration = new DefaultImplementationLookupConfiguration(idcMock,
-				"com.acme.Repositories$NestedRepository");
+		ImplementationLookupConfiguration lookupConfiguration = idcMock
+				.forFragment("com.acme.Repositories$NestedRepository");
 		assertThat(lookupConfiguration.getImplementationBeanName()).isEqualTo("repositories.NestedRepositoryImpl");
 		assertThat(lookupConfiguration.getImplementationClassName()).isEqualTo("NestedRepositoryImpl");
 	}
 
 	private static String getImplementationBeanName(ImplementationDetectionConfiguration idcMock, String interfaceName) {
 
-		var configuration = new DefaultImplementationLookupConfiguration(idcMock,
-				interfaceName);
+		RepositoryConfigurationSource source = mock(RepositoryConfigurationSource.class);
+		when(source.generateBeanName(any())).thenReturn(Introspector.decapitalize(ClassUtils.getShortName(interfaceName)));
+
+		RepositoryConfiguration<?> repoConfig = new DefaultRepositoryConfiguration<>(source,
+				BeanDefinitionBuilder.rootBeanDefinition(interfaceName).getBeanDefinition(), null);
+
+		ImplementationLookupConfiguration configuration = idcMock.forRepositoryConfiguration(repoConfig);
 		return configuration.getImplementationBeanName();
 	}
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryComponentProviderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryComponentProviderUnitTests.java
@@ -71,7 +71,7 @@ class RepositoryComponentProviderUnitTests {
 		provider.setConsiderNestedRepositoryInterfaces(true);
 
 		var components = provider.findCandidateComponents("org.springframework.data.repository.config");
-		var nestedRepositoryClassName = "org.springframework.data.repository.config.RepositoryComponentProviderUnitTests$MyNestedRepository";
+		var nestedRepositoryClassName = "org.springframework.data.repository.config.RepositoryComponentProviderUnitTests$MyNestedRepositoryDefinition";
 
 		assertThat(components.size()).isGreaterThanOrEqualTo(1);
 		assertThat(components).extracting(BeanDefinition::getBeanClassName).contains(nestedRepositoryClassName);
@@ -91,5 +91,5 @@ class RepositoryComponentProviderUnitTests {
 		assertThat(provider.getRegistry()).isEqualTo(registry);
 	}
 
-	interface MyNestedRepository extends Repository<Person, Long> {}
+	interface MyNestedRepositoryDefinition extends Repository<Person, Long> {}
 }

--- a/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationDelegateUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationDelegateUnitTests.java
@@ -23,11 +23,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
 import org.springframework.aop.framework.Advised;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
@@ -78,8 +77,7 @@ class RepositoryConfigurationDelegateUnitTests {
 
 			var beanDefinition = definition.getBeanDefinition();
 
-			assertThat(beanDefinition.getAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE).toString())
-					.endsWith("Repository");
+			assertThat(beanDefinition.getAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE).toString()).endsWith("Repository");
 		}
 	}
 
@@ -95,25 +93,6 @@ class RepositoryConfigurationDelegateUnitTests {
 
 		assertThat(beanFactory.getBeanNamesForType(DeferredRepositoryInitializationListener.class)).isNotEmpty();
 
-	}
-
-	private static ListableBeanFactory assertLazyRepositoryBeanSetup(Class<?> configClass) {
-
-		var environment = new StandardEnvironment();
-		var context = new AnnotationConfigApplicationContext(configClass);
-
-		assertThat(context.getDefaultListableBeanFactory().getAutowireCandidateResolver())
-				.isInstanceOf(LazyRepositoryInjectionPointResolver.class);
-
-		var client = context.getBean(AddressRepositoryClient.class);
-		var repository = client.getRepository();
-
-		assertThat(Advised.class.isInstance(repository)).isTrue();
-
-		var targetSource = Advised.class.cast(repository).getTargetSource();
-		assertThat(targetSource).isNotNull();
-
-		return context.getDefaultListableBeanFactory();
 	}
 
 	@Test // DATACMNS-1832
@@ -139,14 +118,14 @@ class RepositoryConfigurationDelegateUnitTests {
 	@Test // GH-2487
 	void considersDefaultBeanNames() {
 
-		StandardEnvironment environment = new StandardEnvironment();
-		GenericApplicationContext context = new GenericApplicationContext();
+		var environment = new StandardEnvironment();
+		var context = new GenericApplicationContext();
 
 		RepositoryConfigurationSource configSource = new AnnotationRepositoryConfigurationSource(
 				AnnotationMetadata.introspect(DefaultBeanNamesConfig.class), EnableRepositories.class, context, environment,
 				context.getDefaultListableBeanFactory(), new AnnotationBeanNameGenerator());
 
-		RepositoryConfigurationDelegate delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
+		var delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
 
 		delegate.registerRepositoriesIn(context, extension);
 
@@ -157,15 +136,14 @@ class RepositoryConfigurationDelegateUnitTests {
 	@Test // GH-2487
 	void considersAnnotatedBeanNamesFromRepository() {
 
-		StandardEnvironment environment = new StandardEnvironment();
-		GenericApplicationContext context = new GenericApplicationContext();
+		var environment = new StandardEnvironment();
+		var context = new GenericApplicationContext();
 
 		RepositoryConfigurationSource configSource = new AnnotationRepositoryConfigurationSource(
 				AnnotationMetadata.introspect(AnnotatedDerivedBeanNamesConfig.class), EnableRepositories.class, context,
-				environment,
-				context.getDefaultListableBeanFactory(), new AnnotationBeanNameGenerator());
+				environment, context.getDefaultListableBeanFactory(), new AnnotationBeanNameGenerator());
 
-		RepositoryConfigurationDelegate delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
+		var delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
 
 		delegate.registerRepositoriesIn(context, extension);
 
@@ -176,14 +154,14 @@ class RepositoryConfigurationDelegateUnitTests {
 	@Test // GH-2487
 	void considersAnnotatedBeanNamesFromAtComponent() {
 
-		StandardEnvironment environment = new StandardEnvironment();
-		GenericApplicationContext context = new GenericApplicationContext();
+		var environment = new StandardEnvironment();
+		var context = new GenericApplicationContext();
 
 		RepositoryConfigurationSource configSource = new AnnotationRepositoryConfigurationSource(
 				AnnotationMetadata.introspect(AnnotatedBeanNamesConfig.class), EnableRepositories.class, context, environment,
 				context.getDefaultListableBeanFactory(), new AnnotationBeanNameGenerator());
 
-		RepositoryConfigurationDelegate delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
+		var delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
 
 		delegate.registerRepositoriesIn(context, extension);
 
@@ -196,8 +174,8 @@ class RepositoryConfigurationDelegateUnitTests {
 	@Test // GH-2487
 	void skipsRegistrationOnAlreadyRegisteredBeansUsingAtComponentNames() {
 
-		StandardEnvironment environment = new StandardEnvironment();
-		GenericApplicationContext context = new GenericApplicationContext();
+		var environment = new StandardEnvironment();
+		var context = new GenericApplicationContext();
 		context.setAllowBeanDefinitionOverriding(false);
 		context.registerBean("fragment", MyFragmentImpl.class);
 		context.registerBean("anotherBeanName", MyAnnotatedRepositoryImpl.class);
@@ -206,7 +184,7 @@ class RepositoryConfigurationDelegateUnitTests {
 				AnnotationMetadata.introspect(AnnotatedBeanNamesConfig.class), EnableRepositories.class, context, environment,
 				context.getDefaultListableBeanFactory(), new AnnotationBeanNameGenerator());
 
-		RepositoryConfigurationDelegate delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
+		var delegate = new RepositoryConfigurationDelegate(configSource, context, environment);
 
 		delegate.registerRepositoriesIn(context, extension);
 
@@ -218,17 +196,17 @@ class RepositoryConfigurationDelegateUnitTests {
 
 	private static ListableBeanFactory assertLazyRepositoryBeanSetup(Class<?> configClass) {
 
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
+		var context = new AnnotationConfigApplicationContext(configClass);
 
 		assertThat(context.getDefaultListableBeanFactory().getAutowireCandidateResolver())
 				.isInstanceOf(LazyRepositoryInjectionPointResolver.class);
 
-		AddressRepositoryClient client = context.getBean(AddressRepositoryClient.class);
-		AddressRepository repository = client.getRepository();
+		var client = context.getBean(AddressRepositoryClient.class);
+		var repository = client.getRepository();
 
 		assertThat(Advised.class.isInstance(repository)).isTrue();
 
-		TargetSource targetSource = Advised.class.cast(repository).getTargetSource();
+		var targetSource = Advised.class.cast(repository).getTargetSource();
 		assertThat(targetSource).isNotNull();
 
 		return context.getDefaultListableBeanFactory();

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.annotated;
+
+import org.springframework.data.mapping.Person;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Mark Paluch
+ */
+public interface MyAnnotatedRepository extends CrudRepository<Person, String>, MyFragment {}

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyAnnotatedRepositoryImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.annotated;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Mark Paluch
+ */
+@Component("anotherBeanName")
+public class MyAnnotatedRepositoryImpl {}

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyFragment.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyFragment.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyFragment.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.annotated;
+
+/**
+ * @author Mark Paluch
+ */
+interface MyFragment {}

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyFragmentImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyFragmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/repository/config/annotated/MyFragmentImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/annotated/MyFragmentImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.annotated;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Mark Paluch
+ */
+@Component("fragment")
+public class MyFragmentImpl implements MyFragment {}

--- a/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.stereotype;
+
+import org.springframework.data.mapping.Person;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Mark Paluch
+ */
+@Component("fooRepository")
+public interface MyStereotypeRepository extends CrudRepository<Person, String> {}

--- a/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/stereotype/MyStereotypeRepositoryImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.stereotype;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Mark Paluch
+ */
+@Component("fooRepositoryImpl")
+public class MyStereotypeRepositoryImpl {}


### PR DESCRIPTION
We now consider the repository bean name when checking for existing bean definitions of default custom implementation beans. Previously, we used the repository interface name without considering the repository bean name.

We also now consider the actual bean name when registering custom implementations and repository fragments after falling back to component scan mode. Previously we derived the bean name either from the repository bean name or the class name.