### PR TITLE
Fixed the URL for the Spring Data Commons documentation

### DIFF
--- a/src/main/antora/antora-playbook.yml
+++ b/src/main/antora/antora-playbook.yml
@@ -8,7 +8,7 @@ antora:
       root_component_name: 'data-commons'
 site:
   title: Spring Data Reference
-  url: https://docs.spring.io/spring-data-commons/reference
+  url: https://docs.spring.io/spring-data/commons/reference
 content:
   sources:
     - url: ./../../..


### PR DESCRIPTION
I fixed an incorrect URL in the antora-playbook.yml file.