### PR TITLE
Add `@Transient` properties to `PersistentEntity` and use value defaulting for transient constructor properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-ISSUE-1432-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/antora/modules/ROOT/pages/object-mapping.adoc
+++ b/src/main/antora/modules/ROOT/pages/object-mapping.adoc
@@ -154,7 +154,7 @@ By default, Spring Data attempts to use generated property accessors and falls b
 Let's have a look at the following entity:
 
 .A sample entity
-[source, java]
+[source,java]
 ----
 class Person {
 
@@ -165,14 +165,15 @@ class Person {
 
   private String comment;                                                   <4>
   private @AccessType(Type.PROPERTY) String remarks;                        <5>
+  private @Transient String summary;                                        <6>
 
-  static Person of(String firstname, String lastname, LocalDate birthday) { <6>
+  static Person of(String firstname, String lastname, LocalDate birthday) { <7>
 
     return new Person(null, firstname, lastname, birthday,
       Period.between(birthday, LocalDate.now()).getYears());
   }
 
-  Person(Long id, String firstname, String lastname, LocalDate birthday, int age) { <6>
+  Person(Long id, String firstname, String lastname, LocalDate birthday, int age) { <7>
 
     this.id = id;
     this.firstname = firstname;
@@ -201,7 +202,10 @@ With the design shown, the database value will trump the defaulting as Spring Da
 Even if the intent is that the calculation should be preferred, it's important that this constructor also takes `age` as parameter (to potentially ignore it) as otherwise the property population step will attempt to set the age field and fail due to it being immutable and no `with…` method being present.
 <4> The `comment` property is mutable and is populated by setting its field directly.
 <5> The `remarks` property is mutable and is populated by invoking the setter method.
-<6> The class exposes a factory method and a constructor for object creation.
+<6> The `summary` property transient and will not be persisted as it is annotated with `@Transient`.
+Spring Data doesn't use Java's `transient` keyword to exclude properties from being persisted as `transient` is part of the Java Serialization Framework.
+Note that this property can be used with a persistence constructor, but its value will default to `null` (or the respective primitive initial value if the property type was a primitive one).
+<7> The class exposes a factory method and a constructor for object creation.
 The core idea here is to use factory methods instead of additional constructors to avoid the need for constructor disambiguation through `@PersistenceCreator`.
 Instead, defaulting of properties is handled within the factory method.
 If you want Spring Data to use the factory method for object instantiation, annotate it with `@PersistenceCreator`.

--- a/src/main/java/org/springframework/data/annotation/PersistenceCreator.java
+++ b/src/main/java/org/springframework/data/annotation/PersistenceCreator.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marker annotation to declare a constructor or factory method annotation as factory/preferred constructor annotation.
+ * Properties used by the constructor (or factory method) must refer to persistent properties or be annotated with
+ * {@link org.springframework.beans.factory.annotation.Value @Value(…)} to obtain a value for object creation.
  *
  * @author Mark Paluch
  * @author Oliver Drotbohm
@@ -29,4 +31,5 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
-public @interface PersistenceCreator {}
+public @interface PersistenceCreator {
+}

--- a/src/main/java/org/springframework/data/annotation/Transient.java
+++ b/src/main/java/org/springframework/data/annotation/Transient.java
@@ -22,13 +22,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a field to be transient for the mapping framework. Thus the property will not be persisted and not further
- * inspected by the mapping framework.
+ * Marks a field to be transient for the mapping framework. Thus, the property will not be persisted.
+ * <p>
+ * Excluding properties from the persistence mechanism is separate from Java's {@code transient} keyword that serves the
+ * purpose of excluding properties from being serialized through Java Serialization.
+ * <p>
+ * Transient properties can be used in {@link PersistenceCreator constructor creation/factory methods}, however they
+ * will use Java default values. We highly recommend using {@link org.springframework.beans.factory.annotation.Value
+ * SpEL expressions through @Value(…)} to provide a meaningful value.
  *
  * @author Oliver Gierke
  * @author Jon Brisbin
+ * @author Mark Paluch
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = { FIELD, METHOD, ANNOTATION_TYPE })
+@Target(value = { FIELD, METHOD, ANNOTATION_TYPE, RECORD_COMPONENT })
 public @interface Transient {
 }

--- a/src/main/java/org/springframework/data/mapping/PersistentEntity.java
+++ b/src/main/java/org/springframework/data/mapping/PersistentEntity.java
@@ -47,9 +47,9 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	 * Returns the {@link PreferredConstructor} to be used to instantiate objects of this {@link PersistentEntity}.
 	 *
 	 * @return {@literal null} in case no suitable constructor for automatic construction can be found. This usually
-	 *         indicates that the instantiation of the object of that persistent entity is done through either a
-	 *         customer {@link org.springframework.data.mapping.model.EntityInstantiator} or handled by custom
-	 *         conversion mechanisms entirely.
+	 *         indicates that the instantiation of the object of that persistent entity is done through either a customer
+	 *         {@link org.springframework.data.mapping.model.EntityInstantiator} or handled by custom conversion
+	 *         mechanisms entirely.
 	 * @deprecated since 3.0, use {@link #getInstanceCreatorMetadata()}.
 	 */
 	@Nullable
@@ -61,8 +61,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	 *
 	 * @return {@literal null} in case no suitable creation mechanism for automatic construction can be found. This
 	 *         usually indicates that the instantiation of the object of that persistent entity is done through either a
-	 *         customer {@link org.springframework.data.mapping.model.EntityInstantiator} or handled by custom
-	 *         conversion mechanisms entirely.
+	 *         customer {@link org.springframework.data.mapping.model.EntityInstantiator} or handled by custom conversion
+	 *         mechanisms entirely.
 	 * @since 3.0
 	 */
 	@Nullable
@@ -136,8 +136,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	}
 
 	/**
-	 * Returns the version property of the {@link PersistentEntity}. Can be {@literal null} in case no version property
-	 * is available on the entity.
+	 * Returns the version property of the {@link PersistentEntity}. Can be {@literal null} in case no version property is
+	 * available on the entity.
 	 *
 	 * @return the version property of the {@link PersistentEntity}.
 	 */
@@ -145,8 +145,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	P getVersionProperty();
 
 	/**
-	 * Returns the version property of the {@link PersistentEntity}. Can be {@literal null} in case no version property
-	 * is available on the entity.
+	 * Returns the version property of the {@link PersistentEntity}. Can be {@literal null} in case no version property is
+	 * available on the entity.
 	 *
 	 * @return the version property of the {@link PersistentEntity}.
 	 * @throws IllegalStateException if {@link PersistentEntity} does not define a {@literal version} property.
@@ -166,7 +166,7 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	/**
 	 * Obtains a {@link PersistentProperty} instance by name.
 	 *
-	 * @param name The name of the property. Can be {@literal null}.
+	 * @param name the name of the property. Can be {@literal null}.
 	 * @return the {@link PersistentProperty} or {@literal null} if it doesn't exist.
 	 */
 	@Nullable
@@ -214,6 +214,28 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	Iterable<P> getPersistentProperties(Class<? extends Annotation> annotationType);
 
 	/**
+	 * Obtains a transient {@link PersistentProperty} instance by name. You can check with {@link #isTransient(String)}
+	 * whether there is a transient property before calling this method.
+	 *
+	 * @param name the name of the property. Can be {@literal null}.
+	 * @return the {@link PersistentProperty} or {@literal null} if it doesn't exist.
+	 * @since 3.3
+	 * @see #isTransient(String)
+	 */
+	@Nullable
+	P getTransientProperty(String name);
+
+	/**
+	 * Returns whether the property is transient.
+	 *
+	 * @param property name of the property.
+	 * @return {@code true} if the property is transient. Applies only for existing properties. {@code false} if the
+	 *         property does not exist or is not transient.
+	 * @since 3.3
+	 */
+	boolean isTransient(String property);
+
+	/**
 	 * Returns whether the {@link PersistentEntity} has an id property. If this call returns {@literal true},
 	 * {@link #getIdProperty()} will return a non-{@literal null} value.
 	 *
@@ -237,8 +259,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	Class<T> getType();
 
 	/**
-	 * Returns the alias to be used when storing type information. Might be {@literal null} to indicate that there was
-	 * no alias defined through the mapping metadata.
+	 * Returns the alias to be used when storing type information. Might be {@literal null} to indicate that there was no
+	 * alias defined through the mapping metadata.
 	 *
 	 * @return
 	 */
@@ -268,8 +290,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	void doWithProperties(SimplePropertyHandler handler);
 
 	/**
-	 * Applies the given {@link AssociationHandler} to all {@link Association} contained in this
-	 * {@link PersistentEntity}. The iteration order is undefined.
+	 * Applies the given {@link AssociationHandler} to all {@link Association} contained in this {@link PersistentEntity}.
+	 * The iteration order is undefined.
 	 *
 	 * @param handler must not be {@literal null}.
 	 */
@@ -284,8 +306,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	void doWithAssociations(SimpleAssociationHandler handler);
 
 	/**
-	 * Applies the given {@link PropertyHandler} to both all {@link PersistentProperty}s as well as all inverse
-	 * properties of all {@link Association}s. The iteration order is undefined.
+	 * Applies the given {@link PropertyHandler} to both all {@link PersistentProperty}s as well as all inverse properties
+	 * of all {@link Association}s. The iteration order is undefined.
 	 *
 	 * @param handler must not be {@literal null}.
 	 * @since 2.5
@@ -370,7 +392,7 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	 *
 	 * @param bean must not be {@literal null}.
 	 * @throws IllegalArgumentException in case the given bean is not an instance of the typ represented by the
-	 *             {@link PersistentEntity}.
+	 *           {@link PersistentEntity}.
 	 * @return whether the given bean is considered a new instance.
 	 */
 	boolean isNew(Object bean);
@@ -386,8 +408,8 @@ public interface PersistentEntity<T, P extends PersistentProperty<P>> extends It
 	boolean isImmutable();
 
 	/**
-	 * Returns whether the entity needs properties to be populated, i.e. if any property exists that's not initialized
-	 * by the constructor.
+	 * Returns whether the entity needs properties to be populated, i.e. if any property exists that's not initialized by
+	 * the constructor.
 	 *
 	 * @return
 	 * @since 2.1

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
@@ -562,10 +561,6 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 		private void createAndRegisterProperty(Property input) {
 
 			P property = createPersistentProperty(input, entity, simpleTypeHolder);
-
-			if (property.isTransient()) {
-				return;
-			}
 
 			if (!input.isFieldBacked() && !property.usePropertyAccess()) {
 				return;

--- a/src/main/java/org/springframework/data/mapping/model/AnnotationBasedPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AnnotationBasedPersistentProperty.java
@@ -37,7 +37,6 @@ import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
-import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.Optionals;
 import org.springframework.data.util.ReflectionUtils;
@@ -197,10 +196,12 @@ public abstract class AnnotationBasedPersistentProperty<P extends PersistentProp
 		return isTransient.get();
 	}
 
+	@Override
 	public boolean isIdProperty() {
 		return isId.get();
 	}
 
+	@Override
 	public boolean isVersionProperty() {
 		return isVersion.get();
 	}
@@ -226,6 +227,7 @@ public abstract class AnnotationBasedPersistentProperty<P extends PersistentProp
 	 * @param annotationType must not be {@literal null}.
 	 * @return {@literal null} if annotation type not found on property.
 	 */
+	@Override
 	@Nullable
 	public <A extends Annotation> A findAnnotation(Class<A> annotationType) {
 
@@ -262,11 +264,12 @@ public abstract class AnnotationBasedPersistentProperty<P extends PersistentProp
 	}
 
 	/**
-	 * Returns whether the property carries the an annotation of the given type.
+	 * Returns whether the property carries the annotation of the given type.
 	 *
 	 * @param annotationType the annotation type to look up.
-	 * @return
+	 * @return {@literal true} if the annotation is present, {@literal false} otherwise.
 	 */
+	@Override
 	public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
 		return doFindAnnotation(annotationType).isPresent();
 	}

--- a/src/main/java/org/springframework/data/mapping/model/KotlinValueUtils.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinValueUtils.java
@@ -287,7 +287,7 @@ class KotlinValueUtils {
 		}
 
 		/**
-		 * @return {@code true} if the value hierarchy applies boxing.
+		 * @return {@literal true} if the value hierarchy applies boxing.
 		 */
 		public boolean appliesBoxing() {
 			return applyBoxing;

--- a/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
+++ b/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
@@ -42,7 +42,7 @@ public class PersistentEntityParameterValueProvider<P extends PersistentProperty
 	private final @Nullable Object parent;
 
 	public PersistentEntityParameterValueProvider(PersistentEntity<?, P> entity, PropertyValueProvider<P> provider,
-			Object parent) {
+			@Nullable Object parent) {
 		this.entity = entity;
 		this.provider = provider;
 		this.parent = parent;
@@ -53,6 +53,7 @@ public class PersistentEntityParameterValueProvider<P extends PersistentProperty
 		return parameterType.isPrimitive() ? ReflectionUtils.getPrimitiveDefault(parameterType) : null;
 	}
 
+	@Override
 	@Nullable
 	@SuppressWarnings("unchecked")
 	public <T> T getParameterValue(Parameter<T, P> parameter) {

--- a/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
+++ b/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
@@ -21,16 +21,18 @@ import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.Parameter;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.util.ReflectionUtils;
 import org.springframework.lang.Nullable;
 
 /**
- * {@link ParameterValueProvider} based on a {@link PersistentEntity} to use a {@link PropertyValueProvider} to lookup
- * the value of the property referenced by the given {@link Parameter}. Additionally a
+ * {@link ParameterValueProvider} based on a {@link PersistentEntity} to use a {@link PropertyValueProvider} to look up
+ * the value of the property referenced by the given {@link Parameter}. Additionally, a
  * {@link DefaultSpELExpressionEvaluator} can be configured to get property value resolution trumped by a SpEL
  * expression evaluation.
  *
  * @author Oliver Gierke
  * @author Johannes Englmeier
+ * @author Mark Paluch
  */
 public class PersistentEntityParameterValueProvider<P extends PersistentProperty<P>>
 		implements ParameterValueProvider<P> {
@@ -47,23 +49,24 @@ public class PersistentEntityParameterValueProvider<P extends PersistentProperty
 	}
 
 	@Nullable
+	private static Object getTransientDefault(Class<?> parameterType) {
+		return parameterType.isPrimitive() ? ReflectionUtils.getPrimitiveDefault(parameterType) : null;
+	}
+
+	@Nullable
 	@SuppressWarnings("unchecked")
 	public <T> T getParameterValue(Parameter<T, P> parameter) {
 
 		InstanceCreatorMetadata<P> creator = entity.getInstanceCreatorMetadata();
+		String name = parameter.getName();
 
 		if (creator != null && creator.isParentParameter(parameter)) {
 			return (T) parent;
 		}
 
-		if (parameter.getAnnotations().isPresent(Transient.class)) {
-
-			// parameter.getRawType().isPrimitive()
-			return null;
-
+		if (parameter.getAnnotations().isPresent(Transient.class) || (name != null && entity.isTransient(name))) {
+			return (T) getTransientDefault(parameter.getRawType());
 		}
-
-		String name = parameter.getName();
 
 		if (name == null) {
 			throw new MappingException(String.format("Parameter %s does not have a name", parameter));

--- a/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
+++ b/src/main/java/org/springframework/data/mapping/model/PersistentEntityParameterValueProvider.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.mapping.model;
 
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.mapping.InstanceCreatorMetadata;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.Parameter;
@@ -53,6 +54,13 @@ public class PersistentEntityParameterValueProvider<P extends PersistentProperty
 
 		if (creator != null && creator.isParentParameter(parameter)) {
 			return (T) parent;
+		}
+
+		if (parameter.getAnnotations().isPresent(Transient.class)) {
+
+			// parameter.getRawType().isPrimitive()
+			return null;
+
 		}
 
 		String name = parameter.getName();

--- a/src/test/java/org/springframework/data/mapping/model/BasicPersistentEntityUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/BasicPersistentEntityUnitTests.java
@@ -31,6 +31,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -105,8 +107,7 @@ class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 	@SuppressWarnings("unchecked")
 	void considersComparatorForPropertyOrder() {
 
-		var entity = createEntity(Person.class,
-				Comparator.comparing(PersistentProperty::getName));
+		var entity = createEntity(Person.class, Comparator.comparing(PersistentProperty::getName));
 
 		var lastName = (T) Mockito.mock(PersistentProperty.class);
 		when(lastName.getName()).thenReturn("lastName");
@@ -198,8 +199,8 @@ class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 		assertThat(accessor).isNotInstanceOf(BeanWrapper.class);
 		assertThat(accessor).isInstanceOfSatisfying(InstantiationAwarePropertyAccessor.class, it -> {
 
-			var delegateFunction = (Function<Object, PersistentPropertyAccessor<Object>>) ReflectionTestUtils
-					.getField(it, "delegateFunction");
+			var delegateFunction = (Function<Object, PersistentPropertyAccessor<Object>>) ReflectionTestUtils.getField(it,
+					"delegateFunction");
 
 			var delegate = delegateFunction.apply(value);
 			assertThat(delegate.getClass().getName()).contains("_Accessor_");
@@ -359,6 +360,18 @@ class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 				.forEach(it -> assertThat(createPopulatedPersistentEntity(it).requiresPropertyPopulation()).isFalse());
 	}
 
+	@ParameterizedTest // GH-1432
+	@ValueSource(classes = { WithTransient.class, RecordWithTransient.class, DataClassWithTransientProperty.class })
+	void includesTransientProperty(Class<?> classUnderTest) {
+
+		PersistentEntity<Object, ?> entity = createPopulatedPersistentEntity(classUnderTest);
+
+		assertThat(entity).extracting(PersistentProperty::getName).hasSize(1).containsOnly("firstname");
+		assertThat(entity.isTransient("firstname")).isFalse();
+		assertThat(entity.isTransient("lastname")).isTrue();
+		assertThat(entity.getTransientProperty("lastname").getName()).isEqualTo("lastname");
+	}
+
 	@Test // #2325
 	void doWithAllInvokesPropertyHandlerForBothAPropertiesAndAssociations() {
 
@@ -475,6 +488,17 @@ class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 		}
 	}
 
+	private static class WithTransient {
+
+		String firstname;
+		@Transient String lastname;
+
+	}
+
+	record RecordWithTransient(String firstname, @Transient String lastname) {
+
+	}
+
 	// #2325
 
 	static class WithAssociation {
@@ -482,4 +506,5 @@ class BasicPersistentEntityUnitTests<T extends PersistentProperty<T>> {
 		String property;
 		@Reference WithAssociation association;
 	}
+
 }

--- a/src/test/java/org/springframework/data/mapping/model/EntityInstantiatorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/mapping/model/EntityInstantiatorIntegrationTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.mapping.context.SampleMappingContext;
+import org.springframework.data.mapping.context.SamplePersistentProperty;
+
+/**
+ * Integration tests for {@link EntityInstantiator}.
+ *
+ * @author Mark Paluch
+ */
+public class EntityInstantiatorIntegrationTests {
+
+	SampleMappingContext context = new SampleMappingContext();
+	EntityInstantiators instantiators = new EntityInstantiators();
+
+	@Test // GH-2942
+	void shouldDefaultTransientProperties() {
+
+		WithTransientProperty instance = createInstance(WithTransientProperty.class);
+
+		assertThat(instance.foo).isEqualTo(null);
+		assertThat(instance.bar).isEqualTo(0);
+	}
+
+	@Test // GH-2942
+	void shouldDefaultTransientRecordProperties() {
+
+		RecordWithTransientProperty instance = createInstance(RecordWithTransientProperty.class);
+
+		assertThat(instance.foo).isEqualTo(null);
+		assertThat(instance.bar).isEqualTo(0);
+	}
+
+	@Test // GH-2942
+	void shouldDefaultTransientKotlinProperty() {
+
+		DataClassWithTransientProperties instance = createInstance(DataClassWithTransientProperties.class);
+
+		// Kotlin defaulting
+		assertThat(instance.getFoo()).isEqualTo("foo");
+
+		// Our defaulting
+		assertThat(instance.getBar()).isEqualTo(0);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <E> E createInstance(Class<E> entityType) {
+
+		var entity = context.getRequiredPersistentEntity(entityType);
+		var instantiator = instantiators.getInstantiatorFor(entity);
+
+		return (E) instantiator.createInstance(entity,
+				new PersistentEntityParameterValueProvider<>(entity, new PropertyValueProvider<SamplePersistentProperty>() {
+					@Override
+					public <T> T getPropertyValue(SamplePersistentProperty property) {
+						return null;
+					}
+				}, null));
+	}
+
+	static class WithTransientProperty {
+
+		@Transient String foo;
+		@Transient int bar;
+
+		public WithTransientProperty(String foo, int bar) {
+
+		}
+	}
+
+	record RecordWithTransientProperty(@Transient String foo, @Transient int bar) {
+
+	}
+
+}

--- a/src/test/kotlin/org/springframework/data/mapping/model/DataClasses.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/DataClasses.kt
@@ -16,6 +16,7 @@
 package org.springframework.data.mapping.model
 
 import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Transient
 import java.time.LocalDateTime
 
 /**
@@ -32,6 +33,10 @@ data class ExtendedDataClassKt(val id: Long, val name: String) {
 data class SingleSettableProperty constructor(val id: Double = Math.random()) {
 	val version: Int? = null
 }
+
+// note: Kotlin ships also a @Transient annotation to indicate JVM's transient keyword.
+data class DataClassWithTransientProperty(val firstname: String, @Transient val lastname: String)
+data class DataClassWithTransientProperties(@Transient val foo: String = "foo", @Transient val bar: Int)
 
 data class WithCustomCopyMethod(
 	val id: String?,


### PR DESCRIPTION
We now maintain `@Transient` metadata in the mapping model to determine whether a transient property has been used in a Kotlin Data class, Record or plain Java class. 


```java
record MyRecord(String firstname, @Transient String lastname) {
}
```

```kotlin
data class MyDataClass(@Transient val firstname: String = "foo", @Transient val age: Int)
```

Entity instantiation populates properties with default values (`null` for object types, or primitive default values) so that Kotlin data classes can use defaulting.

Closes #1432 
Closes #2942