### PR TITLE
Add missing runtime hit for Unpaged required by PageModule. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.2.3-SNAPSHOT</version>
+	<version>3.2.x-3025-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/web/aot/hint/WebRuntimeHints.java
+++ b/src/main/java/org/springframework/data/web/aot/hint/WebRuntimeHints.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web.aot.hint;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.data.web.config.SpringDataJacksonConfiguration.PageModule;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Christoph Strobl
+ * @since 3.2.3
+ */
+public class WebRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+
+		hints.reflection().registerType(TypeReference.of("org.springframework.data.domain.Unpaged"), hint -> {
+			hint.onReachableType(PageModule.class);
+		});
+	}
+}

--- a/src/main/java/org/springframework/data/web/config/SpringDataJacksonConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/SpringDataJacksonConfiguration.java
@@ -15,19 +15,13 @@
  */
 package org.springframework.data.web.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.geo.GeoModule;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase;
-import com.fasterxml.jackson.databind.util.StdConverter;
 
 /**
  * JavaConfig class to export Jackson specific configuration.

--- a/src/main/resources/META-INF/spring/aot.factories
+++ b/src/main/resources/META-INF/spring/aot.factories
@@ -3,7 +3,8 @@ org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=\
 
 org.springframework.aot.hint.RuntimeHintsRegistrar=\
 	org.springframework.data.repository.aot.hint.RepositoryRuntimeHints,\
-	org.springframework.data.querydsl.aot.QuerydslHints
+	org.springframework.data.querydsl.aot.QuerydslHints,\
+	org.springframework.data.web.aot.hint.WebRuntimeHints
 
 org.springframework.beans.factory.aot.BeanRegistrationAotProcessor=\
     org.springframework.data.aot.AuditingBeanRegistrationAotProcessor


### PR DESCRIPTION
The `PageModule` is loading the `Unpaged` type via its name which requires additional reflection configuration for native images.

Fixes: #3025 

----

Should be forward ported to _main_ as well.
