### PR TITLE
Exclude "entries" property from bean info for kotlin enum class

### DIFF
--- a/src/main/java/org/springframework/data/util/KotlinBeanInfoFactory.java
+++ b/src/main/java/org/springframework/data/util/KotlinBeanInfoFactory.java
@@ -39,6 +39,7 @@ import org.springframework.core.Ordered;
  * {@link BeanInfoFactory} specific to Kotlin types using Kotlin reflection to determine bean properties.
  *
  * @author Mark Paluch
+ * @author Yanming Zhou
  * @since 3.2
  * @see JvmClassMappingKt
  * @see ReflectJvmMapping
@@ -63,6 +64,12 @@ public class KotlinBeanInfoFactory implements BeanInfoFactory, Ordered {
 		for (KCallable<?> member : kotlinClass.getMembers()) {
 
 			if (member instanceof KProperty<?> property) {
+
+				// Kotlin introduce auto-generated "entries" property for enum class since 1.8.20 and stable from 1.9.0
+				// see https://youtrack.jetbrains.com/issue/KT-48872
+				if (beanClass.isEnum() && property.getName().equals("entries")) {
+					continue;
+				}
 
 				Method getter = ReflectJvmMapping.getJavaGetter(property);
 				Method setter = property instanceof KMutableProperty<?> kmp ? ReflectJvmMapping.getJavaSetter(kmp) : null;

--- a/src/test/kotlin/org/springframework/data/util/KotlinBeanInfoFactoryUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/util/KotlinBeanInfoFactoryUnitTests.kt
@@ -22,6 +22,7 @@ import org.springframework.beans.BeanUtils
 /**
  * Unit tests for [KotlinBeanInfoFactory].
  * @author Mark Paluch
+ * @author Yanming Zhou
  */
 class KotlinBeanInfoFactoryUnitTests {
 
@@ -73,6 +74,14 @@ class KotlinBeanInfoFactoryUnitTests {
 		assertThat(pds).hasSize(1).extracting("name").containsOnly("firstname")
 	}
 
+	@Test // GH-2990
+	internal fun determinesEnumClassProperties() {
+
+		val pds = BeanUtils.getPropertyDescriptors(Gender::class.java)
+
+		assertThat(pds).extracting("name").containsOnly("value", "name", "ordinal");
+	}
+
 	data class SimpleDataClass(val id: String, var name: String)
 
 	@JvmInline
@@ -86,4 +95,7 @@ class KotlinBeanInfoFactoryUnitTests {
 		fun getFirstname(): String
 	}
 
+	enum class Gender(val value: Int) {
+		Male(0), FEMALE(1)
+	}
 }


### PR DESCRIPTION
Fix GH-2990