### PR TITLE
Consider vavr collections to be collection like

### DIFF
--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -52,10 +52,12 @@ import org.springframework.util.ReflectionUtils;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Jürgen Diez
  */
 class TypeDiscoverer<S> implements TypeInformation<S> {
 
 	private static final Class<?>[] MAP_TYPES;
+	private static final Class<?>[] COLLECTION_TYPES;
 
 	static {
 
@@ -69,6 +71,19 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 		} catch (ClassNotFoundException o_O) {}
 
 		MAP_TYPES = mapTypes.toArray(new Class[0]);
+
+		Set<Class<?>> collectionTypes = new HashSet<>();
+		collectionTypes.add(Collection.class);
+
+		try {
+			collectionTypes.add(ClassUtils.forName("io.vavr.collection.Seq", classLoader));
+		} catch (ClassNotFoundException o_O) {}
+
+		try {
+			collectionTypes.add(ClassUtils.forName("io.vavr.collection.Set", classLoader));
+		} catch (ClassNotFoundException o_O) {}
+
+		COLLECTION_TYPES = collectionTypes.toArray(new Class[0]);
 	}
 
 	private final Type type;
@@ -369,8 +384,21 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 
 		return rawType.isArray() //
 				|| Iterable.class.equals(rawType) //
-				|| Collection.class.isAssignableFrom(rawType) //
-				|| Streamable.class.isAssignableFrom(rawType);
+				|| Streamable.class.isAssignableFrom(rawType)
+				|| isCollection();
+	}
+
+	private boolean isCollection() {
+
+		Class<S> type = getType();
+
+		for (Class<?> collectionType : COLLECTION_TYPES) {
+			if (collectionType.isAssignableFrom(type)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/util/TypeDiscovererUnitTests.java
+++ b/src/test/java/org/springframework/data/util/TypeDiscovererUnitTests.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * Unit tests for {@link TypeDiscoverer}.
  *
  * @author Oliver Gierke
+ * @author Jürgen Diez
  */
 @ExtendWith(MockitoExtension.class)
 public class TypeDiscovererUnitTests {
@@ -177,6 +178,38 @@ public class TypeDiscovererUnitTests {
 		assertThat(type.isSubTypeOf(Collection.class)).isTrue();
 		assertThat(type.isSubTypeOf(Set.class)).isFalse();
 		assertThat(type.isSubTypeOf(String.class)).isFalse();
+	}
+
+	@Test
+	void considerVavrMapToBeAMap() {
+
+		TypeInformation<io.vavr.collection.Map> type = from(io.vavr.collection.Map.class);
+
+		assertThat(type.isMap()).isTrue();
+	}
+
+	@Test
+	void considerVavrSetToBeCollectionLike() {
+
+		TypeInformation<io.vavr.collection.Set> type = from(io.vavr.collection.Set.class);
+
+		assertThat(type.isCollectionLike()).isTrue();
+	}
+
+	@Test
+	void considerVavrSeqToBeCollectionLike() {
+
+		TypeInformation<io.vavr.collection.Seq> type = from(io.vavr.collection.Seq.class);
+
+		assertThat(type.isCollectionLike()).isTrue();
+	}
+
+	@Test
+	void considerVavrListToBeCollectionLike() {
+
+		TypeInformation<io.vavr.collection.List> type = from(io.vavr.collection.List.class);
+
+		assertThat(type.isCollectionLike()).isTrue();
 	}
 
 	class Person {


### PR DESCRIPTION
Apparently vavr collections are currently not considered collection like.
To treat them as collection correclty for example in `MappingMongoConverter` from `spring-data-mongodb` they should also be considered collection like.