### PR TITLE
Generate custom bean initialization code for types exposed via ManagedTypes during AOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.x-GH-2680-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<!--  RxJava -->
 

--- a/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
@@ -56,7 +56,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 		}
 
 		BeanFactory beanFactory = registeredBean.getBeanFactory();
-		return contribute(AotContext.from(beanFactory), resolveManagedTypes(registeredBean));
+		return contribute(AotContext.from(beanFactory), resolveManagedTypes(registeredBean), registeredBean.getBeanClass());
 	}
 
 	ManagedTypes resolveManagedTypes(RegisteredBean registeredBean) {
@@ -114,8 +114,8 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	 * @return new instance of {@link ManagedTypesBeanRegistrationAotProcessor} or {@literal null} if nothing to do.
 	 */
 	@Nullable
-	protected BeanRegistrationAotContribution contribute(AotContext aotContext, ManagedTypes managedTypes) {
-		return new ManagedTypesRegistrationAotContribution(aotContext, managedTypes, this::contributeType);
+	protected BeanRegistrationAotContribution contribute(AotContext aotContext, ManagedTypes managedTypes, Class<?> sourceClass) {
+		return new ManagedTypesRegistrationAotContribution(aotContext, managedTypes, sourceClass, this::contributeType);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
@@ -56,7 +56,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 		}
 
 		BeanFactory beanFactory = registeredBean.getBeanFactory();
-		return contribute(AotContext.from(beanFactory), resolveManagedTypes(registeredBean), registeredBean.getBeanClass());
+		return contribute(AotContext.from(beanFactory), resolveManagedTypes(registeredBean), registeredBean);
 	}
 
 	ManagedTypes resolveManagedTypes(RegisteredBean registeredBean) {
@@ -114,8 +114,8 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	 * @return new instance of {@link ManagedTypesBeanRegistrationAotProcessor} or {@literal null} if nothing to do.
 	 */
 	@Nullable
-	protected BeanRegistrationAotContribution contribute(AotContext aotContext, ManagedTypes managedTypes, Class<?> sourceClass) {
-		return new ManagedTypesRegistrationAotContribution(aotContext, managedTypes, sourceClass, this::contributeType);
+	protected BeanRegistrationAotContribution contribute(AotContext aotContext, ManagedTypes managedTypes, RegisteredBean registeredBean) {
+		return new ManagedTypesRegistrationAotContribution(aotContext, managedTypes, registeredBean, this::contributeType);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
@@ -15,15 +15,27 @@
  */
 package org.springframework.data.aot;
 
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
+import org.springframework.aot.generate.AccessVisibility;
+import org.springframework.aot.generate.GeneratedMethod;
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
 import org.springframework.beans.factory.aot.BeanRegistrationCode;
+import org.springframework.beans.factory.aot.BeanRegistrationCodeFragments;
+import org.springframework.cglib.core.VisibilityPredicate;
 import org.springframework.core.ResolvableType;
 import org.springframework.data.domain.ManagedTypes;
+import org.springframework.javapoet.CodeBlock;
+import org.springframework.javapoet.ParameterizedTypeName;
 import org.springframework.lang.Nullable;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * {@link BeanRegistrationAotContribution} used to contribute a {@link ManagedTypes} registration.
@@ -37,13 +49,15 @@ public class ManagedTypesRegistrationAotContribution implements BeanRegistration
 	private final AotContext aotContext;
 	private final ManagedTypes managedTypes;
 	private final BiConsumer<ResolvableType, GenerationContext> contributionAction;
+	private final Class<?> beanType;
 
-	public ManagedTypesRegistrationAotContribution(AotContext aotContext, @Nullable ManagedTypes managedTypes,
+	public ManagedTypesRegistrationAotContribution(AotContext aotContext, @Nullable ManagedTypes managedTypes, Class<?> sourceType,
 			BiConsumer<ResolvableType, GenerationContext> contributionAction) {
 
 		this.aotContext = aotContext;
 		this.managedTypes = managedTypes;
 		this.contributionAction = contributionAction;
+		this.beanType = sourceType;
 	}
 
 	protected AotContext getAotContext() {
@@ -61,6 +75,76 @@ public class ManagedTypesRegistrationAotContribution implements BeanRegistration
 
 		if (!types.isEmpty()) {
 			TypeCollector.inspect(types).forEach(type -> contributionAction.accept(type, generationContext));
+		}
+
+	}
+
+	@Override
+	public BeanRegistrationCodeFragments customizeBeanRegistrationCodeFragments(GenerationContext generationContext, BeanRegistrationCodeFragments codeFragments) {
+
+		if(managedTypes == null) {
+			return codeFragments;
+		}
+
+		return new ManagedTypesInstance(getManagedTypes(), beanType, codeFragments);
+	}
+
+	static class ManagedTypesInstance extends BeanRegistrationCodeFragments {
+
+		private ManagedTypes types;
+		private Class<?> sourceBeanType;
+
+		protected ManagedTypesInstance(ManagedTypes managedTypes, Class<?> beanType, BeanRegistrationCodeFragments codeFragments) {
+			super(codeFragments);
+			this.types = managedTypes;
+			this.sourceBeanType = beanType;
+		}
+
+		@Override
+		public CodeBlock generateInstanceSupplierCode(GenerationContext generationContext, BeanRegistrationCode beanRegistrationCode, Executable constructorOrFactoryMethod, boolean allowDirectSupplierShortcut) {
+
+			GeneratedMethod generatedMethod = beanRegistrationCode.getMethods().add("Instance", method -> {
+
+				List<Class<?>> sourceTypes = types.toList();
+				boolean allPublic = sourceTypes.stream().allMatch(it -> AccessVisibility.PUBLIC.equals(AccessVisibility.forClass(it)));
+
+				Class<?> beanType = ManagedTypes.class;
+				ParameterizedTypeName listType = ParameterizedTypeName.get(List.class, allPublic ? Class.class : String.class);
+
+				method.addModifiers(Modifier.PRIVATE, Modifier.STATIC);
+				method.returns(beanType);
+				method.addStatement("var types = $T.of($L)",// listType,
+						List.class, toCodeBlock(sourceTypes, allPublic));
+
+				if(!ObjectUtils.nullSafeEquals(sourceBeanType, beanType)) {
+					String factoryMethodName = "from";
+					for(Method beanMethod : ReflectionUtils.getDeclaredMethods(sourceBeanType)) {
+						if(beanMethod.getParameterCount() == 1 && ObjectUtils.nullSafeEquals(beanMethod.getParameterTypes()[0], ManagedTypes.class)){
+							factoryMethodName = beanMethod.getName();
+						}
+					}
+					if (allPublic) {
+						method.addStatement("return $T."+factoryMethodName+"($T.fromIterable($L))", sourceBeanType, beanType, "types");
+					} else {
+						method.addStatement("return $T."+factoryMethodName+"($T.fromClassNames($L))", sourceBeanType, beanType, "types");
+					}
+				} else {
+					if (allPublic) {
+						method.addStatement("return $T.fromIterable($L)", beanType, "types");
+					} else {
+						method.addStatement("return $T.fromClassNames($L))", beanType, "types");
+					}
+				}
+			});
+
+			return CodeBlock.of("() -> $T.$L()", beanRegistrationCode.getClassName(), generatedMethod.getName());
+		}
+
+		private CodeBlock toCodeBlock(List<Class<?>> values, boolean allPublic) {
+			if(allPublic) {
+				return CodeBlock.join(values.stream().map(value -> CodeBlock.of("$T.class", value)).toList(), ", ");
+			}
+			return CodeBlock.join(values.stream().map(value -> CodeBlock.of("$S", value.getName())).toList(), ", ");
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
@@ -56,7 +56,7 @@ import org.springframework.util.ReflectionUtils;
  * public static InstanceSupplier&lt;ManagedTypes&gt; instance() {
  *   return (registeredBean) -> {
  *     var types = List.of("com.example.A", "com.example.B");
- *     return ManagedTypes.ofStream(types.stream().map(it -> ClassUtils.forName(it, registeredBean.getBeanFactory().getBeanClassLoader())));
+ *     return ManagedTypes.ofStream(types.stream().map(it -> ClassUtils.resolveClassName(it, registeredBean.getBeanFactory().getBeanClassLoader())));
  *   }
  * }
  * </code>
@@ -200,11 +200,8 @@ public class ManagedTypesRegistrationAotContribution implements RegisteredBeanAo
 			} else {
 				builder.add(CodeBlock.builder()
 						.beginControlFlow("var managedTypes = $T.fromStream(types.stream().map(it ->", ManagedTypes.class)
-						.beginControlFlow("try")
-						.addStatement("return $T.forName(it, registeredBean.getBeanFactory().getBeanClassLoader())",
+						.addStatement("return $T.resolveClassName(it, registeredBean.getBeanFactory().getBeanClassLoader())",
 								ClassUtils.class)
-						.nextControlFlow("catch ($T e)", ClassNotFoundException.class)
-						.addStatement("throw new $T($S, e)", IllegalArgumentException.class, "Cannot to load type").endControlFlow()
 						.endControlFlow("))").build());
 			}
 			if (ObjectUtils.nullSafeEquals(source.getBeanClass(), ManagedTypes.class)) {

--- a/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
@@ -132,7 +132,7 @@ public class ManagedTypesRegistrationAotContribution implements BeanRegistration
 					if (allPublic) {
 						method.addStatement("return $T.fromIterable($L)", beanType, "types");
 					} else {
-						method.addStatement("return $T.fromClassNames($L))", beanType, "types");
+						method.addStatement("return $T.fromClassNames($L)", beanType, "types");
 					}
 				}
 			});

--- a/src/main/java/org/springframework/data/aot/RegisteredBeanAotContribution.java
+++ b/src/main/java/org/springframework/data/aot/RegisteredBeanAotContribution.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aot;
+
+import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
+import org.springframework.beans.factory.support.RegisteredBean;
+
+/**
+ * @author Christoph Strobl
+ */
+public interface RegisteredBeanAotContribution extends BeanRegistrationAotContribution {
+
+	RegisteredBean getSource();
+}

--- a/src/main/java/org/springframework/data/domain/ManagedTypes.java
+++ b/src/main/java/org/springframework/data/domain/ManagedTypes.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.Streamable;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -85,19 +86,21 @@ public interface ManagedTypes {
 	 *
 	 * @param types {@link Iterable} of {@literal class names} used to initialize the {@link ManagedTypes}; must not be
 	 *          {@literal null}.
+	 * @param classLoader the class loader to use. Can be {@literal null}, which indicates the default class loader.
 	 * @return new instance of {@link ManagedTypes} initialized the given, required {@link Iterable} of {@link Class
 	 *         types}.
 	 * @throws IllegalStateException if class cannot be loaded.
 	 * @see java.lang.Iterable
 	 * @see #fromStream(Stream)
 	 * @see #fromSupplier(Supplier)
+	 * @see ClassUtils#forName(String, ClassLoader)
 	 */
-	static ManagedTypes fromClassNames(Iterable<String> types) {
+	static ManagedTypes fromClassNames(Iterable<String> types, @Nullable ClassLoader classLoader) {
 
 		Assert.notNull(types, "Types must not be null");
 		return Streamable.of(types).map(it -> {
 			try {
-				return ClassUtils.forName(it, ManagedTypes.class.getClassLoader());
+				return ClassUtils.forName(it, classLoader);
 			} catch (ClassNotFoundException e) {
 				throw new IllegalStateException(e);
 			}

--- a/src/main/java/org/springframework/data/domain/ManagedTypes.java
+++ b/src/main/java/org/springframework/data/domain/ManagedTypes.java
@@ -24,7 +24,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.springframework.data.util.Lazy;
+import org.springframework.data.util.Streamable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * Types managed by a Spring Data implementation. Used to predefine a set of known entities that might need processing
@@ -75,6 +77,18 @@ public interface ManagedTypes {
 
 		Assert.notNull(types, "Types must not be null");
 		return types::forEach;
+	}
+
+	static ManagedTypes fromClassNames(Iterable<String> types) {
+
+		Assert.notNull(types, "Types must not be null");
+		return Streamable.of(types).map(it -> {
+			try {
+				return ClassUtils.forName(it, ManagedTypes.class.getClassLoader());
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		})::forEach;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/domain/ManagedTypes.java
+++ b/src/main/java/org/springframework/data/domain/ManagedTypes.java
@@ -79,6 +79,19 @@ public interface ManagedTypes {
 		return types::forEach;
 	}
 
+	/**
+	 * Factory method used to construct {@link ManagedTypes} from the given, required {@link Iterable} of {@link String
+	 * type names}.
+	 *
+	 * @param types {@link Iterable} of {@literal class names} used to initialize the {@link ManagedTypes}; must not be
+	 *          {@literal null}.
+	 * @return new instance of {@link ManagedTypes} initialized the given, required {@link Iterable} of {@link Class
+	 *         types}.
+	 * @throws IllegalStateException if class cannot be loaded.
+	 * @see java.lang.Iterable
+	 * @see #fromStream(Stream)
+	 * @see #fromSupplier(Supplier)
+	 */
 	static ManagedTypes fromClassNames(Iterable<String> types) {
 
 		Assert.notNull(types, "Types must not be null");
@@ -86,7 +99,7 @@ public interface ManagedTypes {
 			try {
 				return ClassUtils.forName(it, ManagedTypes.class.getClassLoader());
 			} catch (ClassNotFoundException e) {
-				throw new RuntimeException(e);
+				throw new IllegalStateException(e);
 			}
 		})::forEach;
 	}

--- a/src/main/java/org/springframework/data/domain/ManagedTypes.java
+++ b/src/main/java/org/springframework/data/domain/ManagedTypes.java
@@ -24,10 +24,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.springframework.data.util.Lazy;
-import org.springframework.data.util.Streamable;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * Types managed by a Spring Data implementation. Used to predefine a set of known entities that might need processing
@@ -78,33 +75,6 @@ public interface ManagedTypes {
 
 		Assert.notNull(types, "Types must not be null");
 		return types::forEach;
-	}
-
-	/**
-	 * Factory method used to construct {@link ManagedTypes} from the given, required {@link Iterable} of {@link String
-	 * type names}.
-	 *
-	 * @param types {@link Iterable} of {@literal class names} used to initialize the {@link ManagedTypes}; must not be
-	 *          {@literal null}.
-	 * @param classLoader the class loader to use. Can be {@literal null}, which indicates the default class loader.
-	 * @return new instance of {@link ManagedTypes} initialized the given, required {@link Iterable} of {@link Class
-	 *         types}.
-	 * @throws IllegalStateException if class cannot be loaded.
-	 * @see java.lang.Iterable
-	 * @see #fromStream(Stream)
-	 * @see #fromSupplier(Supplier)
-	 * @see ClassUtils#forName(String, ClassLoader)
-	 */
-	static ManagedTypes fromClassNames(Iterable<String> types, @Nullable ClassLoader classLoader) {
-
-		Assert.notNull(types, "Types must not be null");
-		return Streamable.of(types).map(it -> {
-			try {
-				return ClassUtils.forName(it, classLoader);
-			} catch (ClassNotFoundException e) {
-				throw new IllegalStateException(e);
-			}
-		})::forEach;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/aot/AotTestCodeContributionBuilder.java
+++ b/src/test/java/org/springframework/data/aot/AotTestCodeContributionBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aot;
+
+import javax.lang.model.element.Modifier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.mockito.Mockito;
+import org.springframework.aot.test.generator.compile.Compiled;
+import org.springframework.aot.test.generator.compile.TestCompiler;
+import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
+import org.springframework.beans.factory.aot.BeanRegistrationCodeFragments;
+import org.springframework.data.domain.ManagedTypes;
+import org.springframework.javapoet.CodeBlock;
+import org.springframework.javapoet.MethodSpec;
+import org.springframework.javapoet.ParameterizedTypeName;
+import org.springframework.test.aot.generate.TestGenerationContext;
+
+/**
+ * @author Christoph Strobl
+ */
+public class AotTestCodeContributionBuilder {
+
+	TestGenerationContext generationContext;
+	MockBeanRegistrationCode beanRegistrationCode;
+
+	static AotTestCodeContributionBuilder withContextFor(Class<?> type) {
+		return withContext(new TestGenerationContext(type));
+	}
+
+	static AotTestCodeContributionBuilder withContext(TestGenerationContext ctx) {
+
+		AotTestCodeContributionBuilder codeGenerationBuilder = new AotTestCodeContributionBuilder();
+		codeGenerationBuilder.generationContext = ctx;
+		codeGenerationBuilder.beanRegistrationCode = new MockBeanRegistrationCode(ctx);
+		return codeGenerationBuilder;
+	}
+
+	BeanRegistrationCodeFragments getFragments(BeanRegistrationAotContribution contribution) {
+		return contribution.customizeBeanRegistrationCodeFragments(generationContext,
+				Mockito.mock(BeanRegistrationCodeFragments.class));
+	}
+
+	AotTestCodeContributionBuilder writeContentFor(BeanRegistrationAotContribution contribution) {
+
+		CodeBlock codeBlock = getFragments(contribution).generateInstanceSupplierCode(generationContext,
+				beanRegistrationCode, null, false);
+
+		ParameterizedTypeName parameterizedReturnTypeName = ParameterizedTypeName.get(Supplier.class, ManagedTypes.class);
+		beanRegistrationCode.getTypeBuilder().set(type -> {
+			type.addModifiers(Modifier.PUBLIC);
+			type.addMethod(MethodSpec.methodBuilder("get").addModifiers(Modifier.PUBLIC)
+					.returns(parameterizedReturnTypeName).addStatement("return $L", codeBlock).build());
+		});
+
+		return this;
+	}
+
+	public void compile() {
+		compile(it -> {
+		});
+	}
+
+	public void compile(Consumer<Compiled> compiled) {
+		generationContext.writeGeneratedContent();
+		TestCompiler.forSystem().withFiles(generationContext.getGeneratedFiles()).compile(compiled);
+	}
+}

--- a/src/test/java/org/springframework/data/aot/AotTestCodeContributionBuilder.java
+++ b/src/test/java/org/springframework/data/aot/AotTestCodeContributionBuilder.java
@@ -15,23 +15,20 @@
  */
 package org.springframework.data.aot;
 
-import javax.lang.model.element.Modifier;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+
+import javax.lang.model.element.Modifier;
 
 import org.mockito.Mockito;
-import org.springframework.aot.test.generator.compile.Compiled;
-import org.springframework.aot.test.generator.compile.TestCompiler;
-import org.springframework.beans.factory.aot.BeanInstanceSupplier;
+import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.aot.test.generate.compile.Compiled;
+import org.springframework.aot.test.generate.compile.TestCompiler;
 import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
 import org.springframework.beans.factory.aot.BeanRegistrationCodeFragments;
 import org.springframework.beans.factory.support.InstanceSupplier;
-import org.springframework.beans.factory.support.RegisteredBean;
-import org.springframework.data.domain.ManagedTypes;
 import org.springframework.javapoet.CodeBlock;
 import org.springframework.javapoet.MethodSpec;
 import org.springframework.javapoet.ParameterizedTypeName;
-import org.springframework.test.aot.generate.TestGenerationContext;
 
 /**
  * @author Christoph Strobl
@@ -69,22 +66,23 @@ public class AotTestCodeContributionBuilder {
 
 		Class<?> beanType = Object.class;
 		try {
-			beanType = contribution instanceof RegisteredBeanAotContribution ? ((RegisteredBeanAotContribution) contribution).getSource().getBeanClass() : Object.class;
+			beanType = contribution instanceof RegisteredBeanAotContribution
+					? ((RegisteredBeanAotContribution) contribution).getSource().getBeanClass()
+					: Object.class;
 		} catch (Exception e) {}
 
 		ParameterizedTypeName parameterizedReturnTypeName = ParameterizedTypeName.get(InstanceSupplier.class, beanType);
 		beanRegistrationCode.getTypeBuilder().set(type -> {
 			type.addModifiers(Modifier.PUBLIC);
-			type.addMethod(MethodSpec.methodBuilder("get").addModifiers(Modifier.PUBLIC)
-					.returns(parameterizedReturnTypeName).addStatement("return $L", codeBlock).build());
+			type.addMethod(MethodSpec.methodBuilder("get").addModifiers(Modifier.PUBLIC).returns(parameterizedReturnTypeName)
+					.addStatement("return $L", codeBlock).build());
 		});
 
 		return this;
 	}
 
 	public void compile() {
-		compile(it -> {
-		});
+		compile(it -> {});
 	}
 
 	public void compile(Consumer<Compiled> compiled) {

--- a/src/test/java/org/springframework/data/aot/BeanRegistrationContributionAssert.java
+++ b/src/test/java/org/springframework/data/aot/BeanRegistrationContributionAssert.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 import java.util.function.Consumer;
 
 import org.assertj.core.api.AbstractAssert;
-
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;

--- a/src/test/java/org/springframework/data/aot/DeferredTypeBuilder.java
+++ b/src/test/java/org/springframework/data/aot/DeferredTypeBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aot;
+
+import java.util.function.Consumer;
+
+import org.springframework.javapoet.TypeSpec;
+import org.springframework.javapoet.TypeSpec.Builder;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christoph Strobl
+ */
+public class DeferredTypeBuilder implements Consumer<Builder> {
+
+	@Nullable
+	private Consumer<Builder> type;
+
+	@Override
+	public void accept(Builder type) {
+		Assert.notNull(this.type, "No type builder set");
+		this.type.accept(type);
+	}
+
+	public void set(Consumer<Builder> type) {
+		this.type = type;
+	}
+}

--- a/src/test/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessorUnitTests.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -32,7 +31,6 @@ import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.aot.BeanInstanceSupplier;
 import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
 import org.springframework.beans.factory.aot.BeanRegistrationCodeFragments;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -202,8 +200,7 @@ class ManagedTypesBeanRegistrationAotProcessorUnitTests {
 
 		RegisteredBean registeredBean = RegisteredBean.of(beanFactory, "commons.managed-types");
 
-		BeanRegistrationAotContribution contribution = createPostProcessor("commons")
-				.processAheadOfTime(registeredBean);
+		BeanRegistrationAotContribution contribution = createPostProcessor("commons").processAheadOfTime(registeredBean);
 
 		AotTestCodeContributionBuilder.withContextFor(this.getClass()).writeContentFor(contribution).compile(it -> {
 
@@ -225,8 +222,7 @@ class ManagedTypesBeanRegistrationAotProcessorUnitTests {
 		RegisteredBean registeredBean = RegisteredBean.of(beanFactory, "managed-types");
 
 		ManagedTypesInstanceCodeFragment fragment = new ManagedTypesInstanceCodeFragment(
-				ManagedTypes.from(A.class, B.class), registeredBean,
-				Mockito.mock(BeanRegistrationCodeFragments.class));
+				ManagedTypes.from(A.class, B.class), registeredBean, Mockito.mock(BeanRegistrationCodeFragments.class));
 		Builder methodBuilder = MethodSpec.methodBuilder("instance");
 		fragment.generateInstanceFactory(methodBuilder);
 
@@ -324,20 +320,6 @@ class ManagedTypesBeanRegistrationAotProcessorUnitTests {
 		@Bean(name = "commons.managed-types")
 		ManagedTypes managedTypes() {
 			return ManagedTypes.from(A.class, B.class);
-		}
-	}
-
-	public class ManagedTypesBeanRegistrationAotProcessorUnitTests__TestCode {
-		public BeanInstanceSupplier<? extends ManagedTypes> get() {
-			return ManagedTypesBeanRegistrationAotProcessorUnitTests__TestCode.instance();
-		}
-
-		private static BeanInstanceSupplier<StoreManagedTypesWithCustomFactoryMethod> instance(
-		) {
-			return BeanInstanceSupplier.<ManagedTypesBeanRegistrationAotProcessorUnitTests.StoreManagedTypesWithCustomFactoryMethod>forFactoryMethod(Class.class, "managedTypes").withGenerator(registeredBean ->  {
-				var types = List.of("org.springframework.data.aot.ManagedTypesBeanRegistrationAotProcessorUnitTests$A", "org.springframework.data.aot.ManagedTypesBeanRegistrationAotProcessorUnitTests$B");
-				return ManagedTypesBeanRegistrationAotProcessorUnitTests.StoreManagedTypesWithCustomFactoryMethod.of(ManagedTypes.fromClassNames(types, registeredBean.getBeanFactory().getBeanClassLoader()));
-			} );
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/aot/MockBeanRegistrationCode.java
+++ b/src/test/java/org/springframework/data/aot/MockBeanRegistrationCode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.aot.generate.GeneratedClass;
+import org.springframework.aot.generate.GeneratedMethods;
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.generate.MethodReference;
+import org.springframework.beans.factory.aot.BeanRegistrationCode;
+import org.springframework.javapoet.ClassName;
+
+/**
+ * @author Christoph Strobl
+ */
+public class MockBeanRegistrationCode implements BeanRegistrationCode {
+
+	private final GeneratedClass generatedClass;
+
+	private final List<MethodReference> instancePostProcessors = new ArrayList<>();
+
+	private final DeferredTypeBuilder typeBuilder = new DeferredTypeBuilder();
+
+	public MockBeanRegistrationCode(GenerationContext generationContext) {
+		this.generatedClass = generationContext.getGeneratedClasses().addForFeature("TestCode", this.typeBuilder);
+	}
+
+	public DeferredTypeBuilder getTypeBuilder() {
+		return this.typeBuilder;
+	}
+
+	@Override
+	public ClassName getClassName() {
+		return this.generatedClass.getName();
+	}
+
+	@Override
+	public GeneratedMethods getMethods() {
+		return this.generatedClass.getMethods();
+	}
+
+	@Override
+	public void addInstancePostProcessor(MethodReference methodReference) {
+		this.instancePostProcessors.add(methodReference);
+	}
+}


### PR DESCRIPTION
This PR introduces AOT code fragment generation for `ManagedTypes`.