### PR TITLE
Migrate DependencyTests to ArchUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 
 		<scala>2.11.7</scala>
 		<xmlbeam>1.4.24</xmlbeam>
+		<archunit.version>1.0.0</archunit.version>
 		<java-module-name>spring.data.commons</java-module-name>
 
 	</properties>
@@ -335,17 +336,17 @@
 		</dependency>
 
 		<dependency>
-			<groupId>de.schauderhaft.degraph</groupId>
-			<artifactId>degraph-check</artifactId>
-			<version>0.1.4</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.jmolecules.integrations</groupId>
 			<artifactId>jmolecules-spring</artifactId>
 			<version>${jmolecules-integration}</version>
 			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit</artifactId>
+			<version>${archunit.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-dependencies-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/querydsl/QuerydslRepositoryRuntimeHints.java
+++ b/src/main/java/org/springframework/data/querydsl/QuerydslRepositoryRuntimeHints.java
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.repository.aot.hint;
+package org.springframework.data.querydsl;
 
-import java.util.Arrays;
-import java.util.Properties;
-
+import com.querydsl.core.types.Predicate;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -26,9 +24,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.io.InputStreamSource;
 import org.springframework.data.domain.Example;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.querydsl.QuerydslPredicateExecutor;
-import org.springframework.data.querydsl.QuerydslUtils;
-import org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.repository.core.support.RepositoryFragment;
@@ -42,70 +37,41 @@ import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
-import com.querydsl.core.types.Predicate;
+import java.util.Arrays;
+import java.util.Properties;
 
 /**
- * {@link RuntimeHintsRegistrar} holding required hints to bootstrap data repositories. <br />
+ * {@link RuntimeHintsRegistrar} holding required hints to bootstrap Querydsl repositories. <br />
  * Already registered via {@literal aot.factories}.
  *
  * @author Christoph Strobl
  * @author Mark Paluch
  * @since 3.0
  */
-class RepositoryRuntimeHints implements RuntimeHintsRegistrar {
+class QuerydslRepositoryRuntimeHints implements RuntimeHintsRegistrar {
 
 	private static final boolean PROJECT_REACTOR_PRESENT = ClassUtils.isPresent("reactor.core.publisher.Flux",
-			RepositoryRuntimeHints.class.getClassLoader());
+			QuerydslRepositoryRuntimeHints.class.getClassLoader());
 
 	@Override
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 
-		// repository infrastructure
-		hints.reflection().registerTypes(Arrays.asList( //
-				TypeReference.of(RepositoryFactoryBeanSupport.class), //
-				TypeReference.of(RepositoryFragmentsFactoryBean.class), //
-				TypeReference.of(RepositoryFragment.class), //
-				TypeReference.of(TransactionalRepositoryFactoryBeanSupport.class), //
-				TypeReference.of(Example.class), //
-				TypeReference.of(QueryByExampleExecutor.class), //
-				TypeReference.of(MappingContext.class), //
-				TypeReference.of(RepositoryMetadata.class), //
-				TypeReference.of(FluentQuery.class), //
-				TypeReference.of(FetchableFluentQuery.class) //
-		), builder -> {
-			builder.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
-		});
-
-		if (PROJECT_REACTOR_PRESENT) {
+		if (QuerydslUtils.QUERY_DSL_PRESENT) {
 
 			// repository infrastructure
 			hints.reflection().registerTypes(Arrays.asList( //
-					TypeReference.of(ReactiveFluentQuery.class), //
-					TypeReference.of(ReactiveQueryByExampleExecutor.class)), //
-					builder -> {
+					TypeReference.of(Predicate.class), //
+					TypeReference.of(QuerydslPredicateExecutor.class)), builder -> {
 						builder.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
 					});
+
+			if (PROJECT_REACTOR_PRESENT) {
+				// repository infrastructure
+				hints.reflection().registerTypes(Arrays.asList( //
+						TypeReference.of(ReactiveQuerydslPredicateExecutor.class)), builder -> {
+							builder.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
+						});
+			}
 		}
-
-		// named queries
-		hints.reflection().registerTypes(Arrays.asList( //
-				TypeReference.of(Properties.class), //
-				TypeReference.of(BeanFactory.class), //
-				TypeReference.of(InputStreamSource[].class) //
-		), builder -> builder.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS));
-
-		//
-		hints.reflection().registerType(Throwable.class,
-				builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS));
-
-		// SpEL support
-		hints.reflection().registerType(
-				TypeReference.of("org.springframework.data.projection.SpelEvaluatingMethodInterceptor$TargetWrapper"),
-				builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-						MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_PUBLIC_METHODS));
-
-		// annotated queries
-		hints.proxies().registerJdkProxy( //
-				TypeReference.of("org.springframework.data.annotation.QueryAnnotation"));
 	}
 }

--- a/src/main/java/org/springframework/data/repository/aot/FallbackRepositoryAotConfigurationPostProcessor.java
+++ b/src/main/java/org/springframework/data/repository/aot/FallbackRepositoryAotConfigurationPostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot;
+
+import org.springframework.data.repository.config.RepositoryConfigurationPostProcessor;
+
+/**
+ * default post processing to be applied when no other {@link RepositoryConfigurationPostProcessor} is applied.
+ *
+ * @author Mark Paluch
+ * @author Jens Schauder
+ * @since 3.0
+ */
+class FallbackRepositoryAotConfigurationPostProcessor extends RepositoryRegistrationAotProcessor implements RepositoryConfigurationPostProcessor.FallbackRepositoryConfigurationPostProcessor {
+}

