### PR TITLE
Adapt for Spring Framework Coroutines AOP support

### DIFF
--- a/src/test/kotlin/org/springframework/data/repository/kotlin/CoroutineCrudRepositoryCustomImplementationUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/repository/kotlin/CoroutineCrudRepositoryCustomImplementationUnitTests.kt
@@ -16,6 +16,7 @@
 package org.springframework.data.repository.kotlin
 
 import io.mockk.mockk
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -45,7 +46,7 @@ class CoroutineCrudRepositoryCustomImplementationUnitTests {
 	}
 
 	@Test // DATACMNS-1508
-	fun shouldInvokeFindAll() {
+	fun shouldInvokeFindOne() {
 
 		val result = runBlocking {
 			coRepository.findOne("foo")
@@ -71,6 +72,7 @@ class CoroutineCrudRepositoryCustomImplementationUnitTests {
 	class MyCustomCoRepositoryImpl : MyCustomCoRepository {
 
 		override suspend fun findOne(id: String): User {
+			delay(1)
 			return User()
 		}
 	}

--- a/src/test/kotlin/org/springframework/data/repository/kotlin/CoroutineCrudRepositoryUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/repository/kotlin/CoroutineCrudRepositoryUnitTests.kt
@@ -19,7 +19,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -28,6 +27,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.reactivestreams.Publisher
 import org.springframework.data.repository.core.support.DummyReactiveRepositoryFactory
@@ -199,7 +199,7 @@ class CoroutineCrudRepositoryUnitTests {
 
 		val sample = User()
 
-		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null))).thenReturn(Mono.just(sample))
+		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null, any()))).thenReturn(Mono.just(sample))
 
 		val result = runBlocking {
 			coRepository.findOne("foo")
@@ -215,7 +215,7 @@ class CoroutineCrudRepositoryUnitTests {
 
 		val sample = User()
 
-		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null))).thenReturn(Single.just(sample))
+		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null, any()))).thenReturn(Mono.just(sample))
 
 		val result = runBlocking {
 			coRepository.findOne("foo")
@@ -263,7 +263,7 @@ class CoroutineCrudRepositoryUnitTests {
 
 		val sample = User()
 
-		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null))).thenReturn(Flux.just(sample), Flux.empty<User>())
+		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null, any()))).thenReturn(Flux.just(sample), Flux.empty<User>())
 
 		val result = runBlocking {
 			coRepository.findSuspendedMultiple("foo").toList()
@@ -283,7 +283,7 @@ class CoroutineCrudRepositoryUnitTests {
 
 		val sample = User()
 
-		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null))).thenReturn(Flux.just(sample), Flux.empty<User>())
+		Mockito.`when`(factory.queryOne.execute(arrayOf("foo", null, any()))).thenReturn(Mono.just(listOf(sample)), Mono.empty<User>())
 
 		val result = runBlocking {
 			coRepository.findSuspendedAsList("foo")
@@ -295,7 +295,7 @@ class CoroutineCrudRepositoryUnitTests {
 			coRepository.findSuspendedAsList("foo")
 		}
 
-		assertThat(emptyResult).isEmpty()
+		assertThat(emptyResult).isNull()
 	}
 
 	interface MyCoRepository : CoroutineCrudRepository<User, String> {


### PR DESCRIPTION
This commit adapts Spring Data `RepositoryMethodInvoker` and related tests in order to remove most of the Coroutines specific code and rely on [Spring Framework Coroutines AOP support](https://github.com/spring-projects/spring-framework/issues/22462).