### PR TITLE
Introduce support to pass-thru TemporalAccessor auditing values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-2719-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/auditing/AnnotationAuditingMetadata.java
+++ b/src/main/java/org/springframework/data/auditing/AnnotationAuditingMetadata.java
@@ -16,6 +16,7 @@
 package org.springframework.data.auditing;
 
 import java.lang.reflect.Field;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -58,7 +59,12 @@ final class AnnotationAuditingMetadata {
 
 	static {
 
-		List<String> types = new ArrayList<>(3);
+		List<String> types = new ArrayList<>(Jsr310Converters.getSupportedClasses() //
+				.stream() //
+				.filter(TemporalAccessor.class::isAssignableFrom) //
+				.map(Class::getName) //
+				.toList());
+
 		types.add(Date.class.getName());
 		types.add(Long.class.getName());
 		types.add(long.class.getName());
@@ -104,7 +110,7 @@ final class AnnotationAuditingMetadata {
 
 			Class<?> type = it.getType();
 
-			if (Jsr310Converters.supports(type)) {
+			if (TemporalAccessor.class.isAssignableFrom(type)) {
 				return;
 			}
 

--- a/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
+++ b/src/main/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactory.java
@@ -114,7 +114,8 @@ public class MappingAuditableBeanWrapperFactory extends DefaultAuditableBeanWrap
 		/**
 		 * Creates a new {@link MappingAuditingMetadata} instance from the given {@link PersistentEntity}.
 		 *
-		 * @param entity must not be {@literal null}.
+		 * @param context must not be {@literal null}.
+		 * @param type must not be {@literal null}.
 		 */
 		public <P> MappingAuditingMetadata(MappingContext<?, ? extends PersistentProperty<?>> context, Class<?> type) {
 

--- a/src/main/java/org/springframework/data/convert/Jsr310Converters.java
+++ b/src/main/java/org/springframework/data/convert/Jsr310Converters.java
@@ -38,7 +38,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.lang.NonNull;
 
 /**
- * Helper class to register JSR-310 specific {@link Converter} implementations in case the we're running on Java 8.
+ * Helper class to register JSR-310 specific {@link Converter} implementations.
  *
  * @author Oliver Gierke
  * @author Barak Schoster
@@ -52,9 +52,9 @@ public abstract class Jsr310Converters {
 			Instant.class, ZoneId.class, Duration.class, Period.class);
 
 	/**
-	 * Returns the converters to be registered. Will only return converters in case we're running on Java 8.
+	 * Returns the converters to be registered.
 	 *
-	 * @return
+	 * @return the converters to be registered.
 	 */
 	public static Collection<Converter<?, ?>> getConvertersToRegister() {
 

--- a/src/main/java/org/springframework/data/convert/Jsr310Converters.java
+++ b/src/main/java/org/springframework/data/convert/Jsr310Converters.java
@@ -30,6 +30,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -82,8 +83,15 @@ public abstract class Jsr310Converters {
 	}
 
 	public static boolean supports(Class<?> type) {
-
 		return CLASSES.contains(type);
+	}
+
+	/**
+	 * @return the collection of supported temporal classes.
+	 * @since 3.2
+	 */
+	public static Collection<Class<?>> getSupportedClasses() {
+		return Collections.unmodifiableList(CLASSES);
 	}
 
 	@ReadingConverter


### PR DESCRIPTION
We now allow passing-thru `TemporalAccessor` auditing values, bypassing conversion if the target value type matches the value provided from e.g. `DateTimeProvider`.

Refined the error messages and listing all commonly supported types for which we provide converters.

Closes #2719