### PR TITLE
Extension special types (Pageable and Sort) to subtypes (e.g. PageRequest, etc.)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-gh-2626-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Greg Turnquist
  */
 public class Parameter {
 
@@ -79,7 +80,7 @@ public class Parameter {
 		this.parameter = parameter;
 		this.parameterType = potentiallyUnwrapParameterType(parameter);
 		this.isDynamicProjectionParameter = isDynamicProjectionParameter(parameter);
-		this.name = TYPES.contains(parameter.getParameterType()) ? Lazy.of(Optional.empty()) : Lazy.of(() -> {
+		this.name = isSpecialParameterType(parameter.getParameterType()) ? Lazy.of(Optional.empty()) : Lazy.of(() -> {
 			Param annotation = parameter.getParameterAnnotation(Param.class);
 			return Optional.ofNullable(annotation == null ? parameter.getParameterName() : annotation.value());
 		});
@@ -92,7 +93,7 @@ public class Parameter {
 	 * @see #TYPES
 	 */
 	public boolean isSpecialParameter() {
-		return isDynamicProjectionParameter || TYPES.contains(parameter.getParameterType());
+		return isDynamicProjectionParameter || isSpecialParameterType(parameter.getParameterType());
 	}
 
 	/**
@@ -268,5 +269,16 @@ public class Parameter {
 		}
 
 		return originalType;
+	}
+
+	/**
+	 * Identify is a given {@link Class} is either part of {@code TYPES} or an instanceof of one of its members. For
+	 * example, {@code PageRequest} is an instance of {@code Pageable} (a member of {@code TYPES}).
+	 *
+	 * @param parameterType
+	 * @return boolean
+	 */
+	private static boolean isSpecialParameterType(Class<?> parameterType) {
+		return TYPES.stream().anyMatch(clazz -> clazz.isAssignableFrom(parameterType));
 	}
 }

--- a/src/test/java/org/springframework/data/repository/query/ParametersParameterAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ParametersParameterAccessorUnitTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -27,6 +26,7 @@ import org.springframework.data.domain.Pageable;
  * Unit tests for {@link ParametersParameterAccessor}.
  *
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 class ParametersParameterAccessorUnitTests {
 
@@ -69,10 +69,22 @@ class ParametersParameterAccessorUnitTests {
 		var method = Sample.class.getMethod("method", Pageable.class, String.class);
 		var parameters = new DefaultParameters(method);
 
-		var accessor = new ParametersParameterAccessor(parameters,
-				new Object[] { PageRequest.of(0, 10), "Foo" });
+		var accessor = new ParametersParameterAccessor(parameters, new Object[] { PageRequest.of(0, 10), "Foo" });
 
 		assertThat(accessor).hasSize(1);
+		assertThat(accessor.getBindableValue(0)).isEqualTo("Foo");
+	}
+
+	@Test
+	void handlesPageRequestAsAParameterType() throws NoSuchMethodException {
+
+		var method = Sample.class.getMethod("methodWithPageRequest", PageRequest.class, String.class);
+		var parameters = new DefaultParameters(method);
+
+		var accessor = new ParametersParameterAccessor(parameters, new Object[] { PageRequest.of(0, 10), "Foo" });
+
+		assertThat(accessor).hasSize(1);
+		assertThat(accessor.getBindableValue(0)).isEqualTo("Foo");
 	}
 
 	interface Sample {
@@ -80,5 +92,7 @@ class ParametersParameterAccessorUnitTests {
 		void method(String string, int integer);
 
 		void method(Pageable pageable, String string);
+
+		void methodWithPageRequest(PageRequest pageRequest, String string);
 	}
 }


### PR DESCRIPTION
If someone defines a custom finder using a subtype, like `findByLastname(String lastname, PageRequest page)`, Spring Data Commons will fail to properly handle it, since it has a strict members-only policy for special types.

This list should be extended to subclasses so a custom finder using any of these subtypes will also work.

Closes #2626.