### PR TITLE
Refine parameter and field names to align with `PageRequest` property names

### DIFF
--- a/src/main/java/org/springframework/data/domain/AbstractPageRequest.java
+++ b/src/main/java/org/springframework/data/domain/AbstractPageRequest.java
@@ -24,49 +24,50 @@ import java.io.Serializable;
  * @author Oliver Gierke
  * @author Alex Bondarev
  * @author Johannes Englmeier
+ * @author Thach Le
  */
 public abstract class AbstractPageRequest implements Pageable, Serializable {
 
 	private static final long serialVersionUID = 1232825578694716871L;
 
-	private final int page;
-	private final int size;
+	private final int pageNumber;
+	private final int pageSize;
 
 	/**
-	 * Creates a new {@link AbstractPageRequest}. Pages are zero indexed, thus providing 0 for {@code page} will return
-	 * the first page.
+	 * Creates a new {@link AbstractPageRequest}. Pages are zero indexed, thus providing 0 for {@code pageNumber} will return
+	 * the first pageNumber.
 	 *
-	 * @param page must not be less than zero.
-	 * @param size must not be less than one.
+	 * @param pageNumber must not be less than zero.
+	 * @param pageSize must not be less than one.
 	 */
-	public AbstractPageRequest(int page, int size) {
+	protected AbstractPageRequest(int pageNumber, int pageSize) {
 
-		if (page < 0) {
+		if (pageNumber < 0) {
 			throw new IllegalArgumentException("Page index must not be less than zero");
 		}
 
-		if (size < 1) {
+		if (pageSize < 1) {
 			throw new IllegalArgumentException("Page size must not be less than one");
 		}
 
-		this.page = page;
-		this.size = size;
+		this.pageNumber = pageNumber;
+		this.pageSize = pageSize;
 	}
 
 	public int getPageSize() {
-		return size;
+		return pageSize;
 	}
 
 	public int getPageNumber() {
-		return page;
+		return pageNumber;
 	}
 
 	public long getOffset() {
-		return (long) page * (long) size;
+		return (long) pageNumber * (long) pageSize;
 	}
 
 	public boolean hasPrevious() {
-		return page > 0;
+		return pageNumber > 0;
 	}
 
 	public Pageable previousOrFirst() {
@@ -90,8 +91,8 @@ public abstract class AbstractPageRequest implements Pageable, Serializable {
 		final int prime = 31;
 		int result = 1;
 
-		result = prime * result + page;
-		result = prime * result + size;
+		result = prime * result + pageNumber;
+		result = prime * result + pageSize;
 
 		return result;
 	}
@@ -108,6 +109,6 @@ public abstract class AbstractPageRequest implements Pageable, Serializable {
 		}
 
 		AbstractPageRequest other = (AbstractPageRequest) obj;
-		return this.page == other.page && this.size == other.size;
+		return pageNumber == other.pageNumber && pageSize == other.pageSize;
 	}
 }

--- a/src/main/java/org/springframework/data/domain/PageRequest.java
+++ b/src/main/java/org/springframework/data/domain/PageRequest.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Anastasiia Smirnova
  * @author Mark Paluch
+ * @author Thach Le
  */
 public class PageRequest extends AbstractPageRequest {
 
@@ -36,13 +37,13 @@ public class PageRequest extends AbstractPageRequest {
 	/**
 	 * Creates a new {@link PageRequest} with sort parameters applied.
 	 *
-	 * @param page zero-based page index, must not be negative.
-	 * @param size the size of the page to be returned, must be greater than 0.
+	 * @param pageNumber zero-based pageNumber index, must not be negative.
+	 * @param pageSize the pageSize of the pageNumber to be returned, must be greater than 0.
 	 * @param sort must not be {@literal null}, use {@link Sort#unsorted()} instead.
 	 */
-	protected PageRequest(int page, int size, Sort sort) {
+	protected PageRequest(int pageNumber, int pageSize, Sort sort) {
 
-		super(page, size);
+		super(pageNumber, pageSize);
 
 		Assert.notNull(sort, "Sort must not be null");
 
@@ -52,37 +53,37 @@ public class PageRequest extends AbstractPageRequest {
 	/**
 	 * Creates a new unsorted {@link PageRequest}.
 	 *
-	 * @param page zero-based page index, must not be negative.
-	 * @param size the size of the page to be returned, must be greater than 0.
+	 * @param pageNumber zero-based pageNumber index, must not be negative.
+	 * @param pageSize the pageSize of the pageNumber to be returned, must be greater than 0.
 	 * @since 2.0
 	 */
-	public static PageRequest of(int page, int size) {
-		return of(page, size, Sort.unsorted());
+	public static PageRequest of(int pageNumber, int pageSize) {
+		return of(pageNumber, pageSize, Sort.unsorted());
 	}
 
 	/**
 	 * Creates a new {@link PageRequest} with sort parameters applied.
 	 *
-	 * @param page zero-based page index.
-	 * @param size the size of the page to be returned.
+	 * @param pageNumber zero-based pageNumber index.
+	 * @param pageSize the pageSize of the pageNumber to be returned.
 	 * @param sort must not be {@literal null}, use {@link Sort#unsorted()} instead.
 	 * @since 2.0
 	 */
-	public static PageRequest of(int page, int size, Sort sort) {
-		return new PageRequest(page, size, sort);
+	public static PageRequest of(int pageNumber, int pageSize, Sort sort) {
+		return new PageRequest(pageNumber, pageSize, sort);
 	}
 
 	/**
 	 * Creates a new {@link PageRequest} with sort direction and properties applied.
 	 *
-	 * @param page zero-based page index, must not be negative.
-	 * @param size the size of the page to be returned, must be greater than 0.
+	 * @param pageNumber zero-based pageNumber index, must not be negative.
+	 * @param pageSize the pageSize of the pageNumber to be returned, must be greater than 0.
 	 * @param direction must not be {@literal null}.
 	 * @param properties must not be {@literal null}.
 	 * @since 2.0
 	 */
-	public static PageRequest of(int page, int size, Direction direction, String... properties) {
-		return of(page, size, Sort.by(direction, properties));
+	public static PageRequest of(int pageNumber, int pageSize, Direction direction, String... properties) {
+		return of(pageNumber, pageSize, Sort.by(direction, properties));
 	}
 
 	/**
@@ -126,7 +127,7 @@ public class PageRequest extends AbstractPageRequest {
 			return false;
 		}
 
-		return super.equals(that) && this.sort.equals(that.sort);
+		return super.equals(that) && sort.equals(that.sort);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/querydsl/QPageRequest.java
+++ b/src/main/java/org/springframework/data/querydsl/QPageRequest.java
@@ -29,6 +29,7 @@ import com.querydsl.core.types.OrderSpecifier;
  * @author Thomas Darimont
  * @author Oliver Drotbohm
  * @author Mark Paluch
+ * @author Thach Le
  */
 public class QPageRequest extends AbstractPageRequest {
 
@@ -37,43 +38,43 @@ public class QPageRequest extends AbstractPageRequest {
 	private final QSort sort;
 
 	/**
-	 * Creates a new {@link QPageRequest}. Pages are zero indexed, thus providing 0 for {@code page} will return the first
-	 * page.
+	 * Creates a new {@link QPageRequest}. Pages are zero indexed, thus providing 0 for {@code pageNumber} will return the first
+	 * pageNumber.
 	 *
-	 * @param page must not be negative.
-	 * @param size must be greater or equal to 0.
+	 * @param pageNumber must not be negative.
+	 * @param pageSize must be greater or equal to 0.
 	 * @deprecated since 2.1, use {@link #of(int, int)} instead.
 	 */
 	@Deprecated
-	public QPageRequest(int page, int size) {
-		this(page, size, QSort.unsorted());
+	public QPageRequest(int pageNumber, int pageSize) {
+		this(pageNumber, pageSize, QSort.unsorted());
 	}
 
 	/**
 	 * Creates a new {@link QPageRequest} with the given {@link OrderSpecifier}s applied.
 	 *
-	 * @param page must not be negative.
-	 * @param size must be greater or equal to 0.
+	 * @param pageNumber must not be negative.
+	 * @param pageSize must be greater or equal to 0.
 	 * @param orderSpecifiers must not be {@literal null} or empty;
 	 * @deprecated since 2.1, use {@link #of(int, int, OrderSpecifier...)} instead.
 	 */
 	@Deprecated
-	public QPageRequest(int page, int size, OrderSpecifier<?>... orderSpecifiers) {
-		this(page, size, new QSort(orderSpecifiers));
+	public QPageRequest(int pageNumber, int pageSize, OrderSpecifier<?>... orderSpecifiers) {
+		this(pageNumber, pageSize, new QSort(orderSpecifiers));
 	}
 
 	/**
 	 * Creates a new {@link QPageRequest} with sort parameters applied.
 	 *
-	 * @param page must not be negative.
-	 * @param size must be greater or equal to 0.
+	 * @param pageNumber must not be negative.
+	 * @param pageSize must be greater or equal to 0.
 	 * @param sort must not be {@literal null}.
 	 * @deprecated since 2.1, use {@link #of(int, int, QSort)} instead.
 	 */
 	@Deprecated
-	public QPageRequest(int page, int size, QSort sort) {
+	public QPageRequest(int pageNumber, int pageSize, QSort sort) {
 
-		super(page, size);
+		super(pageNumber, pageSize);
 
 		Assert.notNull(sort, "QSort must not be null");
 
@@ -81,39 +82,39 @@ public class QPageRequest extends AbstractPageRequest {
 	}
 
 	/**
-	 * Creates a new {@link QPageRequest}. Pages are zero indexed, thus providing 0 for {@code page} will return the first
-	 * page.
+	 * Creates a new {@link QPageRequest}. Pages are zero indexed, thus providing 0 for {@code pageNumber} will return the first
+	 * pageNumber.
 	 *
-	 * @param page must not be negative.
-	 * @param size must be greater or equal to 0.
+	 * @param pageNumber must not be negative.
+	 * @param pageSize must be greater or equal to 0.
 	 * @since 2.1
 	 */
-	public static QPageRequest of(int page, int size) {
-		return new QPageRequest(page, size, QSort.unsorted());
+	public static QPageRequest of(int pageNumber, int pageSize) {
+		return new QPageRequest(pageNumber, pageSize, QSort.unsorted());
 	}
 
 	/**
 	 * Creates a new {@link QPageRequest} with the given {@link OrderSpecifier}s applied.
 	 *
-	 * @param page must not be negative.
-	 * @param size must be greater or equal to 0.
+	 * @param pageNumber must not be negative.
+	 * @param pageSize must be greater or equal to 0.
 	 * @param orderSpecifiers must not be {@literal null} or empty;
 	 * @since 2.1
 	 */
-	public static QPageRequest of(int page, int size, OrderSpecifier<?>... orderSpecifiers) {
-		return new QPageRequest(page, size, new QSort(orderSpecifiers));
+	public static QPageRequest of(int pageNumber, int pageSize, OrderSpecifier<?>... orderSpecifiers) {
+		return new QPageRequest(pageNumber, pageSize, new QSort(orderSpecifiers));
 	}
 
 	/**
 	 * Creates a new {@link QPageRequest} with sort parameters applied.
 	 *
-	 * @param page must not be negative.
-	 * @param size must be greater or equal to 0.
+	 * @param pageNumber must not be negative.
+	 * @param pageSize must be greater or equal to 0.
 	 * @param sort must not be {@literal null}.
 	 * @since 2.1
 	 */
-	public static QPageRequest of(int page, int size, QSort sort) {
-		return new QPageRequest(page, size, sort);
+	public static QPageRequest of(int pageNumber, int pageSize, QSort sort) {
+		return new QPageRequest(pageNumber, pageSize, sort);
 	}
 
 	/**


### PR DESCRIPTION
We mix using page with pageNumber, size with pageSize and sometimes, it makes me confused. And I think pageNumber and pageSize are more clearer. Feel free to close this if there is a reason or we can not change it.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
