### PR TITLE
Fix argument conversion in `QuerydslPredicateBuilder`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-GH-2649-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>
@@ -169,7 +169,7 @@
 			<version>${vavr}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<!-- Eclipse Collections -->
 
 		<dependency>

--- a/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
+++ b/src/main/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilder.java
@@ -175,30 +175,29 @@ public class QuerydslPredicateBuilder {
 	 */
 	private Collection<Object> convertToPropertyPathSpecificType(List<?> source, PathInformation path) {
 
-		Class<?> targetType = path.getLeafType();
-
 		if (source.isEmpty() || isSingleElementCollectionWithEmptyItem(source)) {
 			return Collections.emptyList();
 		}
 
+		TypeDescriptor targetType = getTargetTypeDescriptor(path);
 		Collection<Object> target = new ArrayList<>(source.size());
 
 		for (Object value : source) {
-			target.add(getValue(path, targetType, value));
+			target.add(getValue(targetType, value));
 		}
 
 		return target;
 	}
 
 	@Nullable
-	private Object getValue(PathInformation path, Class<?> targetType, Object value) {
+	private Object getValue(TypeDescriptor targetType, Object value) {
 
-		if (ClassUtils.isAssignableValue(targetType, value)) {
+		if (ClassUtils.isAssignableValue(targetType.getType(), value)) {
 			return value;
 		}
 
-		if (conversionService.canConvert(value.getClass(), targetType)) {
-			return conversionService.convert(value, TypeDescriptor.forObject(value), getTargetTypeDescriptor(path));
+		if (conversionService.canConvert(value.getClass(), targetType.getType())) {
+			return conversionService.convert(value, TypeDescriptor.forObject(value), targetType);
 		}
 
 		return value;

--- a/src/test/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/querydsl/binding/QuerydslPredicateBuilderUnitTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assumptions.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.data.querydsl.Address;
 import org.springframework.data.querydsl.QSpecialUser;
 import org.springframework.data.querydsl.QUser;
@@ -31,7 +33,6 @@ import org.springframework.data.querydsl.SimpleEntityPathResolver;
 import org.springframework.data.querydsl.User;
 import org.springframework.data.querydsl.UserWrapper;
 import org.springframework.data.querydsl.Users;
-// import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.data.util.Version;
 import org.springframework.format.support.DefaultFormattingConversionService;
@@ -179,6 +180,18 @@ class QuerydslPredicateBuilderUnitTests {
 		var constant = (Constant<Object>) ((List<?>) getField(getField(predicate, "mixin"), "args")).get(1);
 
 		assertThat(constant.getConstant()).isEqualTo("rivers,two");
+	}
+
+	@Test
+	void resolvesCommaSeparatedArgumentToListCorrectly() {
+
+		values.add("nickNames", "Walt,Heisenberg");
+
+		var predicate = builder.getPredicate(USER_TYPE, values, DEFAULT_BINDINGS);
+
+		var constant = (Constant<Object>) ((List<?>) getField(getField(predicate, "mixin"), "args")).get(0);
+
+		assertThat(constant.getConstant()).isEqualTo(Arrays.asList("Walt", "Heisenberg"));
 	}
 
 	@Test // DATACMNS-883


### PR DESCRIPTION
We now consider the correct argument type instead of checking the assignability of the actual property type against the input value.

Closes #2649