### PR TITLE
Introduce `PersistentProperty.isReadable`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-2915-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/PersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentProperty.java
@@ -263,6 +263,16 @@ public interface PersistentProperty<P extends PersistentProperty<P>> {
 	boolean isWritable();
 
 	/**
+	 * Returns whether the current property is readable through {@link PersistentPropertyAccessor}, i.e. if it is not
+	 * {@link #isTransient()}, if the value can be set on the current instance or read to create a new instance as per
+	 * {@link #getWither()} or via Kotlin Copy methods.
+	 *
+	 * @return
+	 * @since 3.2
+	 */
+	boolean isReadable();
+
+	/**
 	 * Returns whether the current property is immutable, i.e. if there is no setter or the backing {@link Field} is
 	 * {@code final}.
 	 *

--- a/src/main/java/org/springframework/data/mapping/model/BytecodeUtil.java
+++ b/src/main/java/org/springframework/data/mapping/model/BytecodeUtil.java
@@ -165,7 +165,7 @@ abstract class BytecodeUtil {
 	/**
 	 * Checks whether the class is accessible by inspecting modifiers (i.e. whether the class is {@code private}).
 	 *
-	 * @param type must not be {@literal null}.
+	 * @param modifiers modifiers to check.
 	 * @return {@literal true} if the {@code modifiers} do not indicate the private flag.
 	 * @see Modifier#isPrivate(int)
 	 */
@@ -177,7 +177,7 @@ abstract class BytecodeUtil {
 	 * Checks whether the modifiers express {@literal default} (not
 	 * {@literal private}/{@literal protected}/{@literal public}).
 	 *
-	 * @param type must not be {@literal null}.
+	 * @param modifiers modifiers to check.
 	 * @return {@literal true} if the {@code modifiers} indicate {@literal default}.
 	 * @see Modifier#isPrivate(int)
 	 */

--- a/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/ClassGeneratingPropertyAccessorFactory.java
@@ -1029,7 +1029,7 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 					visitWithProperty(entity, property, mv, internalClassName, wither);
 				}
 
-				if (hasKotlinCopyMethod(property)) {
+				if (KotlinDetector.isKotlinType(entity.getType()) && KotlinCopyMethod.hasKotlinCopyMethodFor(property)) {
 					visitKotlinCopy(entity, property, mv, internalClassName);
 				}
 
@@ -1429,38 +1429,7 @@ public class ClassGeneratingPropertyAccessorFactory implements PersistentPropert
 	 * @return {@literal true} if object mutation is supported.
 	 */
 	static boolean supportsMutation(PersistentProperty<?> property) {
-
-		if (property.isImmutable()) {
-
-			if (property.getWither() != null) {
-				return true;
-			}
-
-			if (hasKotlinCopyMethod(property)) {
-				return true;
-			}
-		}
-
-		return (property.usePropertyAccess() && property.getSetter() != null)
-				|| (property.getField() != null && !Modifier.isFinal(property.getField().getModifiers()));
-	}
-
-	/**
-	 * Check whether the owning type of {@link PersistentProperty} declares a {@literal copy} method or {@literal copy}
-	 * method with parameter defaulting.
-	 *
-	 * @param property must not be {@literal null}.
-	 * @return
-	 */
-	private static boolean hasKotlinCopyMethod(PersistentProperty<?> property) {
-
-		Class<?> type = property.getOwner().getType();
-
-		if (isAccessible(type) && KotlinDetector.isKotlinType(type)) {
-			return KotlinCopyMethod.findCopyMethod(type).filter(it -> it.supportsProperty(property)).isPresent();
-		}
-
-		return false;
+		return (property.usePropertyAccess() && property.getSetter() != null) || property.isReadable();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/mapping/model/InstantiationAwarePropertyAccessor.java
+++ b/src/main/java/org/springframework/data/mapping/model/InstantiationAwarePropertyAccessor.java
@@ -17,7 +17,6 @@ package org.springframework.data.mapping.model;
 
 import java.util.function.Function;
 
-import org.springframework.core.KotlinDetector;
 import org.springframework.data.mapping.InstanceCreatorMetadata;
 import org.springframework.data.mapping.Parameter;
 import org.springframework.data.mapping.PersistentEntity;
@@ -76,7 +75,7 @@ public class InstantiationAwarePropertyAccessor<T> implements PersistentProperty
 		PersistentEntity<?, ? extends PersistentProperty<?>> owner = property.getOwner();
 		PersistentPropertyAccessor<T> delegate = delegateFunction.apply(this.bean);
 
-		if (!property.isImmutable() || property.getWither() != null || KotlinDetector.isKotlinType(owner.getType())) {
+		if (property.isReadable()) {
 
 			delegate.setProperty(property, value);
 			this.bean = delegate.getBean();

--- a/src/main/java/org/springframework/data/mapping/model/KotlinCopyMethod.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinCopyMethod.java
@@ -97,6 +97,20 @@ class KotlinCopyMethod {
 		});
 	}
 
+	/**
+	 * Check whether the owning type of {@link PersistentProperty} declares a {@literal copy} method or {@literal copy}
+	 * method with parameter defaulting.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return
+	 */
+	public static boolean hasKotlinCopyMethodFor(PersistentProperty<?> property) {
+
+		Class<?> type = property.getOwner().getType();
+
+		return KotlinCopyMethod.findCopyMethod(type).filter(it -> it.supportsProperty(property)).isPresent();
+	}
+
 	public Method getPublicCopyMethod() {
 		return this.publicCopyMethod;
 	}

--- a/src/test/java/org/springframework/data/mapping/model/AnnotationBasedPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/AnnotationBasedPersistentPropertyUnitTests.java
@@ -178,6 +178,31 @@ public class AnnotationBasedPersistentPropertyUnitTests<P extends AnnotationBase
 				.satisfies(it -> assertThat(it.isWritable()).isFalse());
 	}
 
+	@Test // GH-2915
+	public void treatsReadOnlyAsReadable() {
+
+		assertThat(getProperty(ClassWithReadOnlyProperties.class, "readOnlyProperty"))
+				.satisfies(it -> assertThat(it.isReadable()).isTrue());
+	}
+
+	@Test // GH-2915
+	public void considersReadableForWither() {
+
+		assertThat(getProperty(ClassWithWither.class, "nonReadable"))
+				.satisfies(it -> assertThat(it.isReadable()).isFalse());
+
+		assertThat(getProperty(ClassWithWither.class, "immutable")).satisfies(it -> assertThat(it.isReadable()).isTrue());
+	}
+
+	@Test // GH-2915
+	public void considersReadableForKotlinDataClass() {
+
+		assertThat(getProperty(SingleSettableProperty.class, "version"))
+				.satisfies(it -> assertThat(it.isReadable()).isFalse());
+
+		assertThat(getProperty(SingleSettableProperty.class, "id")).satisfies(it -> assertThat(it.isReadable()).isTrue());
+	}
+
 	@Test // DATACMNS-556
 	public void doesNotRejectNonSpringDataAnnotationsUsedOnBothFieldAndAccessor() {
 		getProperty(TypeWithCustomAnnotationsOnBothFieldAndAccessor.class, "field");
@@ -460,7 +485,8 @@ public class AnnotationBasedPersistentPropertyUnitTests<P extends AnnotationBase
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(value = { FIELD, METHOD, ANNOTATION_TYPE })
 	@Id
-	public @interface MyId {}
+	public @interface MyId {
+	}
 
 	static class FieldAccess {
 		String name;
@@ -491,6 +517,21 @@ public class AnnotationBasedPersistentPropertyUnitTests<P extends AnnotationBase
 		@ReadOnlyProperty String readOnlyProperty;
 
 		@CustomReadOnly String customReadOnlyProperty;
+	}
+
+	static class ClassWithWither {
+
+		private final String nonReadable = "";
+
+		private final String immutable;
+
+		public ClassWithWither(String immutable) {
+			this.immutable = immutable;
+		}
+
+		public ClassWithWither withImmutable(String v) {
+			return new ClassWithWither(v);
+		}
 	}
 
 	static class TypeWithCustomAnnotationsOnBothFieldAndAccessor {


### PR DESCRIPTION
`isReadable` reports whether a property can be read through `PersistentPropertyAccessor`, by either using property access through setters, a wither, Kotlin Copy method or by accessing the field directly.

Closes #2915