### PR TITLE
Update documentation for repository `Pageable` and `Sort` arguments

### DIFF
--- a/src/main/java/org/springframework/data/repository/PagingAndSortingRepository.java
+++ b/src/main/java/org/springframework/data/repository/PagingAndSortingRepository.java
@@ -42,7 +42,7 @@ public interface PagingAndSortingRepository<T, ID> extends CrudRepository<T, ID>
 	/**
 	 * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
 	 *
-	 * @param pageable
+	 * @param pageable must not be {@literal null}.
 	 * @return a page of entities
 	 */
 	Page<T> findAll(Pageable pageable);

--- a/src/main/java/org/springframework/data/repository/query/QueryByExampleExecutor.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryByExampleExecutor.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Sort;
  * @param <T>
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Diego Krupitza
  * @since 1.12
  */
 public interface QueryByExampleExecutor<T> {
@@ -67,7 +68,7 @@ public interface QueryByExampleExecutor<T> {
 	 * {@link Page} is returned.
 	 *
 	 * @param example must not be {@literal null}.
-	 * @param pageable can be {@literal null}.
+	 * @param pageable must not be {@literal null}.
 	 * @return a {@link Page} of entities matching the given {@link Example}.
 	 */
 	<S extends T> Page<S> findAll(Example<S> example, Pageable pageable);


### PR DESCRIPTION
As mentioned in https://github.com/spring-projects/spring-data-jpa/issues/2464 `QueryByExampleExecutor#findAll(Example<S> example, Pageable pageable)` should not accept null values since there is `Pageable.unpaged()`. Furthermore, the same applies to `PagingAndSortingRepository#findAll(Pageable pageable)`.

Related tickets spring-projects/spring-data-jpa/issues/2464
Closes spring-projects/spring-data-jpa/issues/2464

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
