### PR TITLE
AbstractPersistentProperty now considers the owner for equals.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-relational-1657-bad-cached-aggregate-path-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>> implements PersistentProperty<P> {
 
@@ -87,7 +89,7 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 		this.association = Lazy.of(() -> isAssociation() ? createAssociation() : null);
 		this.owner = owner;
 
-		this.hashCode = Lazy.of(property::hashCode);
+		this.hashCode = Lazy.of(() -> Objects.hash(property, owner));
 		this.usePropertyAccess = Lazy.of(() -> owner.getType().isInterface() || CAUSE_FIELD.equals(getField()));
 
 		this.isAssociation = Lazy.of(() -> ASSOCIATION_TYPE != null && ASSOCIATION_TYPE.isAssignableFrom(rawType));
@@ -317,7 +319,7 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 			return false;
 		}
 
-		return this.property.equals(that.property);
+		return this.property.equals(that.property) && this.owner.equals(that.owner);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/AbstractPersistentPropertyUnitTests.java
@@ -81,16 +81,6 @@ public class AbstractPersistentPropertyUnitTests {
 		assertThat(getProperty(TestClassComplex.class, "collection").isEntity()).isFalse();
 	}
 
-	@Test // DATACMNS-121
-	void considersPropertiesEqualIfFieldEquals() {
-
-		var firstProperty = getProperty(FirstConcrete.class, "genericField");
-		var secondProperty = getProperty(SecondConcrete.class, "genericField");
-
-		assertThat(firstProperty).isEqualTo(secondProperty);
-		assertThat(firstProperty.hashCode()).isEqualTo(secondProperty.hashCode());
-	}
-
 	@Test // DATACMNS-180
 	void doesNotConsiderJavaTransientFieldsTransient() {
 		assertThat(getProperty(TestClassComplex.class, "transientField").isTransient()).isFalse();
@@ -207,7 +197,7 @@ public class AbstractPersistentPropertyUnitTests {
 	@Test // DATACMNS-1139
 	void resolvesGenericsForRawType() {
 
-		var property = getProperty(FirstConcrete.class, "genericField");
+		var property = getProperty(Concrete.class, "genericField");
 
 		assertThat(property.getRawType()).isEqualTo(String.class);
 	}
@@ -238,6 +228,15 @@ public class AbstractPersistentPropertyUnitTests {
 		SamplePersistentProperty property = getProperty(VavrWrapper.class, "vavrMap");
 
 		assertThat(property.isMap()).isTrue();
+	}
+
+	@Test // GH-2972
+	void equalsConsidersOwner() {
+
+		SamplePersistentProperty id1 = getProperty(Inherited1.class, "id");
+		SamplePersistentProperty id2 = getProperty(Inherited2.class, "id");
+
+		assertThat(id1).isNotEqualTo(id2);
 	}
 
 	private <T> BasicPersistentEntity<T, SamplePersistentProperty> getEntity(Class<T> type) {
@@ -277,11 +276,7 @@ public class AbstractPersistentPropertyUnitTests {
 
 	}
 
-	class FirstConcrete extends Generic<String> {
-
-	}
-
-	class SecondConcrete extends Generic<Integer> {
+	class Concrete extends Generic<String> {
 
 	}
 
@@ -412,4 +407,15 @@ public class AbstractPersistentPropertyUnitTests {
 	class VavrWrapper {
 		io.vavr.collection.Map<String, String> vavrMap;
 	}
+
+	class Base {
+		Long id;
+	}
+
+	class Inherited1 extends Base {
+	}
+
+	class Inherited2 extends Base {
+	}
+
 }


### PR DESCRIPTION
This makes a difference when a property is declared in a superclass of two entities.
In such a case the property is the same, but the owner is different.

Closes https://github.com/spring-projects/spring-data-commons/issues/2972
See https://github.com/spring-projects/spring-data-relational/issues/1657

As discussed yesterday I build Spring Data JPA and Spring Data Rest based on this change.
The builds ran without a problem.

I also verify that it actually resolves https://github.com/spring-projects/spring-data-relational/issues/1657