### PR TITLE
bug fix when using kotlin value class

### DIFF
--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingEntityInstantiator.java
@@ -298,12 +298,7 @@ class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 
 		int index = 0;
 		for (Parameter<?, P> parameter : constructor.getParameters()) {
-			if (parameter.getType().getType().getName()
-					.equals("kotlin.jvm.internal.DefaultConstructorMarker")) {
-				params[index++] = null;
-			} else {
-				params[index++] = provider.getParameterValue(parameter);
-			}
+			params[index++] = provider.getParameterValue(parameter);
 		}
 
 		return params;

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingEntityInstantiator.java
@@ -298,7 +298,12 @@ class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 
 		int index = 0;
 		for (Parameter<?, P> parameter : constructor.getParameters()) {
-			params[index++] = provider.getParameterValue(parameter);
+			if (parameter.getType().getType().getName()
+					.equals("kotlin.jvm.internal.DefaultConstructorMarker")) {
+				params[index++] = null;
+			} else {
+				params[index++] = provider.getParameterValue(parameter);
+			}
 		}
 
 		return params;

--- a/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
+++ b/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
@@ -55,6 +55,11 @@ public class PersistentEntityParameterValueProvider<P extends PersistentProperty
 			return (T) parent;
 		}
 
+		if (parameter.getType().getType().getName()
+				.equals("kotlin.jvm.internal.DefaultConstructorMarker")) {
+			return null;
+		}
+
 		String name = parameter.getName();
 
 		if (name == null) {


### PR DESCRIPTION
Hi, i am spring data mongo user.
I experienced bug when using spring data mongo with kotlin value class.
[You can see it in this repository.](https://github.com/sangyongchoi/value-class-error-demo)

Classes with "Kotlin value class" as members have private constructors when compiled.
Then, a constructor is created with the DefaultConstructorMarker added.
I think it's the cause of the bug.

Since the DefaultConstructorMarker does nothing, I think return it to null will solve the problem.
Could you consider this?

Thank you 😄 