### PR TITLE
Parameter direction should not be ignored if keys is empty

### DIFF
--- a/src/main/java/org/springframework/data/domain/KeysetScrollPosition.java
+++ b/src/main/java/org/springframework/data/domain/KeysetScrollPosition.java
@@ -30,6 +30,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Mark Paluch
  * @author Oliver Drotbohm
+ * @author Yanming Zhou
  * @since 3.1
  */
 public final class KeysetScrollPosition implements ScrollPosition {
@@ -70,7 +71,7 @@ public final class KeysetScrollPosition implements ScrollPosition {
 		Assert.notNull(keys, "Keys must not be null");
 		Assert.notNull(direction, "Direction must not be null");
 
-		return keys.isEmpty()
+		return keys.isEmpty() && direction == Direction.FORWARD
 				? initial()
 				: new KeysetScrollPosition(Collections.unmodifiableMap(new LinkedHashMap<>(keys)), direction);
 	}

--- a/src/test/java/org/springframework/data/domain/ScrollPositionUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/ScrollPositionUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.ScrollPosition.Direction;
  *
  * @author Mark Paluch
  * @author Oliver Drotbohm
+ * @author Yanming Zhou
  */
 class ScrollPositionUnitTests {
 
@@ -136,5 +137,15 @@ class ScrollPositionUnitTests {
 
 		assertThat(keyset.isInitial()).isTrue();
 		assertThat(keyset.scrollsForward()).isTrue();
+	}
+
+	@Test // GH-2840
+	void keysetPositionWithEmptyKeys() {
+
+		KeysetScrollPosition forwardEmptyKeyset = ScrollPosition.of(Collections.emptyMap(), Direction.FORWARD);
+		KeysetScrollPosition backwordEmptyKeyset = ScrollPosition.of(Collections.emptyMap(), Direction.BACKWARD);
+
+		assertThat(forwardEmptyKeyset.isInitial()).isTrue();
+		assertThat(backwordEmptyKeyset.scrollsBackward()).isTrue();
 	}
 }


### PR DESCRIPTION
After this commit, KeysetScrollPosition.of(Collections.emptyMap(), Direction.BACKWARD) will retain correct direction

Closes GH-2840