### PR TITLE
fix a typo in javadoc

### DIFF
--- a/src/main/java/org/springframework/data/mapping/model/PersistentEntityIsNewStrategy.java
+++ b/src/main/java/org/springframework/data/mapping/model/PersistentEntityIsNewStrategy.java
@@ -24,7 +24,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- * An {@link IsNewStrategy} to use a {@link PersistentEntity}'s version property followed by it
+ * An {@link IsNewStrategy} to use a {@link PersistentEntity}'s version property followed by identifier
  *
  * @author Oliver Gierke
  * @author Mark Paluch


### PR DESCRIPTION
This is a fix to correct a typo in the javadoc of the PersistentEntityIsNewStrategy class.

PersistentEntityIsNewStrategy uses the identifier of the given entity as a fall back property to decide whether the entity is new or not.