### PR TITLE
Fallback to `StringUtils.uncapitalize(…)` when looking up property paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-GH-1851-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
@@ -119,7 +119,34 @@ So our method name would be as follows:
 List<Person> findByAddress_ZipCode(ZipCode zipCode);
 ----
 
-Because we treat the underscore character as a reserved character, we strongly advise following standard Java naming conventions (that is, not using underscores in property names but using camel case instead).
+[NOTE]
+====
+Because we treat underscores (`_`) as a reserved character, we strongly advise to follow standard Java naming conventions (that is, not using underscores in property names but applying camel case instead).
+====
+
+[CAUTION]
+====
+.Field Names starting with underscore:
+Field names may start with underscores like `String \_name`.
+Make sure to preserve the `_` as in `\_name` and use double `_` to split nested paths like `user__name`.
+
+.Upper Case Field Names:
+Field names that are all uppercase can be used as such.
+Nested paths if applicable require splitting via `_` as in `USER_name`.
+
+.Field Names with 2nd uppercase letter:
+Field names that consist of a starting lower case letter followed by an uppercase one like `String qCode` can be resolved by starting with two upper case letters as in `QCode`.
+Please be aware of potential path ambiguities.
+
+.Path Ambiguities:
+In the following sample the arrangement of properties `qCode` and `q`, with `q` containing a property called `code`, creates an ambiguity for the path `QCode`.
+```java
+record Container(String qCode, Code q) {}
+record Code(String code) {}
+```
+Since a direct match on a property is considered first, any potential nested paths will not be considered and the algorithm picks the `qCode` field.
+In order to select the `code` field in `q` the underscore notation `Q_Code` is required.
+====
 
 [[repositories.collections-and-iterables]]
 == Repository Methods Returning Collections or Iterables

--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -74,7 +74,7 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 				.map(ResolvableType::toClass).collect(Collectors.toList()));
 	}
 
