### PR TITLE
Exclude local & anonymous classes from type inspection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.x-2744-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
@@ -82,11 +82,11 @@ public class RepositoryRegistrationAotProcessor implements BeanRegistrationAotPr
 
 		repositoryContext.getResolvedTypes().stream()
 				.filter(it -> !RepositoryRegistrationAotContribution.isJavaOrPrimitiveType(it))
-				.forEach(it -> RepositoryRegistrationAotProcessor.contributeType(it, generationContext));
+				.forEach(it -> contributeType(it, generationContext));
 
 		repositoryContext.getResolvedAnnotations().stream()
 				.filter(RepositoryRegistrationAotProcessor::isSpringDataManagedAnnotation).map(MergedAnnotation::getType)
-				.forEach(it -> RepositoryRegistrationAotProcessor.contributeType(it, generationContext));
+				.forEach(it -> contributeType(it, generationContext));
 	}
 
 	private boolean isRepositoryBean(RegisteredBean bean) {
@@ -167,7 +167,7 @@ public class RepositoryRegistrationAotProcessor implements BeanRegistrationAotPr
 				|| annotation.getMetaTypes().stream().anyMatch(RepositoryRegistrationAotProcessor::isInSpringDataNamespace));
 	}
 
-	private static void contributeType(Class<?> type, GenerationContext generationContext) {
+	protected void contributeType(Class<?> type, GenerationContext generationContext) {
 		TypeContributor.contribute(type, it -> true, generationContext);
 	}
 

--- a/src/main/java/org/springframework/data/util/TypeCollector.java
+++ b/src/main/java/org/springframework/data/util/TypeCollector.java
@@ -48,16 +48,18 @@ public class TypeCollector {
 
 	private static final Log logger = LogFactory.getLog(TypeCollector.class);
 
-	static final Set<String> EXCLUDED_DOMAINS = new HashSet<>(Arrays.asList("java", "sun.", "jdk.", "reactor.",
-			"kotlinx.", "kotlin.", "org.springframework.core.", "org.springframework.data.mapping.",
-			"org.springframework.data.repository.", "org.springframework.boot.", "org.springframework.core."));
+	static final Set<String> EXCLUDED_DOMAINS = new HashSet<>(
+			Arrays.asList("java", "sun.", "jdk.", "reactor.", "kotlinx.", "kotlin.", "org.springframework.core.",
+					"org.springframework.data.mapping.", "org.springframework.data.repository.", "org.springframework.boot.",
+					"org.springframework.context.", "org.springframework.beans."));
 
 	private final Predicate<Class<?>> excludedDomainsFilter = type -> {
-		String packageName = type.getPackageName();
+		String packageName = type.getPackageName() + ".";
 		return EXCLUDED_DOMAINS.stream().noneMatch(packageName::startsWith);
 	};
 
-	private Predicate<Class<?>> typeFilter = excludedDomainsFilter;
+	private Predicate<Class<?>> typeFilter = excludedDomainsFilter
+			.and(it -> !it.isLocalClass() && !it.isAnonymousClass());
 
 	private final Predicate<Method> methodFilter = createMethodFilter();
 

--- a/src/main/java/org/springframework/data/util/TypeCollector.java
+++ b/src/main/java/org/springframework/data/util/TypeCollector.java
@@ -127,6 +127,10 @@ public class TypeCollector {
 		}
 		Set<Type> discoveredTypes = new LinkedHashSet<>();
 		for (Constructor<?> constructor : type.toClass().getDeclaredConstructors()) {
+
+			if (constructor.isSynthetic()) {
+				continue;
+			}
 			for (Class<?> signatureType : TypeUtils.resolveTypesInSignature(type.toClass(), constructor)) {
 				if (typeFilter.test(signatureType)) {
 					discoveredTypes.add(signatureType);

--- a/src/test/java/org/springframework/data/aot/TypeCollectorUnitTests.java
+++ b/src/test/java/org/springframework/data/aot/TypeCollectorUnitTests.java
@@ -61,4 +61,9 @@ public class TypeCollectorUnitTests {
 				WithDeclaredClass.SomeEnum.class);
 	}
 
+	@Test // GH-2744
+	void skipsCoreFrameworkType() {
+		assertThat(TypeCollector.inspect(org.springframework.core.AliasRegistry.class).list()).isEmpty();
+	}
+
 }


### PR DESCRIPTION
_Local_ and _anonymous_ classes should not be picked up during reachable type collection, as those are not targets of the spring data reflection infrastructure. 
We also updated the type filter so that it now matches types present in the very same package and modified method visibility for module specific contribution checks.
Last we excluded _synthetic_ constructors from being inspected as those (in some cases) can contain references to anonymous classes as shown in the snippet below.

```java
public enum Outer {

    INSTANCE {
        @Override
        public Inner getInnerType() {
            return Inner.VALUE;
        }
    },

    public abstract Inner getInnerType();
}
```

```
synthetic Outer(java.lang.String arg0, int arg1, Outer$1 arg2)
         <localVar:index=0 , name=this , desc=LOuter;, sig=null, start=L0, end=L1>
         <localVar:index=1 , name=x0 , desc=Ljava/lang/String;, sig=null, start=L0, end=L1>
         <localVar:index=2 , name=x1 , desc=I, sig=null, start=L0, end=L1>
         <localVar:index=3 , name=x2 , desc=LOuter$1;, sig=null, start=L0, end=L1>
```