### PR TITLE
Proposal to fix #2531 adding explode modifier `*` to `sort` attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,21 +207,6 @@
 		<dependency>
 			<groupId>org.apache.openwebbeans</groupId>
 			<artifactId>openwebbeans-se</artifactId>
-			<classifier>jakarta</classifier>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.openwebbeans</groupId>
-			<artifactId>openwebbeans-spi</artifactId>
-			<classifier>jakarta</classifier>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.openwebbeans</groupId>
-			<artifactId>openwebbeans-impl</artifactId>
-			<classifier>jakarta</classifier>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
@@ -57,11 +57,9 @@ public class HateoasSortHandlerMethodArgumentResolver extends SortHandlerMethodA
 			return TemplateVariables.NONE;
 		}
 
-		String sortParameterExplode = sortParameter + '*';
-
-		String description = String.format("pagination.%s.description", sortParameterExplode);
+		String description = String.format("pagination.%s.description", sortParameter);
 		TemplateVariable.VariableType type = append ? REQUEST_PARAM_CONTINUED : REQUEST_PARAM;
-		return new TemplateVariables(new TemplateVariable(sortParameterExplode, type, description));
+		return new TemplateVariables(new TemplateVariable(sortParameter, type, description).composite());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
@@ -35,6 +35,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Nick Williams
+ * @author Julien Béti
  */
 public class HateoasSortHandlerMethodArgumentResolver extends SortHandlerMethodArgumentResolver
 		implements UriComponentsContributor {

--- a/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolver.java
@@ -56,9 +56,11 @@ public class HateoasSortHandlerMethodArgumentResolver extends SortHandlerMethodA
 			return TemplateVariables.NONE;
 		}
 
-		String description = String.format("pagination.%s.description", sortParameter);
+		String sortParameterExplode = sortParameter + '*';
+
+		String description = String.format("pagination.%s.description", sortParameterExplode);
 		TemplateVariable.VariableType type = append ? REQUEST_PARAM_CONTINUED : REQUEST_PARAM;
-		return new TemplateVariables(new TemplateVariable(sortParameter, type, description));
+		return new TemplateVariables(new TemplateVariable(sortParameterExplode, type, description));
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolverUnitTests.java
@@ -28,6 +28,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * Unit tests for {@link HateoasPageableHandlerMethodArgumentResolver}.
  *
  * @author Oliver Gierke
+ * @author Julien Béti
  */
 class HateoasPageableHandlerMethodArgumentResolverUnitTests
 		extends PageableHandlerMethodArgumentResolverUnitTests {

--- a/src/test/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/HateoasPageableHandlerMethodArgumentResolverUnitTests.java
@@ -69,10 +69,10 @@ class HateoasPageableHandlerMethodArgumentResolverUnitTests
 	@Test // DATACMNS-418
 	void appendsTemplateVariablesCorrectly() {
 
-		assertTemplateEnrichment("/foo", "{?page,size,sort}");
-		assertTemplateEnrichment("/foo?bar=1", "{&page,size,sort}");
-		assertTemplateEnrichment("/foo?page=1", "{&size,sort}");
-		assertTemplateEnrichment("/foo?page=1&size=10", "{&sort}");
+		assertTemplateEnrichment("/foo", "{?page,size,sort*}");
+		assertTemplateEnrichment("/foo?bar=1", "{&page,size,sort*}");
+		assertTemplateEnrichment("/foo?page=1", "{&size,sort*}");
+		assertTemplateEnrichment("/foo?page=1&size=10", "{&sort*}");
 		assertTemplateEnrichment("/foo?page=1&sort=foo,asc", "{&size}");
 		assertTemplateEnrichment("/foo?page=1&size=10&sort=foo,asc", "");
 	}
@@ -86,7 +86,7 @@ class HateoasPageableHandlerMethodArgumentResolverUnitTests
 		resolver.setPageParameterName("foo");
 		var variables = resolver.getPaginationTemplateVariables(null, uriComponents).toString();
 
-		assertThat(variables).isEqualTo("{?foo,size,sort}");
+		assertThat(variables).isEqualTo("{?foo,size,sort*}");
 	}
 
 	@Test // DATACMNS-563

--- a/src/test/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolverUnitTests.java
@@ -28,6 +28,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * Unit tests for {@link HateoasSortHandlerMethodArgumentResolver}
  *
  * @author Oliver Gierke
+ * @author Julien Béti
  */
 class HateoasSortHandlerMethodArgumentResolverUnitTests extends SortHandlerMethodArgumentResolverUnitTests {
 

--- a/src/test/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/HateoasSortHandlerMethodArgumentResolverUnitTests.java
@@ -52,7 +52,7 @@ class HateoasSortHandlerMethodArgumentResolverUnitTests extends SortHandlerMetho
 		var uriComponents = UriComponentsBuilder.fromPath("/").build();
 
 		var resolver = new HateoasSortHandlerMethodArgumentResolver();
-		assertThat(resolver.getSortTemplateVariables(null, uriComponents).toString()).isEqualTo("{?sort}");
+		assertThat(resolver.getSortTemplateVariables(null, uriComponents).toString()).isEqualTo("{?sort*}");
 	}
 
 	private void assertUriStringFor(Sort sort, String expected) throws Exception {


### PR DESCRIPTION
Adding explode modifier `*` to `sort` attribute, making client libraries like Ketting to behave correctly and generate request compliant with Spring

Proposal to fix #2531