### PR TITLE
Fix misordered modifiers 'final static'.

### DIFF
--- a/src/main/java/org/springframework/data/domain/Range.java
+++ b/src/main/java/org/springframework/data/domain/Range.java
@@ -31,7 +31,7 @@ import org.springframework.util.ObjectUtils;
  */
 public final class Range<T> {
 
-	private final static Range<?> UNBOUNDED = Range.of(Bound.unbounded(), Bound.unbounded());
+	private static final Range<?> UNBOUNDED = Range.of(Bound.unbounded(), Bound.unbounded());
 
 	/**
 	 * The lower bound of the range.

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -215,7 +215,7 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 
 	/**
 	 * Generates {@link PersistentPropertyAccessor} classes to access properties of a {@link PersistentEntity}. This code
-	 * uses {@code private final static} held method handles which perform about the speed of native method invocations
+	 * uses {@code private static final} held method handles which perform about the speed of native method invocations
 	 * for property access which is restricted due to Java rules (such as private fields/methods) or private inner
 	 * classes. All other scoped members (package default, protected and public) are accessed via field or property access
 	 * to bypass reflection overhead. That's only possible if the type and the member access is possible from another

--- a/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
+++ b/src/main/java/org/springframework/data/projection/ProxyProjectionFactory.java
@@ -51,7 +51,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  */
 class ProxyProjectionFactory implements ProjectionFactory, BeanClassLoaderAware {
 
-	final static GenericConversionService CONVERSION_SERVICE = new DefaultConversionService();
+	static final GenericConversionService CONVERSION_SERVICE = new DefaultConversionService();
 
 	static {
 		Jsr310Converters.getConvertersToRegister().forEach(CONVERSION_SERVICE::addConverter);

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -84,7 +84,7 @@ import org.springframework.util.ObjectUtils;
  */
 public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, BeanFactoryAware {
 
-	final static GenericConversionService CONVERSION_SERVICE = new DefaultConversionService();
+	static final GenericConversionService CONVERSION_SERVICE = new DefaultConversionService();
 	private static final Log logger = LogFactory.getLog(RepositoryFactorySupport.class);
 
 	static {

--- a/src/main/java/org/springframework/data/repository/query/SpelEvaluator.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelEvaluator.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  */
 public class SpelEvaluator {
 
-	private final static SpelExpressionParser PARSER = new SpelExpressionParser();
+	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
 	private final QueryMethodEvaluationContextProvider evaluationContextProvider;
 	private final Parameters<?, ?> parameters;

--- a/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
@@ -59,8 +59,8 @@ import java.util.stream.Stream;
  */
 public class SpelQueryContext {
 
-	private final static String SPEL_PATTERN_STRING = "([:?])#\\{([^}]+)}";
-	private final static Pattern SPEL_PATTERN = Pattern.compile(SPEL_PATTERN_STRING);
+	private static final String SPEL_PATTERN_STRING = "([:?])#\\{([^}]+)}";
+	private static final Pattern SPEL_PATTERN = Pattern.compile(SPEL_PATTERN_STRING);
 
 	/**
 	 * A function from the index of a SpEL expression in a query and the actual SpEL expression to the parameter name to

--- a/src/main/java/org/springframework/data/transaction/ChainedTransactionManager.java
+++ b/src/main/java/org/springframework/data/transaction/ChainedTransactionManager.java
@@ -70,7 +70,7 @@ import org.springframework.util.Assert;
 @Deprecated
 public class ChainedTransactionManager implements PlatformTransactionManager {
 
-	private final static Log logger = LogFactory.getLog(ChainedTransactionManager.class);
+	private static final Log logger = LogFactory.getLog(ChainedTransactionManager.class);
 
 	private final List<PlatformTransactionManager> transactionManagers;
 	private final SynchronizationManager synchronizationManager;

--- a/src/main/java/org/springframework/data/util/QTypeContributor.java
+++ b/src/main/java/org/springframework/data/util/QTypeContributor.java
@@ -29,7 +29,7 @@ import org.springframework.util.ClassUtils;
  */
 public class QTypeContributor {
 
-	private final static Log logger = LogFactory.getLog(QTypeContributor.class);
+	private static final Log logger = LogFactory.getLog(QTypeContributor.class);
 
 	public static void contributeEntityPath(Class<?> type, GenerationContext context, @Nullable ClassLoader classLoader) {
 

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryDatatypeTests.java
@@ -509,7 +509,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 
 	// DATACMNS-916
 	@AccessType(Type.FIELD)
-	private final static class PrivateFinalFieldAccess {
+	private static final class PrivateFinalFieldAccess {
 
 		int primitiveInteger;
 		int[] primitiveIntegerArray;
@@ -558,7 +558,7 @@ public class ClassGeneratingPropertyAccessorFactoryDatatypeTests {
 
 	// DATACMNS-916
 	@AccessType(Type.PROPERTY)
-	private final static class PrivateFinalPropertyAccess {
+	private static final class PrivateFinalPropertyAccess {
 
 		int primitiveInteger;
 		int[] primitiveIntegerArray;

--- a/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactoryTests.java
@@ -41,8 +41,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @SuppressWarnings("WeakerAccess") // public required for class generation due to visibility rules
 public class ClassGeneratingPropertyAccessorFactoryTests {
 
-	private final static ClassGeneratingPropertyAccessorFactory factory = new ClassGeneratingPropertyAccessorFactory();
-	private final static SampleMappingContext mappingContext = new SampleMappingContext();
+	private static final ClassGeneratingPropertyAccessorFactory factory = new ClassGeneratingPropertyAccessorFactory();
+	private static final SampleMappingContext mappingContext = new SampleMappingContext();
 
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/springframework/data/mapping/model/PersistentPropertyAccessorTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/PersistentPropertyAccessorTests.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  */
 public class PersistentPropertyAccessorTests {
 
-	private final static SampleMappingContext MAPPING_CONTEXT = new SampleMappingContext();
+	private static final SampleMappingContext MAPPING_CONTEXT = new SampleMappingContext();
 
 	@SuppressWarnings("unchecked")
 	public static List<Object[]> parameters() {


### PR DESCRIPTION
Per the Java Language Specification (Java 17; https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.3.1), 'static' should appear before 'final'.

This is also consistent with source code analysis tools, like Checkstyle, rules: https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.html.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
