### PR TITLE
Introduce `PropertyValueConversionService` and specific null-conversion methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.7.0-SNAPSHOT</version>
+	<version>2.7.0-GH-2577-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -205,14 +205,14 @@ public class CustomConversions {
 	 * @param property must not be {@literal null}.
 	 * @param <DV> domain-specific type
 	 * @param <SV> store-native type
-	 * @param <C> conversion context type
+	 * @param <P> conversion context type
 	 * @return the suitable {@link PropertyValueConverter} or {@literal null} if none available.
 	 * @see PropertyValueConversions#getValueConverter(PersistentProperty)
 	 * @since 2.7
 	 */
 	@Nullable
-	public <DV, SV, C extends PersistentProperty<C>, VCC extends ValueConversionContext<C>> PropertyValueConverter<DV, SV, VCC> getPropertyValueConverter(
-			C property) {
+	public <DV, SV, P extends PersistentProperty<P>, VCC extends ValueConversionContext<P>> PropertyValueConverter<DV, SV, VCC> getPropertyValueConverter(
+			P property) {
 		return propertyValueConversions != null ? propertyValueConversions.getValueConverter(property) : null;
 	}
 

--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.converter.Converter;
@@ -42,7 +43,6 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.convert.ConverterBuilder.ConverterAware;
-import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.Predicates;
 import org.springframework.data.util.Streamable;
@@ -185,35 +185,9 @@ public class CustomConversions {
 		VavrCollectionConverters.getConvertersToRegister().forEach(it -> registerConverterIn(it, conversionService));
 	}
 
-	/**
-	 * Delegate check if a {@link PropertyValueConverter} for the given {@literal property} is present via
-	 * {@link PropertyValueConversions}.
-	 *
-	 * @param property must not be {@literal null}.
-	 * @return {@literal true} if a specific {@link PropertyValueConverter} is available.
-	 * @see PropertyValueConversions#hasValueConverter(PersistentProperty)
-	 * @since 2.7
-	 */
-	public boolean hasPropertyValueConverter(PersistentProperty<?> property) {
-		return propertyValueConversions != null && propertyValueConversions.hasValueConverter(property);
-	}
-
-	/**
-	 * Delegate to obtain the {@link PropertyValueConverter} for the given {@literal property} from
-	 * {@link PropertyValueConversions}.
-	 *
-	 * @param property must not be {@literal null}.
-	 * @param <DV> domain-specific type
-	 * @param <SV> store-native type
-	 * @param <P> conversion context type
-	 * @return the suitable {@link PropertyValueConverter} or {@literal null} if none available.
-	 * @see PropertyValueConversions#getValueConverter(PersistentProperty)
-	 * @since 2.7
-	 */
 	@Nullable
-	public <DV, SV, P extends PersistentProperty<P>, VCC extends ValueConversionContext<P>> PropertyValueConverter<DV, SV, VCC> getPropertyValueConverter(
-			P property) {
-		return propertyValueConversions != null ? propertyValueConversions.getValueConverter(property) : null;
+	public PropertyValueConversions getPropertyValueConversions() {
+		return propertyValueConversions;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/convert/PropertyValueConversionService.java
+++ b/src/main/java/org/springframework/data/convert/PropertyValueConversionService.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Conversion service based on {@link CustomConversions} to convert domain and store values using
+ * {@link PropertyValueConverter property-specific converters}.
+ *
+ * @author Mark Paluch
+ * @since 2.7
+ */
+public class PropertyValueConversionService {
+
+	private final CustomConversions conversions;
+
+	public PropertyValueConversionService(CustomConversions conversions) {
+
+		Assert.notNull(conversions, "CustomConversions must not be null");
+
+		this.conversions = conversions;
+	}
+
+	/**
+	 * Return {@literal true} there is a converter registered for {@link PersistentProperty}.
+	 * <p>
+	 * If this method returns {@literal true}, it means {@link #read(Object, PersistentProperty, ValueConversionContext)}
+	 * and {@link #write(Object, PersistentProperty, ValueConversionContext)} are capable to invoke conversion.
+	 *
+	 * @param property the underlying property.
+	 * @return {@literal true} there is a converter registered for {@link PersistentProperty}.
+	 */
+	public boolean hasConverter(PersistentProperty<?> property) {
+		return conversions.hasPropertyValueConverter(property);
+	}
+
+	/**
+	 * Convert a value from its store-native representation into its domain-specific type.
+	 *
+	 * @param value the value to convert. Can be {@code null}.
+	 * @param property the underlying property.
+	 * @param context the context object.
+	 * @param <P> property type.
+	 * @param <VCC> value conversion context type.
+	 * @return the value to be used in the domain model. Can be {@code null}.
+	 */
+	@Nullable
+	public <P extends PersistentProperty<P>, VCC extends ValueConversionContext<P>> Object read(@Nullable Object value,
+			P property, VCC context) {
+
+		PropertyValueConverter<Object, Object, ValueConversionContext<P>> converter = getRequiredConverter(property);
+
+		if (value == null) {
+			return converter.readNull(context);
+		}
+
+		return converter.read(value, context);
+	}
+
+	/**
+	 * Convert a value from its domain-specific value into its store-native representation.
+	 *
+	 * @param value the value to convert. Can be {@code null}.
+	 * @param property the underlying property.
+	 * @param context the context object.
+	 * @param <P> property type.
+	 * @param <VCC> value conversion context type.
+	 * @return the value to be written to the data store. Can be {@code null}.
+	 */
+	@Nullable
+	public <P extends PersistentProperty<P>, VCC extends ValueConversionContext<P>> Object write(@Nullable Object value,
+			P property, VCC context) {
+
+		PropertyValueConverter<Object, Object, ValueConversionContext<P>> converter = getRequiredConverter(property);
+
+		if (value == null) {
+			return converter.writeNull(context);
+		}
+
+		return converter.write(value, context);
+	}
+
+	private <P extends PersistentProperty<P>> PropertyValueConverter<Object, Object, ValueConversionContext<P>> getRequiredConverter(
+			P property) {
+
+		PropertyValueConverter<Object, Object, ValueConversionContext<P>> converter = conversions
+				.getPropertyValueConverter(property);
+
+		if (converter == null) {
+			throw new IllegalArgumentException(String.format("No converter registered for property %s", property));
+		}
+
+		return converter;
+	}
+}

--- a/src/main/java/org/springframework/data/convert/PropertyValueConversions.java
+++ b/src/main/java/org/springframework/data/convert/PropertyValueConversions.java
@@ -47,6 +47,8 @@ public interface PropertyValueConversions {
 	 * @param <SV> store-native type
 	 * @param <P> conversion context type
 	 * @return the suitable {@link PropertyValueConverter}.
+	 * @throws IllegalArgumentException if there is no converter available for {@code property}.
+	 * @see #hasValueConverter(PersistentProperty)
 	 */
 	<DV, SV, P extends PersistentProperty<P>, VCC extends ValueConversionContext<P>> PropertyValueConverter<DV, SV, VCC> getValueConverter(
 			P property);

--- a/src/main/java/org/springframework/data/convert/PropertyValueConversions.java
+++ b/src/main/java/org/springframework/data/convert/PropertyValueConversions.java
@@ -45,11 +45,11 @@ public interface PropertyValueConversions {
 	 * @param property must not be {@literal null}.
 	 * @param <DV> domain-specific type
 	 * @param <SV> store-native type
-	 * @param <C> conversion context type
+	 * @param <P> conversion context type
 	 * @return the suitable {@link PropertyValueConverter}.
 	 */
-	<DV, SV, C extends PersistentProperty<C>, VCC extends ValueConversionContext<C>> PropertyValueConverter<DV, SV, VCC> getValueConverter(
-			C property);
+	<DV, SV, P extends PersistentProperty<P>, VCC extends ValueConversionContext<P>> PropertyValueConverter<DV, SV, VCC> getValueConverter(
+			P property);
 
 	/**
 	 * Helper that allows to create {@link PropertyValueConversions} instance with the configured

--- a/src/main/java/org/springframework/data/convert/PropertyValueConverterFactory.java
+++ b/src/main/java/org/springframework/data/convert/PropertyValueConverterFactory.java
@@ -46,12 +46,12 @@ public interface PropertyValueConverterFactory {
 	 * @param property must not be {@literal null}.
 	 * @param <DV> domain-specific type.
 	 * @param <SV> store-native type.
-	 * @param <C> value conversion context to use.
+	 * @param <P> value conversion context to use.
 	 * @return can be {@literal null}.
 	 */
 	@SuppressWarnings("unchecked")
 	@Nullable
-	default <DV, SV, C extends ValueConversionContext<?>> PropertyValueConverter<DV, SV, C> getConverter(
+	default <DV, SV, P extends ValueConversionContext<?>> PropertyValueConverter<DV, SV, P> getConverter(
 			PersistentProperty<?> property) {
 
 		AnnotatedPropertyValueConverterAccessor accessor = new AnnotatedPropertyValueConverterAccessor(property);
@@ -60,7 +60,7 @@ public interface PropertyValueConverterFactory {
 			return null;
 		}
 
-		return getConverter((Class<PropertyValueConverter<DV, SV, C>>) accessor.getValueConverterType());
+		return getConverter((Class<PropertyValueConverter<DV, SV, P>>) accessor.getValueConverterType());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/convert/SimplePropertyValueConversions.java
+++ b/src/main/java/org/springframework/data/convert/SimplePropertyValueConversions.java
@@ -105,11 +105,17 @@ public class SimplePropertyValueConversions implements PropertyValueConversions,
 		return obtainConverterFactory().getConverter(property) != null;
 	}
 
-	@Nullable
 	@Override
 	public <DV, SV, P extends PersistentProperty<P>, D extends ValueConversionContext<P>> PropertyValueConverter<DV, SV, D> getValueConverter(
 			P property) {
-		return obtainConverterFactory().getConverter(property);
+
+		PropertyValueConverter<DV, SV, D> converter = obtainConverterFactory().getConverter(property);
+
+		if (converter == null) {
+			throw new IllegalArgumentException(String.format("No PropertyValueConverter registered for %s", property));
+		}
+
+		return converter;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/convert/SimplePropertyValueConversions.java
+++ b/src/main/java/org/springframework/data/convert/SimplePropertyValueConversions.java
@@ -107,8 +107,8 @@ public class SimplePropertyValueConversions implements PropertyValueConversions,
 
 	@Nullable
 	@Override
-	public <DV, SV, C extends PersistentProperty<C>, D extends ValueConversionContext<C>> PropertyValueConverter<DV, SV, D> getValueConverter(
-			C property) {
+	public <DV, SV, P extends PersistentProperty<P>, D extends ValueConversionContext<P>> PropertyValueConverter<DV, SV, D> getValueConverter(
+			P property) {
 		return obtainConverterFactory().getConverter(property);
 	}
 

--- a/src/test/benchmark/org/springframework/data/convert/PropertyValueConversionServiceUnitTests.java
+++ b/src/test/benchmark/org/springframework/data/convert/PropertyValueConversionServiceUnitTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.mapping.Person;
+import org.springframework.data.mapping.context.SampleMappingContext;
+import org.springframework.data.mapping.context.SamplePersistentProperty;
+import org.springframework.data.mapping.model.BasicPersistentEntity;
+import org.springframework.data.util.Predicates;
+
+/**
+ * Unit tests for {@link PropertyValueConversionService}.
+ *
+ * @author Mark Paluch
+ */
+class PropertyValueConversionServiceUnitTests {
+
+	SampleMappingContext mappingContext = new SampleMappingContext();
+
+	PropertyValueConversions conversions = PropertyValueConversions.simple(it -> {
+		it.registerConverter(Person.class, "firstName", String.class).writing(w -> "Writing " + w)
+				.reading(r -> "Reading " + r);
+	});
+	PropertyValueConversionService service = createConversionService(conversions);
+
+	@Test // GH-2557
+	void shouldReportConverter() {
+
+		BasicPersistentEntity<Object, SamplePersistentProperty> entity = mappingContext
+				.getRequiredPersistentEntity(Person.class);
+
+		assertThat(service.hasConverter(entity.getRequiredPersistentProperty("firstName"))).isTrue();
+		assertThat(service.hasConverter(entity.getRequiredPersistentProperty("lastName"))).isFalse();
+	}
+
+	@Test // GH-2557
+	void conversionWithoutConverterShouldFail() {
+
+		BasicPersistentEntity<Object, SamplePersistentProperty> entity = mappingContext
+				.getRequiredPersistentEntity(Person.class);
+
+		SamplePersistentProperty property = entity.getRequiredPersistentProperty("lastName");
+		assertThatIllegalArgumentException().isThrownBy(() -> service.read("foo", property, () -> property));
+		assertThatIllegalArgumentException().isThrownBy(() -> service.write("foo", property, () -> property));
+	}
+
+	@Test // GH-2557
+	void readShouldUseReadConverter() {
+
+		BasicPersistentEntity<Object, SamplePersistentProperty> entity = mappingContext
+				.getRequiredPersistentEntity(Person.class);
+
+		SamplePersistentProperty property = entity.getRequiredPersistentProperty("firstName");
+		assertThat(service.read("Walter", property, () -> property)).isEqualTo("Reading Walter");
+		assertThat(service.read(null, property, () -> property)).isEqualTo("Reading null");
+	}
+
+	@Test // GH-2557
+	void readShouldUseWriteConverter() {
+
+		BasicPersistentEntity<Object, SamplePersistentProperty> entity = mappingContext
+				.getRequiredPersistentEntity(Person.class);
+
+		SamplePersistentProperty property = entity.getRequiredPersistentProperty("firstName");
+		assertThat(service.write("Walter", property, () -> property)).isEqualTo("Writing Walter");
+		assertThat(service.write(null, property, () -> property)).isEqualTo("Writing null");
+	}
+
+	@Test // GH-2557
+	void readShouldUseNullConvertersConverter() {
+
+		PropertyValueConversions conversions = PropertyValueConversions.simple(it -> {
+			it.registerConverter(Person.class, "firstName", WithNullConverters.INSTANCE);
+		});
+
+		PropertyValueConversionService service = createConversionService(conversions);
+
+		BasicPersistentEntity<Object, SamplePersistentProperty> entity = mappingContext
+				.getRequiredPersistentEntity(Person.class);
+
+		SamplePersistentProperty property = entity.getRequiredPersistentProperty("firstName");
+
+		assertThat(service.read(null, property, () -> property)).isEqualTo("readNull");
+		assertThat(service.write(null, property, () -> property)).isEqualTo("writeNull");
+	}
+
+	private static PropertyValueConversionService createConversionService(PropertyValueConversions conversions) {
+
+		CustomConversions.ConverterConfiguration configuration = new CustomConversions.ConverterConfiguration(
+				CustomConversions.StoreConversions.NONE, Collections.emptyList(), Predicates.isTrue(), conversions);
+
+		return new PropertyValueConversionService(new CustomConversions(configuration));
+	}
+
+	enum WithNullConverters implements PropertyValueConverter<String, String, ValueConversionContext<?>> {
+		INSTANCE;
+
+		@Override
+		public String read(String value, ValueConversionContext<?> context) {
+			return value;
+		}
+
+		@Override
+		public String readNull(ValueConversionContext<?> context) {
+			return "readNull";
+		}
+
+		@Override
+		public String write(String value, ValueConversionContext<?> context) {
+			return value;
+		}
+
+		@Override
+		public String writeNull(ValueConversionContext<?> context) {
+			return "writeNull";
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/CustomConversionsUnitTests.java
@@ -31,6 +31,7 @@ import org.jmolecules.ddd.types.Association;
 import org.jmolecules.ddd.types.Identifier;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterFactory;
@@ -45,8 +46,8 @@ import org.springframework.data.convert.CustomConversions.StoreConversions;
 import org.springframework.data.convert.Jsr310Converters.LocalDateTimeToDateConverter;
 import org.springframework.data.convert.ThreeTenBackPortConverters.LocalDateTimeToJavaTimeInstantConverter;
 import org.springframework.data.geo.Point;
-import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+
 import org.threeten.bp.LocalDateTime;
 
 /**
@@ -297,30 +298,17 @@ class CustomConversionsUnitTests {
 
 		ConfigurableConversionService conversionService = new DefaultConversionService();
 
-		new CustomConversions(StoreConversions.NONE, Collections.emptyList())
-				.registerConvertersIn(conversionService);
+		new CustomConversions(StoreConversions.NONE, Collections.emptyList()).registerConvertersIn(conversionService);
 
 		assertThat(conversionService.canConvert(io.vavr.collection.List.class, List.class)).isTrue();
 		assertThat(conversionService.canConvert(List.class, io.vavr.collection.List.class)).isTrue();
 	}
 
 	@Test // GH-1484
-	void allowsToRegisterPropertyConversions() {
-
-		PropertyValueConversions propertyValueConversions = mock(PropertyValueConversions.class);
-		when(propertyValueConversions.getValueConverter(any())).thenReturn(mock(PropertyValueConverter.class));
-
-		CustomConversions conversions = new CustomConversions(new ConverterConfiguration(StoreConversions.NONE,
-				Collections.emptyList(), (it) -> true, propertyValueConversions));
-		assertThat(conversions.getPropertyValueConverter(mock(PersistentProperty.class))).isNotNull();
-	}
-
-	@Test // GH-1484
 	void doesNotFailIfPropertiesConversionIsNull() {
 
-		CustomConversions conversions = new CustomConversions(new ConverterConfiguration(StoreConversions.NONE,
-				Collections.emptyList(), (it) -> true, null));
-		assertThat(conversions.getPropertyValueConverter(mock(PersistentProperty.class))).isNull();
+		new CustomConversions(
+				new ConverterConfiguration(StoreConversions.NONE, Collections.emptyList(), (it) -> true, null));
 	}
 
 	private static Class<?> createProxyTypeFor(Class<?> type) {

--- a/src/test/java/org/springframework/data/convert/PropertyValueConverterFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/PropertyValueConverterFactoryUnitTests.java
@@ -226,13 +226,13 @@ public class PropertyValueConverterFactoryUnitTests {
 
 		@Nullable
 		@Override
-		public String read(@Nullable UUID value, ValueConversionContext context) {
+		public String read(UUID value, ValueConversionContext context) {
 			return value.toString();
 		}
 
 		@Nullable
 		@Override
-		public UUID write(@Nullable String value, ValueConversionContext context) {
+		public UUID write(String value, ValueConversionContext context) {
 			return UUID.fromString(value);
 		}
 	}
@@ -248,7 +248,7 @@ public class PropertyValueConverterFactoryUnitTests {
 
 		@Nullable
 		@Override
-		public String read(@Nullable UUID value, ValueConversionContext<SamplePersistentProperty> context) {
+		public String read(UUID value, ValueConversionContext<SamplePersistentProperty> context) {
 
 			assertThat(someDependency).isNotNull();
 			return value.toString();
@@ -256,7 +256,7 @@ public class PropertyValueConverterFactoryUnitTests {
 
 		@Nullable
 		@Override
-		public UUID write(@Nullable String value, ValueConversionContext<SamplePersistentProperty> context) {
+		public UUID write(String value, ValueConversionContext<SamplePersistentProperty> context) {
 
 			assertThat(someDependency).isNotNull();
 			return UUID.fromString(value);


### PR DESCRIPTION
`PropertyValueConverter` read and write methods are never called with null values. Instead, `PropertyValueConverter` now defines `readNull` and `writeNull` to encapsulate `null` conversion. `PropertyValueConversionService` is a facade that encapsulates these details to simplify converter usage.

Closes #2577