--- a/src/main/java/org/springframework/data/repository/aot/RepositoryRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/repository/aot/RepositoryRegistrationAotProcessor.java
@@ -38,6 +38,7 @@ import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.data.aot.TypeContributor;
 import org.springframework.data.repository.config.RepositoryConfiguration;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryConfigurationPostProcessor;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -56,16 +57,14 @@ import org.springframework.util.StringUtils;
  * provide custom logic for contributing additional (eg. reflection) configuration. By default, reflection configuration
  * will be added for types reachable from the repository declaration and query methods as well as all used
  * {@link Annotation annotations} from the {@literal org.springframework.data} namespace.
- * </p>
- * The processor is typically configured via {@link RepositoryConfigurationExtension#getRepositoryAotProcessor()} and
- * gets added by the {@link org.springframework.data.repository.config.RepositoryConfigurationDelegate}.
+
  *
  * @author Christoph Strobl
  * @author John Blum
  * @since 3.0
  */
 @SuppressWarnings("unused")
-public class RepositoryRegistrationAotProcessor implements BeanRegistrationAotProcessor, BeanFactoryAware {
+public class RepositoryRegistrationAotProcessor implements BeanRegistrationAotProcessor, BeanFactoryAware, RepositoryConfigurationPostProcessor {
 
 	private ConfigurableListableBeanFactory beanFactory;
 
@@ -117,6 +116,7 @@ public class RepositoryRegistrationAotProcessor implements BeanRegistrationAotPr
 		return this.beanFactory;
 	}
 
+	@Override
 	public void setConfigMap(@Nullable Map<String, RepositoryConfiguration<?>> configMap) {
 		this.configMap = configMap;
 	}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtension.java
@@ -18,13 +18,10 @@ package org.springframework.data.repository.config;
 import java.util.Collection;
 import java.util.Locale;
 
-import org.springframework.beans.factory.aot.BeanRegistrationAotProcessor;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.data.repository.aot.RepositoryRegistrationAotProcessor;
-import org.springframework.lang.NonNull;
 
 /**
  * SPI to implement store specific extension to the repository bean definition registration process.
@@ -53,20 +50,6 @@ public interface RepositoryConfigurationExtension {
 	 * @return will never be {@literal null}.
 	 */
 	String getModuleName();
-
-	/**
-	 * Returns the {@link BeanRegistrationAotProcessor} type responsible for contributing AOT/native configuration
-	 * required by the Spring Data Repository infrastructure components at native runtime.
-	 *
-	 * @return the {@link BeanRegistrationAotProcessor} type responsible for contributing AOT/native configuration.
-	 *         Defaults to {@link RepositoryRegistrationAotProcessor}. Must not be {@literal null}.
-	 * @see org.springframework.beans.factory.aot.BeanRegistrationAotProcessor
-	 * @since 3.0
-	 */
-	@NonNull
-	default Class<? extends BeanRegistrationAotProcessor> getRepositoryAotProcessor() {
-		return RepositoryRegistrationAotProcessor.class;
-	}
 
 	/**
 	 * Returns all {@link RepositoryConfiguration}s obtained through the given {@link RepositoryConfigurationSource}.

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationPostProcessor.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationPostProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import java.util.Map;
+
+/**
+ * Interface for components that post-process repository configuration of discovered repository interfaces.
+ *
+ * @author Jens Schauder
+ * @author Mark Paluch
+ * @since 3.0
+ */
+public interface RepositoryConfigurationPostProcessor {
+
+	/**
+	 * Set the repository configuration map that contains repository bean names to {@link RepositoryConfiguration}.
+	 *
+	 * @param configMap
+	 */
+	void setConfigMap(Map<String, RepositoryConfiguration<?>> configMap);
+
+
+	/**
+	 * Method to test whether this configuration post-processor can be applied to the given {@link RepositoryConfigurationExtension}.
+	 *
+	 * @param extension
+	 * @return {@code true} if applicable; {@code false} otherwise to skip processing.
+	 */
+	default boolean supports(RepositoryConfigurationExtension extension) {
+		return true;
+	}
+
+	/**
+	 * Marker interface for default fallback post-processors.
+	 */
+	interface FallbackRepositoryConfigurationPostProcessor extends RepositoryConfigurationPostProcessor {
+	}
+
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.data.web.config.SpringDataJacksonModules=org.springframework.data.web.config.SpringDataJacksonConfiguration
 org.springframework.data.util.CustomCollectionRegistrar=org.springframework.data.util.CustomCollections.VavrCollections, \
  org.springframework.data.util.CustomCollections.EclipseCollections
+org.springframework.data.repository.config.RepositoryConfigurationPostProcessor$FallbackRepositoryConfigurationPostProcessor=org.springframework.data.repository.aot.FallbackRepositoryAotConfigurationPostProcessor

--- a/src/main/resources/META-INF/spring/aot.factories
+++ b/src/main/resources/META-INF/spring/aot.factories
@@ -2,7 +2,8 @@ org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=\
 	org.springframework.data.aot.ManagedTypesBeanFactoryInitializationAotProcessor
 
 org.springframework.aot.hint.RuntimeHintsRegistrar=\
-	org.springframework.data.repository.aot.hint.RepositoryRuntimeHints
+	org.springframework.data.repository.aot.hint.RepositoryRuntimeHints,\
+	org.springframework.data.querydsl.QuerydslRepositoryRuntimeHints
 
 org.springframework.beans.factory.aot.BeanRegistrationAotProcessor=\
     org.springframework.data.aot.AuditingBeanRegistrationAotProcessor


### PR DESCRIPTION
Replaces the Degraph based implementation with one based on ArchUnit and reenables the test. 

The test currently fails since the aot code causes cycles.

