### PR TITLE
Change pair to record

### DIFF
--- a/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
@@ -212,8 +212,8 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 				return PathResolution.unresolved(parts, segment, type, currentPath);
 			}
 
-			path = pair.getFirst();
-			current = pair.getSecond();
+			path = pair.first();
+			current = pair.second();
 		}
 
 		return PathResolution.resolved(path);

--- a/src/main/java/org/springframework/data/repository/core/support/DefaultCrudMethods.java
+++ b/src/main/java/org/springframework/data/repository/core/support/DefaultCrudMethods.java
@@ -115,7 +115,7 @@ public class DefaultCrudMethods implements CrudMethods {
 		Class<?> repositoryInterface = metadata.getRepositoryInterface();
 
 		return source//
-				.flatMap(it -> toStream(findMethod(repositoryInterface, it.getFirst(), it.getSecond())))//
+				.flatMap(it -> toStream(findMethod(repositoryInterface, it.first(), it.second())))//
 				.flatMap(it -> toStream(getMostSpecificMethod(it, repositoryInterface)))//
 				.findFirst();
 	}

--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptor.java
@@ -98,8 +98,8 @@ class QueryExecutorMethodInterceptor implements MethodInterceptor {
 
 			Pair<Method, RepositoryQuery> pair = lookupQuery(method, repositoryInformation, lookupStrategy,
 					projectionFactory);
-			invokeListeners(pair.getSecond());
-			result.put(pair.getFirst(), pair.getSecond());
+			invokeListeners(pair.second());
+			result.put(pair.first(), pair.second());
 		}
 
 		return result;

--- a/src/main/java/org/springframework/data/util/Pair.java
+++ b/src/main/java/org/springframework/data/util/Pair.java
@@ -15,104 +15,71 @@
  */
 package org.springframework.data.util;
 
+import org.springframework.util.Assert;
+
 import java.util.Map;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
-
 /**
  * A tuple of things.
  *
+ * @param <S> Type of the first thing.
+ * @param <T> Type of the second thing.
  * @author Tobias Trelle
  * @author Oliver Gierke
  * @author Christoph Strobl
- * @param <S> Type of the first thing.
- * @param <T> Type of the second thing.
+ * @author Iman Hosseinzadeh
  * @since 1.12
  */
-public final class Pair<S, T> {
+public record Pair<S, T>(S first, T second) {
+    public Pair {
 
-	private final S first;
-	private final T second;
+        Assert.notNull(first, "First must not be null");
+        Assert.notNull(second, "Second must not be null");
+    }
 
-	private Pair(S first, T second) {
+    /**
+     * Creates a new {@link Pair} for the given elements.
+     *
+     * @param first  must not be {@literal null}.
+     * @param second must not be {@literal null}.
+     * @return
+     */
+    public static <S, T> Pair<S, T> of(S first, T second) {
+        return new Pair<>(first, second);
+    }
 
-		Assert.notNull(first, "First must not be null");
-		Assert.notNull(second, "Second must not be null");
+    /**
+     * A collector to create a {@link Map} from a {@link Stream} of {@link Pair}s.
+     *
+     * @return
+     */
+    public static <S, T> Collector<Pair<S, T>, ?, Map<S, T>> toMap() {
+        return Collectors.toMap(Pair::first, Pair::second);
+    }
 
-		this.first = first;
-		this.second = second;
-	}
+    /**
+     * @return
+     * @deprecated for removal. Use {@link #first()} instead.
+     */
+    @Deprecated(since = "3.2", forRemoval = true)
+    public S getFirst() {
+        return this.first;
+    }
 
-	/**
-	 * Creates a new {@link Pair} for the given elements.
-	 *
-	 * @param first must not be {@literal null}.
-	 * @param second must not be {@literal null}.
-	 * @return
-	 */
-	public static <S, T> Pair<S, T> of(S first, T second) {
-		return new Pair<>(first, second);
-	}
+    /**
+     * @return
+     * @deprecated for removal. Use {@link #second()} instead.
+     */
+    @Deprecated(since = "3.2", forRemoval = true)
+    public T getSecond() {
+        return this.second;
+    }
 
-	/**
-	 * Returns the first element of the {@link Pair}.
-	 *
-	 * @return
-	 */
-	public S getFirst() {
-		return first;
-	}
-
-	/**
-	 * Returns the second element of the {@link Pair}.
-	 *
-	 * @return
-	 */
-	public T getSecond() {
-		return second;
-	}
-
-	/**
-	 * A collector to create a {@link Map} from a {@link Stream} of {@link Pair}s.
-	 *
-	 * @return
-	 */
-	public static <S, T> Collector<Pair<S, T>, ?, Map<S, T>> toMap() {
-		return Collectors.toMap(Pair::getFirst, Pair::getSecond);
-	}
-
-	@Override
-	public boolean equals(@Nullable Object o) {
-
-		if (this == o) {
-			return true;
-		}
-
-		if (!(o instanceof Pair<?, ?> pair)) {
-			return false;
-		}
-
-		if (!ObjectUtils.nullSafeEquals(first, pair.first)) {
-			return false;
-		}
-
-		return ObjectUtils.nullSafeEquals(second, pair.second);
-	}
-
-	@Override
-	public int hashCode() {
-		int result = ObjectUtils.nullSafeHashCode(first);
-		result = 31 * result + ObjectUtils.nullSafeHashCode(second);
-		return result;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("%s->%s", this.first, this.second);
-	}
+    @Override
+    public String toString() {
+        return String.format("%s->%s", this.first, this.second);
+    }
 }

--- a/src/test/java/org/springframework/data/util/ClassTypeInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/util/ClassTypeInformationUnitTests.java
@@ -380,9 +380,9 @@ public class ClassTypeInformationUnitTests {
 
 		assertThat(Pair.of(abstractBar.specialize(TypeInformation.of(Bar.class)),
 				abstractBar.specialize(TypeInformation.of(Bar.class)))).satisfies(pair -> {
-					assertThat(pair.getFirst()).isEqualTo(pair.getSecond());
-					assertThat(pair.getSecond()).isEqualTo(pair.getFirst());
-					assertThat(pair.getFirst().hashCode()).isEqualTo(pair.getSecond().hashCode());
+					assertThat(pair.first()).isEqualTo(pair.second());
+					assertThat(pair.second()).isEqualTo(pair.first());
+					assertThat(pair.first().hashCode()).isEqualTo(pair.second().hashCode());
 				});
 	}
 

--- a/src/test/java/org/springframework/data/util/PairUnitTests.java
+++ b/src/test/java/org/springframework/data/util/PairUnitTests.java
@@ -31,8 +31,8 @@ class PairUnitTests {
 
 		var pair = Pair.of(1, 2);
 
-		assertThat(pair.getFirst()).isEqualTo(1);
-		assertThat(pair.getSecond()).isEqualTo(2);
+		assertThat(pair.first()).isEqualTo(1);
+		assertThat(pair.second()).isEqualTo(2);
 	}
 
 	@Test // DATACMNS-790


### PR DESCRIPTION
This PR implements the issue of #2910.

Changes in this pull request :
- Use the record feature for the Pair class.
- Deprecate `getFirst()` and `getSecond()` methods.
- Introduce `first()` and `second()` methods.
- Use newer methods in the whole project (main and test).


