### PR TITLE
Use io.spring.maven.antora

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,16 +34,7 @@
 		<xmlbeam>1.4.24</xmlbeam>
 		<java-module-name>spring.data.commons</java-module-name>
 		<kotlin.api.target>1.8</kotlin.api.target>
-
-		<!-- Antora -->
-		<node.version>v18.12.1</node.version>
-		<npm.version>8.19.2</npm.version>
-		<antora.version>3.2.0-alpha.2</antora.version>
-		<antora-atlas.version>1.0.0-alpha.1</antora-atlas.version>
-		<antora-collector.version>1.0.0-alpha.3</antora-collector.version>
-		<asciidoctor-tabs.version>1.0.0-beta.3</asciidoctor-tabs.version>
-		<spring-antora-extensions.version>1.5.0</spring-antora-extensions.version>
-		<spring-asciidoctor-extensions.version>1.0.0-alpha.9</spring-asciidoctor-extensions.version>
+		<io.spring.maven.antora-version>0.0.3</io.spring.maven.antora-version>
 	</properties>
 
 	<dependencies>
@@ -366,98 +357,29 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>io.spring.maven.antora</groupId>
+				<artifactId>antora-maven-plugin</artifactId>
+				<version>${io.spring.maven.antora-version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<playbook>src/main/antora/antora-playbook.yml</playbook>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>io.spring.maven.antora</groupId>
+				<artifactId>antora-component-version-maven-plugin</artifactId>
+				<version>${io.spring.maven.antora-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>antora-component-version</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>docs</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.github.eirslett</groupId>
-						<artifactId>frontend-maven-plugin</artifactId>
-						<version>1.12.1</version>
-						<executions>
-							<execution>
-								<id>install node and npm</id>
-								<goals>
-									<goal>install-node-and-npm</goal>
-								</goals>
-								<phase>initialize</phase>
-								<configuration>
-									<nodeVersion>${node.version}</nodeVersion>
-									<npmVersion>${npm.version}</npmVersion>
-								</configuration>
-							</execution>
-							<execution>
-								<id>npm install antora</id>
-								<goals>
-									<goal>npm</goal>
-								</goals>
-								<phase>initialize</phase>
-								<configuration>
-									<arguments>install @antora/cli@${antora.version} @antora/site-generator-default@${antora.version} @antora/atlas-extension@${antora-atlas.version} @antora/collector-extension@${antora-collector.version} @asciidoctor/tabs@${asciidoctor-tabs.version} @springio/antora-extensions@${spring-antora-extensions.version} @springio/asciidoctor-extensions@${spring-asciidoctor-extensions.version}</arguments>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>exec-maven-plugin</artifactId>
-						<version>3.0.0</version>
-						<executions>
-							<execution>
-								<id>antora</id>
-								<goals>
-									<goal>exec</goal>
-								</goals>
-								<phase>compile</phase>
-								<configuration>
-									<!-- If we don't want to depend on default node installation path we can use a maven
-                                     property aligned with frontend-maven-plugin's installDirectory configuration -->
-									<executable>node/node</executable>
-									<arguments>
-										<argument>node_modules/.bin/antora</argument>
-										<argument>src/main/antora/antora-playbook.yml</argument>
-										<argument>--to-dir=target/site</argument>
-									</arguments>
-									<workingDirectory>${project.basedir}</workingDirectory>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-clean-plugin</artifactId>
-						<version>3.1.0</version>
-						<configuration>
-							<filesets>
-								<fileset>
-									<directory>node</directory>
-									<followSymlinks>false</followSymlinks>
-								</fileset>
-								<fileset>
-									<directory>node_modules</directory>
-									<followSymlinks>false</followSymlinks>
-								</fileset>
-								<fileset>
-									<directory>build</directory>
-									<followSymlinks>false</followSymlinks>
-								</fileset>
-							</filesets>
-						</configuration>
-					</plugin>
-				</plugins>
-				<resources>
-					<resource>
-						<directory>src/main/resources</directory>
-						<filtering>true</filtering>
-					</resource>
-				</resources>
-			</build>
-		</profile>
-	</profiles>
 
 	<repositories>
 		<repository>

--- a/src/main/antora/antora.yml
+++ b/src/main/antora/antora.yml
@@ -6,7 +6,7 @@ nav:
 ext:
   collector:
     - run:
-        command: mvnw -Pdocs resources:resources
+        command: mvnw process-resources
         local: true
       scan:
         dir: target/classes/antora-resources

--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -1,5 +1,5 @@
-version: ${project.version}
-
+version: ${antora-component.version}
+prerelease: ${antora-component.prerelease}
 asciidoc:
   attributes:
     attribute-missing: 'warn'


### PR DESCRIPTION
This switches to using io.spring.maven.antora plugins which does two things:

- corrects the Antora build by using antora-component-version-maven-plugin to generate the `version` and `prerelease` attributes
- Simplifies the Antora build configuration
- Adds a new lifecycle method. Now building Antora is just `mvn antora` This means that it should not need to be behind a profile since it is not longer invoked with the `compile` phase.