### PR TITLE
Specify title to `auditing.auditor-aware`.

### DIFF
--- a/src/main/asciidoc/auditing.adoc
+++ b/src/main/asciidoc/auditing.adoc
@@ -9,7 +9,7 @@ Please refer to the store-specific section for configuration samples.
 
 [NOTE]
 ====
-Applications that only track creation and modification dates do not need to specify an <<auditing.auditor-aware>>.
+Applications that only track creation and modification dates are not required do make their entities implement <<auditing.auditor-aware, `AuditorAware`>>.
 ====
 
 [[auditing.annotations]]


### PR DESCRIPTION
If `auditing.adoc` is included in the rendered documentation, the sentences does not make too much sense (see screenshot).

![Ohne Titel](https://user-images.githubusercontent.com/526383/178438670-b95b320d-03b6-469a-ab41-9b177d551be9.jpg)

