### PR TITLE
Introduce `@Lookup` methods on repository

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/RepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/RepositoryInformation.java
@@ -23,6 +23,7 @@ import org.springframework.data.util.Streamable;
  * Additional repository specific information
  *
  * @author Oliver Gierke
+ * @author Yanming Zhou
  */
 public interface RepositoryInformation extends RepositoryMetadata {
 
@@ -50,6 +51,16 @@ public interface RepositoryInformation extends RepositoryMetadata {
 	 * @return
 	 */
 	boolean isQueryMethod(Method method);
+
+	/**
+	 * Returns whether the given method is a lookup method.
+	 *
+	 * @param method
+	 * @return
+	 */
+	default boolean isLookupMethod(Method method) {
+		return false;
+	}
 
 	/**
 	 * Returns all methods considered to be query methods.

--- a/src/main/java/org/springframework/data/repository/core/RepositoryInformationSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/RepositoryInformationSupport.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import org.springframework.beans.factory.annotation.Lookup;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.annotation.QueryAnnotation;
 import org.springframework.data.util.Lazy;
@@ -37,6 +38,7 @@ import org.springframework.util.ClassUtils;
  * repository base to the latest possible time.
  *
  * @author Christoph Strobl
+ * @author Yanming Zhou
  * @since 3.0
  */
 public abstract class RepositoryInformationSupport implements RepositoryInformation {
@@ -128,6 +130,11 @@ public abstract class RepositoryInformationSupport implements RepositoryInformat
 	}
 
 	@Override
+	public boolean isLookupMethod(Method method) {
+		return AnnotationUtils.findAnnotation(method, Lookup.class) != null;
+	}
+
+	@Override
 	public TypeInformation<?> getDomainTypeInformation() {
 		return getMetadata().getDomainTypeInformation();
 	}
@@ -176,6 +183,7 @@ public abstract class RepositoryInformationSupport implements RepositoryInformat
 	protected boolean isQueryMethodCandidate(Method method) {
 		return !method.isBridge() && !method.isDefault() //
 				&& !Modifier.isStatic(method.getModifiers()) //
+				&& !isLookupMethod(method) //
 				&& (isQueryAnnotationPresentOn(method) || !isCustomMethod(method) && !isBaseClassMethod(method));
 	}
 }

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactorySupport.java
@@ -81,6 +81,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jens Schauder
  * @author John Blum
  * @author Johannes Englmeier
+ * @author Yanming Zhou
  */
 public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, BeanFactoryAware {
 
@@ -354,7 +355,7 @@ public abstract class RepositoryFactorySupport implements BeanClassLoaderAware, 
 
 		Optional<QueryLookupStrategy> queryLookupStrategy = getQueryLookupStrategy(queryLookupStrategyKey,
 				evaluationContextProvider);
-		result.addAdvice(new QueryExecutorMethodInterceptor(information, getProjectionFactory(), queryLookupStrategy,
+		result.addAdvice(new QueryExecutorMethodInterceptor(beanFactory, information, getProjectionFactory(), queryLookupStrategy,
 				namedQueries, queryPostProcessors, methodInvocationListeners));
 
 		result.addAdvice(

--- a/src/test/java/org/springframework/data/repository/config/LookupRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/config/LookupRepositoryIntegrationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.mapping.Person;
+import org.springframework.data.repository.CrudRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for @Lookup.
+ *
+ * @author Yanming Zhou
+ */
+class LookupRepositoryIntegrationTests {
+
+	@Test
+	void lookupBeansFromBeanFactory() {
+
+		var context = new AnnotationConfigApplicationContext(Config.class);
+		var repository = context.getBean(PersonRepository.class);
+		assertThat(repository.getSelf()).isEqualTo(repository);
+	}
+
+	@Configuration
+	@EnableRepositories(considerNestedRepositories = true, //
+			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = PersonRepository.class))
+	static class Config {}
+
+
+	interface PersonRepository extends CrudRepository<Person, Long> {
+
+		@Lookup
+		PersonRepository getSelf();
+	}
+
+}

--- a/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DefaultRepositoryInformationUnitTests.java
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Lookup;
 import org.springframework.data.annotation.QueryAnnotation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,6 +53,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Johannes Englmeier
+ * @author Yanming Zhou
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -272,6 +274,17 @@ class DefaultRepositoryInformationUnitTests {
 		assertThat(information.isCustomMethod(customBaseRepositoryMethod)).isTrue();
 	}
 
+	@Test
+	void discoversLookupMethods() throws Exception {
+
+		RepositoryMetadata metadata = new DefaultRepositoryMetadata(DummyRepository.class);
+		RepositoryInformation information = new DefaultRepositoryInformation(metadata, RepositoryFactorySupport.class,
+				RepositoryComposition.empty());
+
+		var lookupMethod = DummyRepository.class.getMethod("getSelf");
+		assertThat(information.isLookupMethod(lookupMethod)).isTrue();
+	}
+
 	private static Method getMethodFrom(Class<?> type, String name) {
 
 		return Arrays.stream(type.getMethods())//
@@ -392,6 +405,9 @@ class DefaultRepositoryInformationUnitTests {
 
 		@Override
 		<S extends User> List<S> saveAll(Iterable<S> entites);
+
+		@Lookup
+		DummyRepository getSelf();
 	}
 
 	static class DummyRepositoryImpl<T, ID> implements CrudRepository<T, ID> {

--- a/src/test/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptorUnitTests.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.query.QueryLookupStrategy;
@@ -35,6 +37,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Yanming Zhou
  */
 @ExtendWith(MockitoExtension.class)
 class QueryExecutorMethodInterceptorUnitTests {
@@ -42,20 +45,23 @@ class QueryExecutorMethodInterceptorUnitTests {
 	@Mock RepositoryInformation information;
 	@Mock QueryLookupStrategy strategy;
 
+	@Autowired
+	BeanFactory beanFactory;
+
 	@Test // DATACMNS-1508
 	void rejectsRepositoryInterfaceWithQueryMethodsIfNoQueryLookupStrategyIsDefined() {
 
 		when(information.hasQueryMethods()).thenReturn(true);
 
 		assertThatIllegalStateException()
-				.isThrownBy(() -> new QueryExecutorMethodInterceptor(information, new SpelAwareProxyProjectionFactory(),
+				.isThrownBy(() -> new QueryExecutorMethodInterceptor(beanFactory, information, new SpelAwareProxyProjectionFactory(),
 						Optional.empty(), PropertiesBasedNamedQueries.EMPTY, Collections.emptyList(), Collections.emptyList()));
 	}
 
 	@Test // DATACMNS-1508
 	void skipsQueryLookupsIfQueryLookupStrategyIsNotPresent() {
 
-		new QueryExecutorMethodInterceptor(information, new SpelAwareProxyProjectionFactory(), Optional.empty(),
+		new QueryExecutorMethodInterceptor(beanFactory, information, new SpelAwareProxyProjectionFactory(), Optional.empty(),
 				PropertiesBasedNamedQueries.EMPTY, Collections.emptyList(), Collections.emptyList());
 
 		verify(strategy, times(0)).resolveQuery(any(), any(), any(), any());


### PR DESCRIPTION
After this commit, we could lookup beans from BeanFactory and use them in default methods.

```java
interface FooRepository extends CrudRepository<Foo, Long> {

	default void doSomething(Long fooId, Long barId) {
		Optional<Foo> foo = findById(fooId);
		Optional<Bar> bar = barRepository().findById(barId);
		//TODO do something with foo and bar
	}

	@Lookup
	BarRepository barRepository();
}
```

```java
interface BarRepository extends CrudRepository<Bar, Long> {

}
```