### PR TITLE
Detect nullable marker parameters in constructor arguments. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.x-GH-1947-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingEntityInstantiator.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingEntityInstantiator.java
@@ -298,7 +298,7 @@ class ClassGeneratingEntityInstantiator implements EntityInstantiator {
 
 		int index = 0;
 		for (Parameter<?, P> parameter : constructor.getParameters()) {
-			params[index++] = provider.getParameterValue(parameter);
+			params[index++] = !parameter.isNullableMarker() ? provider.getParameterValue(parameter) : null;
 		}
 
 		return params;

--- a/src/test/kotlin/org/springframework/data/mapping/model/WithInlineClass.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/WithInlineClass.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model
+
+inline class TheActualInlineClass(val id: String)
+data class TheTypeConsumingAnInlineClass(val inlineTypeParam: TheActualInlineClass, val someStringParam: String, val id: String)
+


### PR DESCRIPTION
This **draft** seeks to introduce a `nullableMarker` flag to the `Parameter` abstraction. If set, it is safe skip and `null` the parameter value right away.

The `PreferredConstructorDiscoverer` for Kotlin will use this flag when detecting a `DefaultConstructorMarker` argument within the java constructor which is there (as the name indicates) to solely mark the constructor to use but does not map to any parameter from the source Kotlin type, resulting in an unresolvable parameter name/target property for the parameter.
This change will allow the `ClassGeneratingEntityInstantiator` to operate types using Kotlin inline classes.

I think it would also make sense to discuss if the usage of the newly introduced method makes sense in the `ParameterValueProvider` implementations like `PersistentEntityParameterValueProvider` to shortcut the value lookup by simply returning `null`


Closes: #1947 