-	static TypeDiscoverer<?> td(ResolvableType type) {
+	static TypeDiscoverer<?> ofCached(ResolvableType type) {
 
 		Assert.notNull(type, "Type must not be null");
 

--- a/src/main/java/org/springframework/data/util/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/util/TypeDiscoverer.java
@@ -370,8 +370,8 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 		var field = ReflectionUtils.findField(rawType, fieldname);
 
 		return field != null ? Optional.of(TypeInformation.of(ResolvableType.forField(field, resolvableType)))
-				: Optional.ofNullable(BeanUtils.getPropertyDescriptor(rawType, fieldname)).map(it -> from(it, rawType))
-						.map(TypeInformation::of);
+				: Optional.ofNullable(BeanUtils.getPropertyDescriptor(rawType, fieldname))
+						.filter(it -> it.getName().equals(fieldname)).map(it -> from(it, rawType)).map(TypeInformation::of);
 	}
 
 	private ResolvableType from(PropertyDescriptor descriptor, Class<?> rawType) {

--- a/src/main/java/org/springframework/data/util/TypeInformation.java
+++ b/src/main/java/org/springframework/data/util/TypeInformation.java
@@ -60,7 +60,7 @@ public interface TypeInformation<S> {
 		Assert.notNull(type, "Type must not be null");
 
 		return type.hasGenerics() || (type.isArray() && type.getComponentType().hasGenerics()) //
-				|| (type.getType() instanceof TypeVariable) ? TypeDiscoverer.td(type) : ClassTypeInformation.from(type);
+				|| (type.getType() instanceof TypeVariable) ? TypeDiscoverer.ofCached(type) : ClassTypeInformation.from(type);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
@@ -309,6 +309,17 @@ class PropertyPathUnitTests {
 		assertThat(PropertyPath.from("QCode", Foo.class).toDotPath()).isEqualTo("qCode");
 		assertThat(PropertyPath.from("zIndex", MyRecord.class).toDotPath()).isEqualTo("zIndex");
 		assertThat(PropertyPath.from("ZIndex", MyRecord.class).toDotPath()).isEqualTo("zIndex");
+		assertThat(PropertyPath.from("_foo.QCode", Sample2.class).toDotPath()).isEqualTo("_foo.qCode");
+		assertThat(PropertyPath.from("_fooQCode", Sample2.class).toDotPath()).isEqualTo("_foo.qCode");
+	}
+
+	@Test // GH-1851
+	void favoursPropertyHitOverNestedPath() {
+
+		assertThat(PropertyPath.from("qCode", NameAmbiguities.class).toDotPath()).isEqualTo("qCode");
+		assertThat(PropertyPath.from("QCode", NameAmbiguities.class).toDotPath()).isEqualTo("qCode");
+		assertThat(PropertyPath.from("Q_Code", NameAmbiguities.class).toDotPath()).isEqualTo("q.code");
+		assertThat(PropertyPath.from("q_code", NameAmbiguities.class).toDotPath()).isEqualTo("q.code");
 	}
 
 	@Test // DATACMNS-257
@@ -456,6 +467,16 @@ class PropertyPathUnitTests {
 		public void setqCode(String qCode) {
 			this.qCode = qCode;
 		}
+	}
+
+	private static class NameAmbiguities {
+
+		String qCode;
+		Code q;
+	}
+
+	private static class Code {
+		String code;
 	}
 
 	private class Bar {

--- a/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
@@ -124,7 +124,7 @@ class PropertyPathUnitTests {
 	}
 
 	@Test
-	void handlesInvalidCollectionCompountTypeProperl() {
+	void handlesInvalidCollectionCompoundTypeProperly() {
 
 		try {
 			PropertyPath.from("usersMame", Bar.class);

--- a/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
@@ -48,6 +48,16 @@ class PropertyPathUnitTests {
 		assertThat(reference.getOwningType()).isEqualTo(TypeInformation.of(Foo.class));
 	}
 
+	@Test // GH-1851
+	void parsesRecordPropertyCorrectly() {
+
+		var reference = PropertyPath.from("userName", MyRecord.class);
+
+		assertThat(reference.hasNext()).isFalse();
+		assertThat(reference.toDotPath()).isEqualTo("userName");
+		assertThat(reference.getOwningType()).isEqualTo(TypeInformation.of(MyRecord.class));
+	}
+
 	@Test
 	void parsesPathPropertyCorrectly() {
 
@@ -292,6 +302,15 @@ class PropertyPathUnitTests {
 		assertThat(path.getSegment()).isEqualTo("UUID");
 	}
 
+	@Test // GH-1851
+	void findsSecondLetterUpperCaseProperty() {
+
+		assertThat(PropertyPath.from("qCode", Foo.class).toDotPath()).isEqualTo("qCode");
+		assertThat(PropertyPath.from("QCode", Foo.class).toDotPath()).isEqualTo("qCode");
+		assertThat(PropertyPath.from("zIndex", MyRecord.class).toDotPath()).isEqualTo("zIndex");
+		assertThat(PropertyPath.from("ZIndex", MyRecord.class).toDotPath()).isEqualTo("zIndex");
+	}
+
 	@Test // DATACMNS-257
 	void findsNestedAllUppercaseProperty() {
 
@@ -427,7 +446,16 @@ class PropertyPathUnitTests {
 		String userName;
 		String _email;
 		String UUID;
+		String qCode;
 		String var_name_with_underscore;
+
+		public String getqCode() {
+			return qCode;
+		}
+
+		public void setqCode(String qCode) {
+			this.qCode = qCode;
+		}
 	}
 
 	private class Bar {
@@ -487,4 +515,7 @@ class PropertyPathUnitTests {
 	}
 
 	private class B {}
+
+	private record MyRecord(String userName, boolean zIndex) {
+	}
 }

--- a/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/parser/PartTreeUnitTests.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.PropertyPath;
-import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.data.repository.query.parser.Part.IgnoreCaseType;
 import org.springframework.data.repository.query.parser.Part.Type;
 import org.springframework.data.repository.query.parser.PartTree.OrPart;
@@ -616,28 +615,6 @@ class PartTreeUnitTests {
 
 		assertThat(tree).isEmpty();
 		assertThat(tree.hasPredicate()).isFalse();
-	}
-
-	/**
-	 * This test does not verify a desired behaviour but documents a limitation. If it starts failing and everything else
-	 * is green, remove the expectation to fail with an exception.
-	 */
-	@Test // DATACMNS-1570
-	void specialCapitalizationInSubject() {
-
-		assertThatThrownBy(() -> new PartTree("findByZIndex", SpecialCapitalization.class))
-				.isInstanceOf(PropertyReferenceException.class);
-	}
-
-	/**
-	 * This test does not verify a desired behaviour but documents a limitation. If it starts failing and everything else
-	 * is green, remove the expectation to fail with an exception.
-	 */
-	@Test // DATACMNS-1570
-	void specialCapitalizationInOrderBy() {
-
-		assertThatThrownBy(() -> new PartTree("findByOrderByZIndex", SpecialCapitalization.class))
-				.isInstanceOf(PropertyReferenceException.class);
 	}
 
 	@Test // DATACMNS-1570


### PR DESCRIPTION
Naming restrictions for property paths used in query method names require capitalization of the first letter regardless whether the property name uses a second-letter uppercase form (zIndex -> ZIndex, qCode -> QCode). In such cases, `Introspector.decapitalize(…)` shortcuts to non-decapitalization as it checks the second letter casing.

This leads to the case that the property name cannot be resolved, assuming proper property naming (`getzIndex()`, `zIndex()`).

Falling back to `StringUtils.uncapitalize()` allows catching such properties.

Closes #1851