### PR TITLE
Fallback to default fragment implementation if no candidates found

### DIFF
--- a/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultImplementationLookupConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.util.ClassUtils;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Kyrylo Merzlikin
+ * @author Yanming Zhou
  * @since 2.1
  */
 class DefaultImplementationLookupConfiguration implements ImplementationLookupConfiguration {
@@ -51,6 +52,10 @@ class DefaultImplementationLookupConfiguration implements ImplementationLookupCo
 		this.config = config;
 		this.interfaceName = interfaceName;
 		this.beanName = beanName;
+	}
+
+	public String getInterfaceName() {
+		return this.interfaceName;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/repository/config/DefaultFragmentImplementationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/config/DefaultFragmentImplementationIntegrationTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mapping.Child;
+import org.springframework.data.repository.config.app.ChildRepository;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Yanming Zhou
+ */
+class DefaultFragmentImplementationIntegrationTests {
+
+	@Test
+	void defaultFragmentImplementationIsUsing() {
+
+		var context = new AnnotationConfigApplicationContext(Config.class);
+
+		assertThatThrownBy(() -> context.getBean(ChildRepository.class).extensionMethod(new Child(1, "", "")))
+				.isInstanceOf(UnsupportedOperationException.class).hasMessage("Not Implemented");
+	}
+
+	@Configuration
+	@EnableRepositories(basePackageClasses = ChildRepository.class)
+	static class Config {}
+
+}

--- a/src/test/java/org/springframework/data/repository/config/app/ChildRepository.java
+++ b/src/test/java/org/springframework/data/repository/config/app/ChildRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.app;
+
+import org.springframework.data.mapping.Child;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.config.lib.MyExtension;
+
+/**
+ * @author Yanming Zhou
+ */
+public interface ChildRepository extends CrudRepository<Child, String>, MyExtension<Child> {}

--- a/src/test/java/org/springframework/data/repository/config/lib/MyExtension.java
+++ b/src/test/java/org/springframework/data/repository/config/lib/MyExtension.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.lib;
+
+/**
+ * @author Yanming Zhou
+ */
+public interface MyExtension<T> {
+
+	void extensionMethod(T entity);
+}

--- a/src/test/java/org/springframework/data/repository/config/lib/MyExtensionImpl.java
+++ b/src/test/java/org/springframework/data/repository/config/lib/MyExtensionImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config.lib;
+
+/**
+ * @author Yanming Zhou
+ */
+public class MyExtensionImpl<T> implements MyExtension<T> {
+
+	@Override
+	public void extensionMethod(T entity) {
+		throw new UnsupportedOperationException("Not Implemented");
+	}
+}


### PR DESCRIPTION
It's an enhancement that should not break existing behaviors.

The default implementation is `$FragmentInterfaceName + $ImplementationPostfix`, for example `com.example.FragmentImpl` is the default implementation of `com.example.Fragment`.

It's useful for sharing repository fragments as library, application doesn't have to include library package in `@Enable…Repositories`, and it will back off if application provides custom implementation.

See https://github.com/spring-projects/spring-data-jpa/issues/3287
