### PR TITLE
Make getMethod() protected in QueryMethod.java

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/QueryMethod.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethod.java
@@ -281,7 +281,7 @@ public class QueryMethod {
 		return metadata;
 	}
 
-	Method getMethod() {
+	protected Method getMethod() {
 		return method;
 	}
 


### PR DESCRIPTION
I am doing some **spring-data-jdbc** project contributions, and there is a class called _JdbcQueryMethod_ that extends _QueryMethod_ from **spring-data-commons** module. The problem is that we have to store the reference to the same method in the child and in the parent classes, which seems to be cumbersome and redundant, because _getMethod()_ is **package-private** see below:
 
https://github.com/spring-projects/spring-data-relational/blob/main/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethod.java#L68

So, I propose here to make it **protected** to extend access a bit to its subclasses so they can use it.  