### PR TITLE
Make the all args Order constructor public

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-order-constructor-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/domain/Sort.java
+++ b/src/main/java/org/springframework/data/domain/Sort.java
@@ -356,6 +356,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 	 *
 	 * @author Oliver Gierke
 	 * @author Kevin Raymond
+	 * @author Jens Schauder
 	 */
 	public static class Order implements Serializable {
 
@@ -434,7 +435,7 @@ public class Sort implements Streamable<org.springframework.data.domain.Sort.Ord
 		 * @param nullHandling must not be {@literal null}.
 		 * @since 1.7
 		 */
-		private Order(@Nullable Direction direction, String property, boolean ignoreCase, NullHandling nullHandling) {
+		public Order(@Nullable Direction direction, String property, boolean ignoreCase, NullHandling nullHandling) {
 
 			if (!StringUtils.hasText(property)) {
 				throw new IllegalArgumentException("Property must not be null or empty");


### PR DESCRIPTION
`JpaSort` has a workaround for this missing constructor. 
All other constructors are already public, I'm therefore failing to see the point in making this one private.

