### PR TITLE
Query method parameters are now aware of aggregate reference type.

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/DefaultParameters.java
+++ b/src/main/java/org/springframework/data/repository/query/DefaultParameters.java
@@ -18,7 +18,7 @@ package org.springframework.data.repository.query;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import org.springframework.core.MethodParameter;
+import org.springframework.data.util.TypeInformation;
 
 /**
  * Default implementation of {@link Parameters}.
@@ -31,18 +31,26 @@ public final class DefaultParameters extends Parameters<DefaultParameters, Param
 	 * Creates a new {@link DefaultParameters} instance from the given {@link Method}.
 	 *
 	 * @param method must not be {@literal null}.
+	 * @deprecated since 3.1, use {@link #DefaultParameters(Method, TypeInformation)} instead.
 	 */
+	@Deprecated(since = "3.1", forRemoval = true)
 	public DefaultParameters(Method method) {
 		super(method);
 	}
 
-	private DefaultParameters(List<Parameter> parameters) {
-		super(parameters);
+	/**
+	 * Creates a new {@link DefaultParameters} instance from the given {@link Method} and aggregate
+	 * {@link TypeInformation}.
+	 *
+	 * @param method must not be {@literal null}.
+	 * @param aggregateType must not be {@literal null}.
+	 */
+	public DefaultParameters(Method method, TypeInformation<?> aggregateType) {
+		super(method, param -> new Parameter(param, aggregateType));
 	}
 
-	@Override
-	protected Parameter createParameter(MethodParameter parameter) {
-		return new Parameter(parameter);
+	private DefaultParameters(List<Parameter> parameters) {
+		super(parameters);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/repository/query/QueryMethod.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethod.java
@@ -79,8 +79,8 @@ public class QueryMethod {
 
 		this.method = method;
 		this.unwrappedReturnType = potentiallyUnwrapReturnTypeFor(metadata, method);
-		this.parameters = createParameters(method);
 		this.metadata = metadata;
+		this.parameters = createParameters(method);
 
 		if (hasParameterOfType(method, Pageable.class)) {
 
@@ -107,7 +107,7 @@ public class QueryMethod {
 			Class<?> repositoryDomainClass = metadata.getDomainType();
 			Class<?> methodDomainClass = metadata.getReturnedDomainClass(method);
 
-			return (repositoryDomainClass == null) || repositoryDomainClass.isAssignableFrom(methodDomainClass)
+			return repositoryDomainClass == null || repositoryDomainClass.isAssignableFrom(methodDomainClass)
 					? methodDomainClass
 					: repositoryDomainClass;
 		});
@@ -119,11 +119,24 @@ public class QueryMethod {
 	/**
 	 * Creates a {@link Parameters} instance.
 	 *
-	 * @param method
+	 * @param method must not be {@literal null}.
+	 * @return must not return {@literal null}.
+	 * @deprecated since 3.1, call or override {@link #createParameters(Method, TypeInformation)} instead.
+	 */
+	@Deprecated(since = "3.1", forRemoval = true)
+	protected Parameters<?, ?> createParameters(Method method) {
+		return createParameters(method, metadata.getDomainTypeInformation());
+	}
+
+	/**
+	 * Creates a {@link Parameters} instance.
+	 *
+	 * @param method must not be {@literal null}.
+	 * @param aggregateType must not be {@literal null}.
 	 * @return must not return {@literal null}.
 	 */
-	protected Parameters<?, ?> createParameters(Method method) {
-		return new DefaultParameters(method);
+	protected Parameters<?, ?> createParameters(Method method, TypeInformation<?> aggregateType) {
+		return new DefaultParameters(method, aggregateType);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/query/ParameterUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ParameterUnitTests.java
@@ -23,15 +23,19 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.core.MethodParameter;
+import org.springframework.data.repository.query.ParametersUnitTests.User;
+import org.springframework.data.util.TypeInformation;
 
 /**
  * Unit tests for {@link Parameter}.
  *
  * @author Jens Schauder
  */
-class KParameterUnitTests {
+class ParameterUnitTests {
 
 	@Test // DATAJPA-1185
 	void classParameterWithSameTypeParameterAsReturnedListIsDynamicProjectionParameter() throws Exception {
@@ -57,6 +61,28 @@ class KParameterUnitTests {
 		assertThat(parameter.isDynamicProjectionParameter()).isTrue();
 	}
 
+	@TestFactory // #2770
+	Stream<DynamicTest> doesNotConsiderClassParametersDynamicProjectionOnes() {
+
+		var methods = Stream.of( //
+				"genericReturnNonDynamicBind", //
+				"staticReturnNonDynamicBindWildcard", //
+				"staticReturnNonDynamicBindWildcardExtends");
+
+		return DynamicTest.stream(methods, it -> it, it -> {
+			assertThat(new Parameter(getMethodParameter(it), TypeInformation.of(User.class))
+					.isDynamicProjectionParameter()).isFalse();
+		});
+	}
+
+	@Test // #2770
+	void doesNotConsiderAtParamAnnotatedClassParameterDynamicProjectionOne() throws Exception {
+
+		var parameter = new Parameter(getMethodParameter("atParamOnClass"));
+
+		assertThat(parameter.isDynamicProjectionParameter()).isFalse();
+	}
+
 	@NotNull
 	private MethodParameter getMethodParameter(String methodName) throws NoSuchMethodException {
 		return new MethodParameter(this.getClass().getDeclaredMethod(methodName, Class.class), 0);
@@ -72,5 +98,21 @@ class KParameterUnitTests {
 
 	<T> Optional<T> dynamicProjectionWithOptional(Class<T> type) {
 		return Optional.empty();
+	}
+
+	<T> T genericReturnNonDynamicBind(Class<? extends User> one) {
+		return null;
+	}
+
+	User staticReturnNonDynamicBindWildcard(Class<?> two) {
+		return null;
+	}
+
+	User staticReturnNonDynamicBindWildcardExtends(Class<? extends User> one) {
+		return null;
+	}
+
+	<T> T atParamOnClass(@Param("type") Class<T> type) {
+		return null;
 	}
 }


### PR DESCRIPTION
To support the binding of Class parameters to queries for declared query methods, we have to be able to differentiate them from Class parameters that are supposed to represent projections. We can do that by relating the declared Class' element type to the aggregate root type, as a Class typed to that or any subtype of it will never trigger a projection by definition.

So far, the Parameter(s) abstraction was solely created from a query method's Method. We now changed that for QueryMethod to forward the aggregate type detected on the RepositoryMetadata and consider it during the detection of dynamic projection parameters.

As a mitigating measure, we now also support @Param on Class-typed parameters to explicitly mark them for query binding. This is primarily to be able to add this support to the 2.7

The changes are built in a way that modules extending that mechanism will continue to work as is but see deprecation warnings on methods and constructors involved. Adapting extending code to the new APIs will automatically enable the support for bindable Class parameters on query methods.

Fixes #2770.
