### PR TITLE
Support reactive repositories in `ResourceReaderRepositoryPopulator` 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.7.0-SNAPSHOT</version>
+	<version>2.7.0-GH-2558-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 

--- a/src/main/java/org/springframework/data/repository/init/ResourceReaderRepositoryPopulator.java
+++ b/src/main/java/org/springframework/data/repository/init/ResourceReaderRepositoryPopulator.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
-
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.io.Resource;
@@ -207,7 +206,7 @@ public class ResourceReaderRepositoryPopulator implements RepositoryPopulator, A
 
 			RepositoryInformation repositoryInformation = repositories.getRequiredRepositoryInformation(domainType);
 			Object repository = repositories.getRepositoryFor(domainType).orElseThrow(
-					() -> new IllegalArgumentException(String.format("No repository found for domain type: %s", domainType)));
+					() -> new IllegalStateException(String.format("No repository found for domain type: %s", domainType)));
 
 			if (repositoryInformation.isReactiveRepository()) {
 				return repository instanceof ReactiveCrudRepository ? new ReactiveCrudRepositoryPersister(repository)
@@ -244,13 +243,13 @@ public class ResourceReaderRepositoryPopulator implements RepositoryPopulator, A
 		private final Object repository;
 
 		public ReflectivePersister(RepositoryMetadata metadata, Object repository) {
-			this.methods = new DefaultCrudMethods(metadata);
+
+			this.methods = metadata.getCrudMethods();
 			this.repository = repository;
 		}
 
 		@Override
 		public void save(Object object) {
-
 			doPersist(object);
 		}
 

--- a/src/test/java/org/springframework/data/repository/core/support/DummyRepositoryFactoryBean.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DummyRepositoryFactoryBean.java
@@ -17,15 +17,13 @@ package org.springframework.data.repository.core.support;
 
 import static org.mockito.Mockito.*;
 
-import java.io.Serializable;
-
 import org.springframework.data.mapping.context.SampleMappingContext;
 import org.springframework.data.repository.Repository;
 
 /**
  * @author Oliver Gierke
  */
-public class DummyRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
+public class DummyRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 		extends RepositoryFactoryBeanSupport<T, S, ID> {
 
 	private final T repository;

--- a/src/test/java/org/springframework/data/repository/init/ReactiveResourceReaderRepositoryPopulatorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/init/ReactiveResourceReaderRepositoryPopulatorUnitTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.init;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.reactivex.rxjava3.core.Single;
+import reactor.core.publisher.Mono;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.support.DummyRepositoryFactoryBean;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.repository.reactive.RxJava3CrudRepository;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Unit tests for {@link ResourceReaderRepositoryPopulator} using reactive repositories.
+ *
+ * @author Mark Paluch
+ */
+@SpringJUnitConfig(classes = ReactiveResourceReaderRepositoryPopulatorUnitTests.ReactiveSampleConfiguration.class)
+class ReactiveResourceReaderRepositoryPopulatorUnitTests {
+
+	@Autowired ReactivePersonRepository personRepository;
+	@Autowired ReactiveContactRepository contactRepository;
+	@Autowired RxJavaUserRepository userRepository;
+	@Autowired Repositories repositories;
+
+	ApplicationEventPublisher publisher;
+	ResourceReader reader;
+	Resource resource;
+
+	@BeforeEach
+	void setUp() {
+
+		this.reader = mock(ResourceReader.class);
+		this.publisher = mock(ApplicationEventPublisher.class);
+		this.resource = mock(Resource.class);
+	}
+
+	@Test
+	void storesSingleUsingReactiveRepositoryObjectCorrectly() throws Exception {
+
+		ReactivePerson reference = new ReactivePerson();
+		when(personRepository.save(reference)).thenReturn(Mono.just(reference));
+		setUpReferenceAndInitialize(reference);
+
+		verify(personRepository).save(reference);
+	}
+
+	@Test
+	void storesSingleUsingSimpleReactiveRepositoryObjectCorrectly() throws Exception {
+
+		ReactiveContact reference = new ReactiveContact();
+		when(contactRepository.save(reference)).thenReturn(Mono.just(reference));
+		setUpReferenceAndInitialize(reference);
+
+		verify(contactRepository).save(reference);
+	}
+
+	@Test
+	void storesSingleUsingRxJavaRepositoryObjectCorrectly() throws Exception {
+
+		ReactiveUser reference = new ReactiveUser();
+		when(userRepository.save(reference)).thenReturn(Single.just(reference));
+		setUpReferenceAndInitialize(reference);
+
+		verify(userRepository).save(reference);
+	}
+
+	@Test
+	void emitsRepositoriesPopulatedEventIfPublisherConfigured() throws Exception {
+
+		ReactivePerson reference = new ReactivePerson();
+		when(personRepository.save(reference)).thenReturn(Mono.just(reference));
+		RepositoryPopulator populator = setUpReferenceAndInitialize(reference, publisher);
+
+		ApplicationEvent event = new RepositoriesPopulatedEvent(populator, repositories);
+		verify(publisher, times(1)).publishEvent(event);
+	}
+
+	private RepositoryPopulator setUpReferenceAndInitialize(Object reference, ApplicationEventPublisher publish)
+			throws Exception {
+
+		when(reader.readFrom(any(), any())).thenReturn(reference);
+
+		ResourceReaderRepositoryPopulator populator = new ResourceReaderRepositoryPopulator(reader);
+		populator.setResources(resource);
+		populator.setApplicationEventPublisher(publisher);
+		populator.populate(repositories);
+
+		return populator;
+	}
+
+	private RepositoryPopulator setUpReferenceAndInitialize(Object reference) throws Exception {
+		return setUpReferenceAndInitialize(reference, null);
+	}
+
+	@Configuration
+	static class ReactiveSampleConfiguration {
+
+		@Autowired ApplicationContext context;
+
+		@Bean
+		Repositories repositories() {
+			return new Repositories(context);
+		}
+
+		@Bean
+		ReactivePersonRepository personRepository() {
+			return mock(ReactivePersonRepository.class);
+		}
+
+		@Bean
+		RepositoryFactoryBeanSupport<Repository<ReactivePerson, Object>, ReactivePerson, Object> personRepositoryFactory(
+				ReactivePersonRepository personRepository) {
+
+			DummyRepositoryFactoryBean<Repository<ReactivePerson, Object>, ReactivePerson, Object> factoryBean = new DummyRepositoryFactoryBean<>(
+					ReactivePersonRepository.class);
+			factoryBean.setCustomImplementation(personRepository);
+			return factoryBean;
+		}
+
+		@Bean
+		ReactiveContactRepository contactRepository() {
+			return mock(ReactiveContactRepository.class);
+		}
+
+		@Bean
+		RepositoryFactoryBeanSupport<Repository<ReactiveContact, Object>, ReactiveContact, Object> contactRepositoryFactory(
+				ReactiveContactRepository contactRepository) {
+
+			DummyRepositoryFactoryBean<Repository<ReactiveContact, Object>, ReactiveContact, Object> factoryBean = new DummyRepositoryFactoryBean<>(
+					ReactiveContactRepository.class);
+			factoryBean.setCustomImplementation(contactRepository);
+			return factoryBean;
+		}
+
+		@Bean
+		RxJavaUserRepository userRepository() {
+			return mock(RxJavaUserRepository.class);
+		}
+
+		@Bean
+		RepositoryFactoryBeanSupport<Repository<ReactiveUser, Object>, ReactiveUser, Object> userRepositoryFactory(
+				RxJavaUserRepository userRepository) {
+
+			DummyRepositoryFactoryBean<Repository<ReactiveUser, Object>, ReactiveUser, Object> factoryBean = new DummyRepositoryFactoryBean<>(
+					RxJavaUserRepository.class);
+			factoryBean.setCustomImplementation(userRepository);
+			return factoryBean;
+		}
+	}
+
+	static class ReactivePerson {
+
+	}
+
+	static class ReactiveContact {
+
+	}
+
+	static class ReactiveUser {
+
+	}
+
+	interface ReactivePersonRepository extends ReactiveCrudRepository<ReactivePerson, Object> {
+
+	}
+
+	interface ReactiveContactRepository extends Repository<ReactiveContact, Object> {
+
+		Mono<ReactiveContact> save(ReactiveContact contact);
+
+	}
+
+	interface RxJavaUserRepository extends RxJava3CrudRepository<ReactiveUser, Object> {
+
+	}
+}

--- a/src/test/java/org/springframework/data/repository/init/ReactiveResourceReaderRepositoryPopulatorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/init/ReactiveResourceReaderRepositoryPopulatorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * Unit tests for {@link ResourceReaderRepositoryPopulator} using reactive repositories.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @SpringJUnitConfig(classes = ReactiveResourceReaderRepositoryPopulatorUnitTests.ReactiveSampleConfiguration.class)
 class ReactiveResourceReaderRepositoryPopulatorUnitTests {
@@ -64,7 +65,7 @@ class ReactiveResourceReaderRepositoryPopulatorUnitTests {
 		this.resource = mock(Resource.class);
 	}
 
-	@Test
+	@Test // GH-2558
 	void storesSingleUsingReactiveRepositoryObjectCorrectly() throws Exception {
 
 		ReactivePerson reference = new ReactivePerson();
@@ -74,7 +75,7 @@ class ReactiveResourceReaderRepositoryPopulatorUnitTests {
 		verify(personRepository).save(reference);
 	}
 
-	@Test
+	@Test // GH-2558
 	void storesSingleUsingSimpleReactiveRepositoryObjectCorrectly() throws Exception {
 
 		ReactiveContact reference = new ReactiveContact();
@@ -84,7 +85,7 @@ class ReactiveResourceReaderRepositoryPopulatorUnitTests {
 		verify(contactRepository).save(reference);
 	}
 
-	@Test
+	@Test // GH-2558
 	void storesSingleUsingRxJavaRepositoryObjectCorrectly() throws Exception {
 
 		ReactiveUser reference = new ReactiveUser();
@@ -105,7 +106,7 @@ class ReactiveResourceReaderRepositoryPopulatorUnitTests {
 		verify(publisher, times(1)).publishEvent(event);
 	}
 
-	private RepositoryPopulator setUpReferenceAndInitialize(Object reference, ApplicationEventPublisher publish)
+	private RepositoryPopulator setUpReferenceAndInitialize(Object reference, ApplicationEventPublisher publisher)
 			throws Exception {
 
 		when(reader.readFrom(any(), any())).thenReturn(reference);

--- a/src/test/java/org/springframework/data/repository/init/RepositoryPersisterFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/init/RepositoryPersisterFactoryUnitTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.init;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.init.ResourceReaderRepositoryPopulator.RepositoryPersisterFactory;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.repository.support.Repositories;
+
+/**
+ * @author Christoph Strobl
+ */
+@ExtendWith(MockitoExtension.class)
+class RepositoryPersisterFactoryUnitTests {
+
+	@Mock Repositories repositories;
+	@Mock RepositoryInformation repoInfo;
+	RepositoryPersisterFactory factory;
+
+	@BeforeEach
+	void beforeEach() {
+		factory = new RepositoryPersisterFactory(repositories);
+	}
+
+	@Test // GH-2558
+	void errorsOnNoRepoFoundForType() {
+
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> factory.getPersisterFor(Object.class))
+				.withMessageContaining("No repository found");
+	}
+
+	@Test // GH-2558
+	void usesCrudRepoPersisterForNonReactiveCrudRepo() {
+
+		CrudRepository<?, ?> crudRepository = mock(CrudRepository.class);
+		when(repositories.getRequiredRepositoryInformation(any())).thenReturn(repoInfo);
+		when(repoInfo.isReactiveRepository()).thenReturn(false);
+		when(repositories.getRepositoryFor(Mockito.any())).thenReturn(Optional.of(crudRepository));
+
+		assertThat(factory.getPersisterFor(Object.class))
+				.satisfies(it -> it.getClass().getName().contains("CrudRepositoryPersister"));
+	}
+
+	@Test // GH-2558
+	void usesReactiveCrudRepoPersisterForReactiveCrudRepo() {
+
+		ReactiveCrudRepository<?, ?> crudRepository = mock(ReactiveCrudRepository.class);
+		when(repositories.getRequiredRepositoryInformation(any())).thenReturn(repoInfo);
+		when(repoInfo.isReactiveRepository()).thenReturn(true);
+		when(repositories.getRepositoryFor(Mockito.any())).thenReturn(Optional.of(crudRepository));
+
+		assertThat(factory.getPersisterFor(Object.class))
+				.satisfies(it -> it.getClass().getName().contains("ReactiveCrudRepositoryPersister"));
+	}
+
+	@Test // GH-2558
+	void usesReflectiveRepoPersisterForNonReactiveNonCrudRepo() {
+
+		Repository<?, ?> repository = mock(Repository.class);
+		when(repositories.getRequiredRepositoryInformation(any())).thenReturn(repoInfo);
+		when(repoInfo.isReactiveRepository()).thenReturn(false);
+		when(repositories.getRepositoryFor(Mockito.any())).thenReturn(Optional.of(repository));
+
+		assertThat(factory.getPersisterFor(Object.class))
+				.satisfies(it -> it.getClass().getName().contains("ReflectivePersister"));
+	}
+
+	@Test // GH-2558
+	void usesReactiveReflectiveRepoPersisterForReactiveNonCrudRepo() {
+
+		Repository<?, ?> repository = mock(Repository.class);
+		when(repositories.getRequiredRepositoryInformation(any())).thenReturn(repoInfo);
+		when(repoInfo.isReactiveRepository()).thenReturn(true);
+		when(repositories.getRepositoryFor(Mockito.any())).thenReturn(Optional.of(repository));
+
+		assertThat(factory.getPersisterFor(Object.class))
+				.satisfies(it -> it.getClass().getName().contains("ReflectiveReactivePersister"));
+	}
+}

--- a/src/test/java/org/springframework/data/repository/init/ResourceReaderRepositoryPopulatorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/init/ResourceReaderRepositoryPopulatorUnitTests.java
@@ -37,12 +37,13 @@ import org.springframework.data.repository.support.Repositories;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
- * Unit tests for {@link UnmarshallingRepositoryInitializer}.
+ * Unit tests for {@link ResourceReaderRepositoryPopulator}.
  *
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 @SpringJUnitConfig(classes = SampleConfiguration.class)
-class ResourceReaderRepositoryInitializerUnitTests {
+class ResourceReaderRepositoryPopulatorUnitTests {
 
 	@Autowired ProductRepository productRepository;
 	@Autowired Repositories repositories;
@@ -63,7 +64,7 @@ class ResourceReaderRepositoryInitializerUnitTests {
 	void storesSingleObjectCorrectly() throws Exception {
 
 		Product reference = new Product();
-		setUpReferenceAndInititalize(reference);
+		setUpReferenceAndInitialize(reference);
 
 		verify(productRepository).save(reference);
 	}
@@ -74,7 +75,7 @@ class ResourceReaderRepositoryInitializerUnitTests {
 		Product product = new Product();
 		Collection<Product> reference = Collections.singletonList(product);
 
-		setUpReferenceAndInititalize(reference);
+		setUpReferenceAndInitialize(reference);
 
 		verify(productRepository, times(1)).save(product);
 	}
@@ -82,13 +83,13 @@ class ResourceReaderRepositoryInitializerUnitTests {
 	@Test // DATACMNS-224
 	void emitsRepositoriesPopulatedEventIfPublisherConfigured() throws Exception {
 
-		RepositoryPopulator populator = setUpReferenceAndInititalize(new User(), publisher);
+		RepositoryPopulator populator = setUpReferenceAndInitialize(new User(), publisher);
 
 		ApplicationEvent event = new RepositoriesPopulatedEvent(populator, repositories);
 		verify(publisher, times(1)).publishEvent(event);
 	}
 
-	private RepositoryPopulator setUpReferenceAndInititalize(Object reference, ApplicationEventPublisher publish)
+	private RepositoryPopulator setUpReferenceAndInitialize(Object reference, ApplicationEventPublisher publish)
 			throws Exception {
 
 		when(reader.readFrom(any(), any())).thenReturn(reference);
@@ -102,7 +103,7 @@ class ResourceReaderRepositoryInitializerUnitTests {
 		return populator;
 	}
 
-	private RepositoryPopulator setUpReferenceAndInititalize(Object reference) throws Exception {
-		return setUpReferenceAndInititalize(reference, null);
+	private RepositoryPopulator setUpReferenceAndInitialize(Object reference) throws Exception {
+		return setUpReferenceAndInitialize(reference, null);
 	}
 }


### PR DESCRIPTION
We now support reactive repositories in addition to imperative repositories when populating repositories from a resource reader.

Instead of `RepositoryInvokerFactory`, we now use a `RepositoryPersisterFactory` to avoid introducing reactive support to `RepositoryInvokerFactory`.

Closes #2558 