### PR TITLE
Resolve LocalDate Storage Inconsistency Issue

### DIFF
--- a/src/main/java/org/springframework/data/convert/Jsr310Converters.java
+++ b/src/main/java/org/springframework/data/convert/Jsr310Converters.java
@@ -45,6 +45,7 @@ import org.springframework.lang.NonNull;
  * @author Christoph Strobl
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Hamza Hanafi
  */
 public abstract class Jsr310Converters {
 

--- a/src/main/java/org/springframework/data/convert/Jsr310Converters.java
+++ b/src/main/java/org/springframework/data/convert/Jsr310Converters.java
@@ -126,7 +126,7 @@ public abstract class Jsr310Converters {
 		@NonNull
 		@Override
 		public LocalDate convert(Date source) {
-			return ofInstant(ofEpochMilli(source.getTime()), systemDefault()).toLocalDate();
+			return source.toInstant().atZone(ZoneOffset.UTC).toLocalDate();
 		}
 	}
 
@@ -138,7 +138,7 @@ public abstract class Jsr310Converters {
 		@NonNull
 		@Override
 		public Date convert(LocalDate source) {
-			return Date.from(source.atStartOfDay(systemDefault()).toInstant());
+			return new Date(source.atStartOfDay().atZone(ZoneOffset.UTC).toInstant().toEpochMilli());
 		}
 	}
 


### PR DESCRIPTION
Addressing the inconsistencies in date storage related to MongoDB's default timestamp with timezone approach. The current method often leads to discrepancies in date interpretation across various timezones and services. This commit introduces a revised storage strategy that prioritizes storing dates as LocalDate to ensure consistent interpretation irrespective of timezone differences. By avoiding implicit conversions to timestamps, it mitigates issues where the date representation may differ based on the timezone of the reading service or aggregation functions. This change aims to ensure uniformity in date representation, particularly critical for scenarios like invoicing where the date's day component should be preserved consistently across systems.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
