### PR TITLE
Default generic type arguments when resolving KType for Class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.x-3041-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/model/KotlinValueUtils.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinValueUtils.java
@@ -30,9 +30,9 @@ import kotlin.reflect.jvm.ReflectJvmMapping;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -94,8 +94,9 @@ class KotlinValueUtils {
 
 	private static KTypeProjection[] stubKTypeProjections(KClass<?> kotlinClass) {
 
-		return IntStream.range(0, kotlinClass.getTypeParameters().size()).mapToObj(it -> KTypeProjection.star)
-				.toArray(KTypeProjection[]::new);
+		KTypeProjection[] kTypeProjections = new KTypeProjection[kotlinClass.getTypeParameters().size()];
+		Arrays.fill(kTypeProjections, KTypeProjection.star);
+		return kTypeProjections;
 	}
 
 	/**


### PR DESCRIPTION
We now fill up missing `KTypeProjection` arguments with `star` because the Kotlin `Reflection.typeOf` resolution fails if arguments are not provided.

Resolves: #3041 