### PR TITLE
Add `ValueExpression` infrastructure for query methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3049-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/expression/CompositeValueExpression.java
+++ b/src/main/java/org/springframework/data/expression/CompositeValueExpression.java
@@ -72,4 +72,10 @@ record CompositeValueExpression(String raw, List<ValueExpression> expressions) i
 
 		return builder.toString();
 	}
+
+	@Override
+	public Class<?> getValueType(ValueEvaluationContext context) {
+		return String.class;
+	}
+
 }

--- a/src/main/java/org/springframework/data/expression/DefaultValueEvaluationContext.java
+++ b/src/main/java/org/springframework/data/expression/DefaultValueEvaluationContext.java
@@ -17,6 +17,7 @@ package org.springframework.data.expression;
 
 import org.springframework.core.env.Environment;
 import org.springframework.expression.EvaluationContext;
+import org.springframework.lang.Nullable;
 
 /**
  * Default {@link ValueEvaluationContext}.
@@ -24,7 +25,7 @@ import org.springframework.expression.EvaluationContext;
  * @author Mark Paluch
  * @since 3.3
  */
-record DefaultValueEvaluationContext(Environment environment,
+record DefaultValueEvaluationContext(@Nullable Environment environment,
 		EvaluationContext evaluationContext) implements ValueEvaluationContext {
 
 	@Override

--- a/src/main/java/org/springframework/data/expression/DefaultValueExpressionParser.java
+++ b/src/main/java/org/springframework/data/expression/DefaultValueExpressionParser.java
@@ -22,6 +22,7 @@ import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParseException;
 import org.springframework.expression.ParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.util.Assert;
 import org.springframework.util.SystemPropertyUtils;
 
@@ -38,6 +39,8 @@ class DefaultValueExpressionParser implements ValueExpressionParser {
 	public static final char SUFFIX = '}';
 	public static final int PLACEHOLDER_PREFIX_LENGTH = PLACEHOLDER_PREFIX.length();
 	public static final char[] QUOTE_CHARS = { '\'', '"' };
+
+	public static final ValueExpressionParser DEFAULT = new DefaultValueExpressionParser(SpelExpressionParser::new);
 
 	private final ValueParserConfiguration configuration;
 

--- a/src/main/java/org/springframework/data/expression/ExpressionExpression.java
+++ b/src/main/java/org/springframework/data/expression/ExpressionExpression.java
@@ -47,9 +47,14 @@ record ExpressionExpression(Expression expression, ExpressionDependencies depend
 	public Object evaluate(ValueEvaluationContext context) {
 
 		EvaluationContext evaluationContext = context.getEvaluationContext();
-		if (evaluationContext != null) {
-			return expression.getValue(evaluationContext);
-		}
-		return expression.getValue();
+		return evaluationContext != null ? expression.getValue(evaluationContext) : expression.getValue();
 	}
+
+	@Override
+	public Class<?> getValueType(ValueEvaluationContext context) {
+
+		EvaluationContext evaluationContext = context.getEvaluationContext();
+		return evaluationContext != null ? expression.getValueType(evaluationContext) : expression.getValueType();
+	}
+
 }

--- a/src/main/java/org/springframework/data/expression/LiteralValueExpression.java
+++ b/src/main/java/org/springframework/data/expression/LiteralValueExpression.java
@@ -39,4 +39,9 @@ record LiteralValueExpression(String expression) implements ValueExpression {
 		return expression;
 	}
 
+	@Override
+	public Class<?> getValueType(ValueEvaluationContext context) {
+		return String.class;
+	}
+
 }

--- a/src/main/java/org/springframework/data/expression/PlaceholderExpression.java
+++ b/src/main/java/org/springframework/data/expression/PlaceholderExpression.java
@@ -38,7 +38,7 @@ record PlaceholderExpression(String expression) implements ValueExpression {
 	}
 
 	@Override
-	public Object evaluate(ValueEvaluationContext context) {
+	public String evaluate(ValueEvaluationContext context) {
 
 		Environment environment = context.getEnvironment();
 		if (environment != null) {
@@ -49,6 +49,11 @@ record PlaceholderExpression(String expression) implements ValueExpression {
 			}
 		}
 		return expression;
+	}
+
+	@Override
+	public Class<?> getValueType(ValueEvaluationContext context) {
+		return String.class;
 	}
 
 }

--- a/src/main/java/org/springframework/data/expression/ReactiveValueEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/expression/ReactiveValueEvaluationContextProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.expression;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.data.spel.ExpressionDependencies;
+import org.springframework.lang.Nullable;
+
+/**
+ * Reactive extension to {@link ValueEvaluationContext} for obtaining a {@link ValueEvaluationContext} that participates
+ * in the reactive flow.
+ *
+ * @author Mark Paluch
+ * @since 3.4
+ */
+public interface ReactiveValueEvaluationContextProvider extends ValueEvaluationContextProvider {
+
+	/**
+	 * Return a {@link ValueEvaluationContext} built using the given parameter values.
+	 *
+	 * @param rootObject the root object to set in the {@link ValueEvaluationContext}.
+	 * @return a mono that emits exactly one {@link ValueEvaluationContext}.
+	 */
+	Mono<ValueEvaluationContext> getEvaluationContextLater(@Nullable Object rootObject);
+
+	/**
+	 * Return a tailored {@link ValueEvaluationContext} built using the given parameter values and considering
+	 * {@link ExpressionDependencies expression dependencies}. The returned {@link ValueEvaluationContext} may contain a
+	 * reduced visibility of methods and properties/fields according to the required {@link ExpressionDependencies
+	 * expression dependencies}.
+	 *
+	 * @param rootObject the root object to set in the {@link ValueEvaluationContext}.
+	 * @param dependencies the requested expression dependencies to be available.
+	 * @return a mono that emits exactly one {@link ValueEvaluationContext}.
+	 */
+	default Mono<ValueEvaluationContext> getEvaluationContextLater(@Nullable Object rootObject,
+			ExpressionDependencies dependencies) {
+		return getEvaluationContextLater(rootObject);
+	}
+}

--- a/src/main/java/org/springframework/data/expression/ValueEvaluationContext.java
+++ b/src/main/java/org/springframework/data/expression/ValueEvaluationContext.java
@@ -36,7 +36,7 @@ public interface ValueEvaluationContext {
 	 * @param evaluationContext
 	 * @return a new {@link ValueEvaluationContext} for the given environment and evaluation context.
 	 */
-	static ValueEvaluationContext of(Environment environment, EvaluationContext evaluationContext) {
+	static ValueEvaluationContext of(@Nullable Environment environment, EvaluationContext evaluationContext) {
 		return new DefaultValueEvaluationContext(environment, evaluationContext);
 	}
 
@@ -51,8 +51,26 @@ public interface ValueEvaluationContext {
 	/**
 	 * Returns the {@link EvaluationContext} if provided.
 	 *
-	 * @return the {@link EvaluationContext} or {@literal null}.
+	 * @return the {@link EvaluationContext} or {@literal null} if not set.
 	 */
 	@Nullable
 	EvaluationContext getEvaluationContext();
+
+	/**
+	 * Returns the required {@link EvaluationContext} or throws {@link IllegalStateException} if there is no evaluation
+	 * context available.
+	 *
+	 * @return the {@link EvaluationContext}.
+	 * @since 3.4
+	 */
+	default EvaluationContext getRequiredEvaluationContext() {
+
+		EvaluationContext evaluationContext = getEvaluationContext();
+
+		if (evaluationContext == null) {
+			throw new IllegalStateException("No evaluation context available");
+		}
+
+		return evaluationContext;
+	}
 }

--- a/src/main/java/org/springframework/data/expression/ValueEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/expression/ValueEvaluationContextProvider.java
@@ -17,6 +17,7 @@ package org.springframework.data.expression;
 
 import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
+import org.springframework.lang.Nullable;
 
 /**
  * SPI to provide to access a centrally defined potentially shared {@link ValueEvaluationContext}.
@@ -24,6 +25,7 @@ import org.springframework.expression.EvaluationContext;
  * @author Mark Paluch
  * @since 3.3
  */
+@FunctionalInterface
 public interface ValueEvaluationContextProvider {
 
 	/**
@@ -32,7 +34,7 @@ public interface ValueEvaluationContextProvider {
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @return
 	 */
-	ValueEvaluationContext getEvaluationContext(Object rootObject);
+	ValueEvaluationContext getEvaluationContext(@Nullable Object rootObject);
 
 	/**
 	 * Return a tailored {@link EvaluationContext} built using the given parameter values and considering
@@ -44,7 +46,8 @@ public interface ValueEvaluationContextProvider {
 	 * @param dependencies the requested expression dependencies to be available.
 	 * @return
 	 */
-	default ValueEvaluationContext getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {
+	default ValueEvaluationContext getEvaluationContext(@Nullable Object rootObject,
+			ExpressionDependencies dependencies) {
 		return getEvaluationContext(rootObject);
 	}
 }

--- a/src/main/java/org/springframework/data/expression/ValueExpression.java
+++ b/src/main/java/org/springframework/data/expression/ValueExpression.java
@@ -62,4 +62,15 @@ public interface ValueExpression {
 	@Nullable
 	Object evaluate(ValueEvaluationContext context) throws EvaluationException;
 
+	/**
+	 * Return the most general type that the expression would use as return type for the given context.
+	 *
+	 * @param context the context in which to evaluate the expression.
+	 * @return the most general type of value.
+	 * @throws EvaluationException if there is a problem determining the type
+	 * @since 3.4
+	 */
+	@Nullable
+	Class<?> getValueType(ValueEvaluationContext context) throws EvaluationException;
+
 }

--- a/src/main/java/org/springframework/data/expression/ValueExpressionParser.java
+++ b/src/main/java/org/springframework/data/expression/ValueExpressionParser.java
@@ -28,6 +28,16 @@ import org.springframework.expression.ParseException;
 public interface ValueExpressionParser {
 
 	/**
+	 * Creates a default parser to parse expression strings.
+	 *
+	 * @return the parser instance.
+	 * @since 3.4
+	 */
+	static ValueExpressionParser create() {
+		return DefaultValueExpressionParser.DEFAULT;
+	}
+
+	/**
 	 * Creates a new parser to parse expression strings.
 	 *
 	 * @param configuration the parser context configuration.

--- a/src/main/java/org/springframework/data/mapping/model/CachingValueExpressionEvaluatorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/model/CachingValueExpressionEvaluatorFactory.java
@@ -23,6 +23,7 @@ import org.springframework.data.expression.ValueExpressionParser;
 import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.ExpressionParser;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ConcurrentLruCache;
 
@@ -38,11 +39,29 @@ public class CachingValueExpressionEvaluatorFactory implements ValueEvaluationCo
 	private final EnvironmentCapable environmentProvider;
 	private final EvaluationContextProvider evaluationContextProvider;
 
+	/**
+	 * Creates a new {@link CachingValueExpressionEvaluatorFactory} for the given {@link ExpressionParser},
+	 * {@link EnvironmentCapable Environment provider} and {@link EvaluationContextProvider} with a cache size of 256.
+	 *
+	 * @param expressionParser
+	 * @param environmentProvider
+	 * @param evaluationContextProvider
+	 */
 	public CachingValueExpressionEvaluatorFactory(ExpressionParser expressionParser,
 			EnvironmentCapable environmentProvider, EvaluationContextProvider evaluationContextProvider) {
 		this(expressionParser, environmentProvider, evaluationContextProvider, 256);
 	}
 
+	/**
+	 * Creates a new {@link CachingValueExpressionEvaluatorFactory} for the given {@link ExpressionParser},
+	 * {@link EnvironmentCapable Environment provider} and {@link EvaluationContextProvider} with a specific
+	 * {@code cacheSize}.
+	 *
+	 * @param expressionParser
+	 * @param environmentProvider
+	 * @param evaluationContextProvider
+	 * @param cacheSize
+	 */
 	public CachingValueExpressionEvaluatorFactory(ExpressionParser expressionParser,
 			EnvironmentCapable environmentProvider, EvaluationContextProvider evaluationContextProvider, int cacheSize) {
 
@@ -55,13 +74,13 @@ public class CachingValueExpressionEvaluatorFactory implements ValueEvaluationCo
 	}
 
 	@Override
-	public ValueEvaluationContext getEvaluationContext(Object rootObject) {
+	public ValueEvaluationContext getEvaluationContext(@Nullable Object rootObject) {
 		return ValueEvaluationContext.of(environmentProvider.getEnvironment(),
 				evaluationContextProvider.getEvaluationContext(rootObject));
 	}
 
 	@Override
-	public ValueEvaluationContext getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {
+	public ValueEvaluationContext getEvaluationContext(@Nullable Object rootObject, ExpressionDependencies dependencies) {
 		return ValueEvaluationContext.of(environmentProvider.getEnvironment(),
 				evaluationContextProvider.getEvaluationContext(rootObject, dependencies));
 	}

--- a/src/main/java/org/springframework/data/repository/core/support/ReactiveRepositoryFactorySupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/ReactiveRepositoryFactorySupport.java
@@ -17,14 +17,20 @@ package org.springframework.data.repository.core.support;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.reactivestreams.Publisher;
+
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
+import org.springframework.data.repository.query.ReactiveExtensionAwareQueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider;
+import org.springframework.data.repository.query.ValueExpressionDelegate;
 import org.springframework.data.repository.util.ReactiveWrapperConverters;
 import org.springframework.data.util.ReactiveWrappers;
+import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -67,6 +73,28 @@ public abstract class ReactiveRepositoryFactorySupport extends RepositoryFactory
 		super.setEvaluationContextProvider(
 				evaluationContextProvider == null ? ReactiveQueryMethodEvaluationContextProvider.DEFAULT
 						: evaluationContextProvider);
+	}
+
+	/**
+	 * Returns the {@link QueryLookupStrategy} for the given {@link QueryLookupStrategy.Key} and
+	 * {@link ValueExpressionDelegate}. Favor implementing this method over
+	 * {@link #getQueryLookupStrategy(QueryLookupStrategy.Key, QueryMethodEvaluationContextProvider)} for extended
+	 * {@link org.springframework.data.expression.ValueExpression} support.
+	 * <p>
+	 * This method delegates to
+	 * {@link #getQueryLookupStrategy(QueryLookupStrategy.Key, QueryMethodEvaluationContextProvider)} unless overridden.
+	 * </p>
+	 *
+	 * @param key can be {@literal null}.
+	 * @param valueExpressionDelegate will never be {@literal null}.
+	 * @return the {@link QueryLookupStrategy} to use or {@literal null} if no queries should be looked up.
+	 * @since 3.4
+	 */
+	@Override
+	protected Optional<QueryLookupStrategy> getQueryLookupStrategy(@Nullable QueryLookupStrategy.Key key,
+			ValueExpressionDelegate valueExpressionDelegate) {
+		return getQueryLookupStrategy(key,
+				new ReactiveExtensionAwareQueryMethodEvaluationContextProvider(getEvaluationContextProvider()));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/core/support/TransactionalRepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/TransactionalRepositoryFactoryBeanSupport.java
@@ -101,6 +101,7 @@ public abstract class TransactionalRepositoryFactoryBeanSupport<T extends Reposi
 	 */
 	protected abstract RepositoryFactorySupport doCreateRepositoryFactory();
 
+	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 
 		Assert.isInstanceOf(ListableBeanFactory.class, beanFactory);

--- a/src/main/java/org/springframework/data/repository/query/CachingValueExpressionDelegate.java
+++ b/src/main/java/org/springframework/data/repository/query/CachingValueExpressionDelegate.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import org.springframework.data.expression.ValueExpression;
+import org.springframework.data.expression.ValueExpressionParser;
+import org.springframework.expression.ParseException;
+import org.springframework.util.ConcurrentLruCache;
+
+/**
+ * Caching variant of {@link ValueExpressionDelegate}.
+ *
+ * @author Mark Paluch
+ * @since 3.4
+ */
+public class CachingValueExpressionDelegate extends ValueExpressionDelegate {
+
+	private final ConcurrentLruCache<String, ValueExpression> expressionCache;
+
+	/**
+	 * Creates a new {@link CachingValueExpressionDelegate} given {@link ValueExpressionDelegate}.
+	 *
+	 * @param delegate must not be {@literal null}.
+	 */
+	public CachingValueExpressionDelegate(ValueExpressionDelegate delegate) {
+		super(delegate);
+		this.expressionCache = new ConcurrentLruCache<>(256, delegate.getValueExpressionParser()::parse);
+	}
+
+	/**
+	 * Creates a new {@link CachingValueExpressionDelegate} given {@link QueryMethodValueEvaluationContextAccessor} and
+	 * {@link ValueExpressionParser}.
+	 *
+	 * @param providerFactory the factory to create value evaluation context providers, must not be {@code null}.
+	 * @param valueExpressionParser the parser to parse expression strings into value expressions, must not be
+	 *          {@code null}.
+	 */
+	public CachingValueExpressionDelegate(QueryMethodValueEvaluationContextAccessor providerFactory,
+			ValueExpressionParser valueExpressionParser) {
+		super(providerFactory, valueExpressionParser);
+		this.expressionCache = new ConcurrentLruCache<>(256, valueExpressionParser::parse);
+	}
+
+	@Override
+	public ValueExpressionParser getValueExpressionParser() {
+		return this;
+	}
+
+	@Override
+	public ValueExpression parse(String expressionString) throws ParseException {
+		return expressionCache.get(expressionString);
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/QueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethodEvaluationContextProvider.java
@@ -17,6 +17,7 @@ package org.springframework.data.repository.query;
 
 import java.util.Collections;
 
+import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.spel.ExpressionDependencies;
 import org.springframework.expression.EvaluationContext;
 
@@ -27,7 +28,9 @@ import org.springframework.expression.EvaluationContext;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @since 1.9
+ * @deprecated since 3.4 in favor of {@link QueryMethodValueEvaluationContextAccessor}.
  */
+@Deprecated(since = "3.4")
 public interface QueryMethodEvaluationContextProvider {
 
 	QueryMethodEvaluationContextProvider DEFAULT = new ExtensionAwareQueryMethodEvaluationContextProvider(
@@ -51,4 +54,9 @@ public interface QueryMethodEvaluationContextProvider {
 	 */
 	<T extends Parameters<?, ?>> EvaluationContext getEvaluationContext(T parameters, Object[] parameterValues,
 			ExpressionDependencies dependencies);
+
+	/**
+	 * @return the underlying {@link EvaluationContextProvider}.
+	 */
+	EvaluationContextProvider getEvaluationContextProvider();
 }

--- a/src/main/java/org/springframework/data/repository/query/QueryMethodValueEvaluationContextAccessor.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethodValueEvaluationContextAccessor.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.data.expression.ReactiveValueEvaluationContextProvider;
+import org.springframework.data.expression.ValueEvaluationContext;
+import org.springframework.data.expression.ValueEvaluationContextProvider;
+import org.springframework.data.spel.EvaluationContextProvider;
+import org.springframework.data.spel.ExpressionDependencies;
+import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
+import org.springframework.data.spel.ReactiveEvaluationContextProvider;
+import org.springframework.data.spel.ReactiveExtensionAwareEvaluationContextProvider;
+import org.springframework.data.spel.spi.EvaluationContextExtension;
+import org.springframework.data.spel.spi.ExtensionIdAware;
+import org.springframework.data.util.ReactiveWrappers;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Factory to create {@link ValueEvaluationContextProvider} instances. Supports its reactive variant
+ * {@link ReactiveValueEvaluationContextProvider} if the underlying {@link EvaluationContextProvider} is a reactive one.
+ *
+ * @author Mark Paluch
+ * @since 3.4
+ */
+public class QueryMethodValueEvaluationContextAccessor {
+
+	public static final EvaluationContextProvider DEFAULT_CONTEXT_PROVIDER = createEvaluationContextProvider(
+			Collections.emptyList());
+
+	static final StandardEnvironment ENVIRONMENT = new StandardEnvironment();
+
+	private final @Nullable Environment environment;
+	private final EvaluationContextProvider evaluationContextProvider;
+
+	/**
+	 * Creates a new {@link QueryMethodValueEvaluationContextAccessor} from {@link ApplicationContext}.
+	 *
+	 * @param context the application context to use, must not be {@literal null}.
+	 */
+	public QueryMethodValueEvaluationContextAccessor(ApplicationContext context) {
+
+		Assert.notNull(context, "ApplicationContext must not be null");
+
+		this.environment = context.getEnvironment();
+		this.evaluationContextProvider = createEvaluationContextProvider(context);
+	}
+
+	/**
+	 * Creates a new {@link QueryMethodValueEvaluationContextAccessor} from {@link Environment} and
+	 * {@link ListableBeanFactory}.
+	 *
+	 * @param environment
+	 * @param beanFactory the bean factory to use, must not be {@literal null}.
+	 */
+	public QueryMethodValueEvaluationContextAccessor(@Nullable Environment environment, ListableBeanFactory beanFactory) {
+		this(environment, createEvaluationContextProvider(beanFactory));
+	}
+
+	/**
+	 * Creates a new {@link QueryMethodValueEvaluationContextAccessor} from {@link Environment} and
+	 * {@link EvaluationContextProvider}.
+	 *
+	 * @param environment
+	 * @param evaluationContextProvider the underlying {@link EvaluationContextProvider} to use, must not be
+	 *          {@literal null}.
+	 */
+	public QueryMethodValueEvaluationContextAccessor(@Nullable Environment environment,
+			EvaluationContextProvider evaluationContextProvider) {
+
+		Assert.notNull(evaluationContextProvider, "EvaluationContextProvider must not be null");
+
+		this.environment = environment;
+		this.evaluationContextProvider = evaluationContextProvider;
+	}
+
+	/**
+	 * Creates a new {@link QueryMethodValueEvaluationContextAccessor} for the given {@link EvaluationContextExtension}s.
+	 *
+	 * @param environment
+	 * @param extensions must not be {@literal null}.
+	 */
+	public QueryMethodValueEvaluationContextAccessor(@Nullable Environment environment,
+			Collection<? extends ExtensionIdAware> extensions) {
+
+		Assert.notNull(extensions, "EvaluationContextExtensions must not be null");
+
+		this.environment = environment;
+		this.evaluationContextProvider = createEvaluationContextProvider(extensions);
+	}
+
+	private static EvaluationContextProvider createEvaluationContextProvider(ListableBeanFactory factory) {
+
+		return ReactiveWrappers.isAvailable(ReactiveWrappers.ReactiveLibrary.PROJECT_REACTOR)
+				? new ReactiveExtensionAwareEvaluationContextProvider(factory)
+				: new ExtensionAwareEvaluationContextProvider(factory);
+
+	}
+
+	private static EvaluationContextProvider createEvaluationContextProvider(
+			Collection<? extends ExtensionIdAware> extensions) {
+
+		return ReactiveWrappers.isAvailable(ReactiveWrappers.ReactiveLibrary.PROJECT_REACTOR)
+				? new ReactiveExtensionAwareEvaluationContextProvider(extensions)
+				: new ExtensionAwareEvaluationContextProvider(extensions);
+	}
+
+	/**
+	 * Creates a default {@link QueryMethodValueEvaluationContextAccessor} using the
+	 * {@link org.springframework.core.env.StandardEnvironment} and extension-less
+	 * {@link org.springframework.data.spel.EvaluationContextProvider}.
+	 *
+	 * @return a default {@link ValueExpressionDelegate}.
+	 */
+	public static QueryMethodValueEvaluationContextAccessor create() {
+		return new QueryMethodValueEvaluationContextAccessor(ENVIRONMENT, DEFAULT_CONTEXT_PROVIDER);
+	}
+
+	EvaluationContextProvider getEvaluationContextProvider() {
+		return evaluationContextProvider;
+	}
+
+	/**
+	 * Creates a new {@link ValueEvaluationContextProvider} for the given {@link Parameters}.
+	 *
+	 * @param parameters must not be {@literal null}.
+	 * @return a new {@link ValueEvaluationContextProvider} for the given {@link Parameters}.
+	 */
+	public ValueEvaluationContextProvider create(Parameters<?, ?> parameters) {
+
+		Assert.notNull(parameters, "Parameters must not be null");
+
+		if (ReactiveWrappers.isAvailable(ReactiveWrappers.ReactiveLibrary.PROJECT_REACTOR)) {
+			if (evaluationContextProvider instanceof ReactiveEvaluationContextProvider reactive) {
+				return new DefaultReactiveQueryMethodValueEvaluationContextProvider(environment, parameters, reactive);
+			}
+		}
+
+		return new DefaultQueryMethodValueEvaluationContextProvider(environment, parameters, evaluationContextProvider);
+	}
+
+	/**
+	 * Exposes variables for all named parameters for the given arguments. Also exposes non-bindable parameters under the
+	 * names of their types.
+	 *
+	 * @param parameters must not be {@literal null}.
+	 * @param arguments must not be {@literal null}.
+	 * @return
+	 */
+	static Map<String, Object> collectVariables(Parameters<?, ?> parameters, Object[] arguments) {
+
+		if (parameters.getNumberOfParameters() != arguments.length) {
+
+			throw new IllegalArgumentException(
+					"Number of method parameters (%d) must match the number of method invocation arguments (%d)"
+							.formatted(parameters.getNumberOfParameters(), arguments.length));
+		}
+
+		Map<String, Object> variables = new HashMap<>(parameters.getNumberOfParameters(), 1.0f);
+
+		for (Parameter parameter : parameters) {
+
+			if (parameter.isSpecialParameter()) {
+				variables.put(//
+						StringUtils.uncapitalize(parameter.getType().getSimpleName()), //
+						arguments[parameter.getIndex()]);
+			}
+
+			if (parameter.isNamedParameter()) {
+				variables.put(parameter.getRequiredName(), //
+						arguments[parameter.getIndex()]);
+			}
+		}
+
+		return variables;
+	}
+
+	/**
+	 * Imperative {@link ValueEvaluationContextProvider} variant.
+	 */
+	static class DefaultQueryMethodValueEvaluationContextProvider implements ValueEvaluationContextProvider {
+
+		final @Nullable Environment environment;
+		final Parameters<?, ?> parameters;
+		final EvaluationContextProvider delegate;
+
+		DefaultQueryMethodValueEvaluationContextProvider(@Nullable Environment environment, Parameters<?, ?> parameters,
+				EvaluationContextProvider delegate) {
+			this.environment = environment;
+			this.parameters = parameters;
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ValueEvaluationContext getEvaluationContext(@Nullable Object rootObject) {
+			return doGetEvaluationContext(delegate.getEvaluationContext(rootObject), rootObject);
+		}
+
+		@Override
+		public ValueEvaluationContext getEvaluationContext(@Nullable Object rootObject,
+				ExpressionDependencies dependencies) {
+			return doGetEvaluationContext(delegate.getEvaluationContext(rootObject, dependencies), rootObject);
+		}
+
+		ValueEvaluationContext doGetEvaluationContext(EvaluationContext evaluationContext, @Nullable Object rootObject) {
+
+			if (rootObject instanceof Object[] parameterValues) {
+				collectVariables(parameters, parameterValues).forEach(evaluationContext::setVariable);
+			}
+
+			return ValueEvaluationContext.of(environment, evaluationContext);
+		}
+
+	}
+
+	/**
+	 * Reactive {@link ValueEvaluationContextProvider} extension to
+	 * {@link DefaultQueryMethodValueEvaluationContextProvider}.
+	 */
+	static class DefaultReactiveQueryMethodValueEvaluationContextProvider
+			extends DefaultQueryMethodValueEvaluationContextProvider implements ReactiveValueEvaluationContextProvider {
+
+		private final ReactiveEvaluationContextProvider delegate;
+
+		DefaultReactiveQueryMethodValueEvaluationContextProvider(@Nullable Environment environment,
+				Parameters<?, ?> parameters, ReactiveEvaluationContextProvider delegate) {
+			super(environment, parameters, delegate);
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Mono<ValueEvaluationContext> getEvaluationContextLater(@Nullable Object rootObject) {
+			return delegate.getEvaluationContextLater(rootObject).map(it -> doGetEvaluationContext(it, rootObject));
+		}
+
+		@Override
+		public Mono<ValueEvaluationContext> getEvaluationContextLater(@Nullable Object rootObject,
+				ExpressionDependencies dependencies) {
+			return delegate.getEvaluationContextLater(rootObject, dependencies)
+					.map(it -> doGetEvaluationContext(it, rootObject));
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/repository/query/ReactiveQueryMethodEvaluationContextProvider.java
@@ -28,7 +28,9 @@ import org.springframework.expression.EvaluationContext;
  *
  * @author Mark Paluch
  * @since 2.4
+ * @deprecated since 4.0 in favor of {@link QueryMethodValueEvaluationContextAccessor}.
  */
+@Deprecated(since = "4.0")
 public interface ReactiveQueryMethodEvaluationContextProvider extends QueryMethodEvaluationContextProvider {
 
 	ReactiveQueryMethodEvaluationContextProvider DEFAULT = new ReactiveExtensionAwareQueryMethodEvaluationContextProvider(

--- a/src/main/java/org/springframework/data/repository/query/SpelEvaluator.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelEvaluator.java
@@ -35,7 +35,9 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @since 2.1
  * @see SpelQueryContext#parse(String)
+ * @deprecated since 3.3, use {@link ValueExpressionQueryRewriter} instead.
  */
+@Deprecated(since = "3.3")
 public class SpelEvaluator {
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();

--- a/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
@@ -58,7 +58,7 @@ import org.springframework.util.Assert;
  * @author Gerrit Meier
  * @author Mark Paluch
  * @since 2.1
- * @deprecated since 3.3, use {@link ValueExpressionQueryRewriter.QueryExpressionEvaluator} instead.
+ * @deprecated since 3.3, use {@link ValueExpressionQueryRewriter} instead.
  */
 @Deprecated(since = "3.3")
 public class SpelQueryContext {

--- a/src/main/java/org/springframework/data/repository/query/ValueExpressionDelegate.java
+++ b/src/main/java/org/springframework/data/repository/query/ValueExpressionDelegate.java
@@ -64,6 +64,14 @@ public class ValueExpressionDelegate implements ValueExpressionParser {
 				ValueExpressionParser.create());
 	}
 
+	public ValueExpressionParser getValueExpressionParser() {
+		return valueExpressionParser;
+	}
+
+	public QueryMethodValueEvaluationContextAccessor getEvaluationContextAccessor() {
+		return contextAccessor;
+	}
+
 	/**
 	 * Creates a {@link ValueEvaluationContextProvider} for query method {@link Parameters} for later creation of a
 	 * {@link ValueEvaluationContext} based on the actual method parameter values. The resulting
@@ -74,10 +82,6 @@ public class ValueExpressionDelegate implements ValueExpressionParser {
 	 */
 	public ValueEvaluationContextProvider createValueContextProvider(Parameters<?, ?> parameters) {
 		return contextAccessor.create(parameters);
-	}
-
-	public ValueExpressionParser getValueExpressionParser() {
-		return valueExpressionParser;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/repository/query/ValueExpressionDelegate.java
+++ b/src/main/java/org/springframework/data/repository/query/ValueExpressionDelegate.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import org.springframework.data.expression.ValueEvaluationContext;
+import org.springframework.data.expression.ValueEvaluationContextProvider;
+import org.springframework.data.expression.ValueExpression;
+import org.springframework.data.expression.ValueExpressionParser;
+import org.springframework.expression.ParseException;
+
+/**
+ * Delegate to provide a {@link ValueExpressionParser} along with a context factory.
+ * <p>
+ * Subclasses can customize parsing behavior.
+ *
+ * @author Mark Paluch
+ */
+public class ValueExpressionDelegate implements ValueExpressionParser {
+
+	private final QueryMethodValueEvaluationContextAccessor contextAccessor;
+	private final ValueExpressionParser valueExpressionParser;
+
+	/**
+	 * Creates a new {@link ValueExpressionDelegate} given {@link QueryMethodValueEvaluationContextAccessor} and
+	 * {@link ValueExpressionParser}.
+	 *
+	 * @param contextAccessor the factory to create value evaluation context providers, must not be {@code null}.
+	 * @param valueExpressionParser the parser to parse expression strings into value expressions, must not be
+	 *          {@code null}.
+	 */
+	public ValueExpressionDelegate(QueryMethodValueEvaluationContextAccessor contextAccessor,
+			ValueExpressionParser valueExpressionParser) {
+		this.contextAccessor = contextAccessor;
+		this.valueExpressionParser = valueExpressionParser;
+	}
+
+	ValueExpressionDelegate(ValueExpressionDelegate original) {
+		this.contextAccessor = original.contextAccessor;
+		this.valueExpressionParser = original.valueExpressionParser;
+	}
+
+	/**
+	 * Creates a default {@link ValueExpressionDelegate} using the
+	 * {@link org.springframework.core.env.StandardEnvironment}, a default {@link ValueExpression} and extension-less
+	 * {@link org.springframework.data.spel.EvaluationContextProvider}.
+	 *
+	 * @return a default {@link ValueExpressionDelegate}.
+	 */
+	public static ValueExpressionDelegate create() {
+		return new ValueExpressionDelegate(QueryMethodValueEvaluationContextAccessor.create(),
+				ValueExpressionParser.create());
+	}
+
+	/**
+	 * Creates a {@link ValueEvaluationContextProvider} for query method {@link Parameters} for later creation of a
+	 * {@link ValueEvaluationContext} based on the actual method parameter values. The resulting
+	 * {@link ValueEvaluationContextProvider} is only valid for the given parameters
+	 *
+	 * @param parameters the query method parameters to use.
+	 * @return
+	 */
+	public ValueEvaluationContextProvider createValueContextProvider(Parameters<?, ?> parameters) {
+		return contextAccessor.create(parameters);
+	}
+
+	public ValueExpressionParser getValueExpressionParser() {
+		return valueExpressionParser;
+	}
+
+	@Override
+	public ValueExpression parse(String expressionString) throws ParseException {
+		return valueExpressionParser.parse(expressionString);
+	}
+}

--- a/src/main/java/org/springframework/data/repository/query/ValueExpressionQueryRewriter.java
+++ b/src/main/java/org/springframework/data/repository/query/ValueExpressionQueryRewriter.java
@@ -98,19 +98,37 @@ public class ValueExpressionQueryRewriter {
 	}
 
 	/**
-	 * Creates a new {@link ValueExpressionQueryRewriter} using the given {@link ValueExpressionParser} and rewrite
-	 * functions.
+	 * Creates a new ValueExpressionQueryRewriter using the given {@link ValueExpressionParser} and rewrite functions.
 	 *
 	 * @param expressionParser the expression parser to use.
 	 * @param parameterNameSource function to generate parameter names. Typically, a function of the form
 	 *          {@code (index, expression) -> "__some_placeholder_" + index}.
 	 * @param replacementSource function to generate replacements. Typically, a concatenation of the prefix and the
 	 *          parameter name such as {@code String::concat}.
-	 * @return
+	 * @return a ValueExpressionQueryRewriter instance to rewrite queries and extract parsed {@link ValueExpression}s.
 	 */
 	public static ValueExpressionQueryRewriter of(ValueExpressionParser expressionParser,
 			BiFunction<Integer, String, String> parameterNameSource, BiFunction<String, String, String> replacementSource) {
 		return new ValueExpressionQueryRewriter(expressionParser, parameterNameSource, replacementSource);
+	}
+
+	/**
+	 * Creates a new EvaluatingValueExpressionQueryRewriter using the given {@link ValueExpressionDelegate} and rewrite
+	 * functions.
+	 *
+	 * @param delegate the ValueExpressionDelegate to use for parsing and to obtain EvaluationContextAccessor from.
+	 * @param parameterNameSource function to generate parameter names. Typically, a function of the form
+	 *          {@code (index, expression) -> "__some_placeholder_" + index}.
+	 * @param replacementSource function to generate replacements. Typically, a concatenation of the prefix and the
+	 *          parameter name such as {@code String::concat}.
+	 * @return a EvaluatingValueExpressionQueryRewriter instance to rewrite queries and extract parsed
+	 *         {@link ValueExpression}s.
+	 * @since 3.4
+	 */
+	public static EvaluatingValueExpressionQueryRewriter of(ValueExpressionDelegate delegate,
+			BiFunction<Integer, String, String> parameterNameSource, BiFunction<String, String, String> replacementSource) {
+		return of((ValueExpressionParser) delegate, parameterNameSource, replacementSource)
+				.withEvaluationContextAccessor(delegate.getEvaluationContextAccessor());
 	}
 
 	/**
@@ -137,15 +155,15 @@ public class ValueExpressionQueryRewriter {
 	 * Creates a {@link EvaluatingValueExpressionQueryRewriter} from the current one and the given
 	 * {@link QueryMethodValueEvaluationContextAccessor}.
 	 *
-	 * @param factory must not be {@literal null}.
-	 * @return
+	 * @param accessor must not be {@literal null}.
+	 * @return EvaluatingValueExpressionQueryRewriter instance to rewrite and evaluate Value Expressions.
 	 */
 	public EvaluatingValueExpressionQueryRewriter withEvaluationContextAccessor(
-			QueryMethodValueEvaluationContextAccessor factory) {
+			QueryMethodValueEvaluationContextAccessor accessor) {
 
-		Assert.notNull(factory, "QueryMethodValueEvaluationContextAccessor must not be null");
+		Assert.notNull(accessor, "QueryMethodValueEvaluationContextAccessor must not be null");
 
-		return new EvaluatingValueExpressionQueryRewriter(expressionParser, factory, parameterNameSource,
+		return new EvaluatingValueExpressionQueryRewriter(expressionParser, accessor, parameterNameSource,
 				replacementSource);
 	}
 

--- a/src/main/java/org/springframework/data/repository/query/ValueExpressionQueryRewriter.java
+++ b/src/main/java/org/springframework/data/repository/query/ValueExpressionQueryRewriter.java
@@ -72,17 +72,17 @@ public class ValueExpressionQueryRewriter {
 	private final ValueExpressionParser expressionParser;
 
 	/**
-	 * A function from the index of a Value expression in a query and the actual SpEL expression to the parameter name to
-	 * be used in place of the SpEL expression. A typical implementation is expected to look like
-	 * <code>(index, spel) -> "__some_placeholder_" + index</code>
+	 * A function from the index of a Value expression in a query and the actual Value Expression to the parameter name to
+	 * be used in place of the Value Expression. A typical implementation is expected to look like
+	 * <code>(index, expression) -> "__some_placeholder_" + index</code>
 	 */
 	private final BiFunction<Integer, String, String> parameterNameSource;
 
 	/**
-	 * A function from a prefix used to demarcate a SpEL expression in a query and a parameter name as returned from
-	 * {@link #parameterNameSource} to a {@literal String} to be used as a replacement of the SpEL in the query. The
-	 * returned value should normally be interpretable as a bind parameter by the underlying persistence mechanism. A
-	 * typical implementation is expected to look like <code>(prefix, name) -> prefix + name</code> or
+	 * A function from a prefix used to demarcate a Value Expression in a query and a parameter name as returned from
+	 * {@link #parameterNameSource} to a {@literal String} to be used as a replacement of the Value Expressions in the
+	 * query. The returned value should normally be interpretable as a bind parameter by the underlying persistence
+	 * mechanism. A typical implementation is expected to look like <code>(prefix, name) -> prefix + name</code> or
 	 * <code>(prefix, name) -> "{" + name + "}"</code>
 	 */
 	private final BiFunction<String, String, String> replacementSource;
@@ -116,9 +116,9 @@ public class ValueExpressionQueryRewriter {
 	 * with prefix being the character ':' or '?'. Parsing honors quoted {@literal String}s enclosed in single or double
 	 * quotation marks.
 	 *
-	 * @param query a query containing SpEL expressions in the format described above. Must not be {@literal null}.
-	 * @return A {@link ParsedQuery} which makes the query with SpEL expressions replaced by bind parameters and a map
-	 *         from bind parameter to SpEL expression available. Guaranteed to be not {@literal null}.
+	 * @param query a query containing Value Expressions in the format described above. Must not be {@literal null}.
+	 * @return A {@link ParsedQuery} which makes the query with Value Expressions replaced by bind parameters and a map
+	 *         from bind parameter to Value Expression available. Guaranteed to be not {@literal null}.
 	 */
 	public ParsedQuery parse(String query) {
 		return new ParsedQuery(expressionParser, query);
@@ -168,7 +168,7 @@ public class ValueExpressionQueryRewriter {
 		}
 
 		/**
-		 * Parses the query for SpEL expressions using the pattern:
+		 * Parses the query for Value Expressions using the pattern:
 		 *
 		 * <pre>
 		 * &lt;prefix&gt;#{&lt;spel&gt;}
@@ -257,7 +257,7 @@ public class ValueExpressionQueryRewriter {
 		}
 
 		/**
-		 * The query with all the SpEL expressions replaced with bind parameters.
+		 * The query with all the Value Expressions replaced with bind parameters.
 		 *
 		 * @return Guaranteed to be not {@literal null}.
 		 */
@@ -289,11 +289,20 @@ public class ValueExpressionQueryRewriter {
 		}
 
 		/**
-		 * A {@literal Map} from parameter name to SpEL expression.
+		 * Returns whether the query contains Value Expressions.
+		 *
+		 * @return {@literal true} if the query contains Value Expressions.
+		 */
+		public boolean hasParameterBindings() {
+			return !expressions.isEmpty();
+		}
+
+		/**
+		 * A {@literal Map} from parameter name to Value Expression.
 		 *
 		 * @return Guaranteed to be not {@literal null}.
 		 */
-		Map<String, ValueExpression> getParameterMap() {
+		public Map<String, ValueExpression> getParameterMap() {
 			return expressions;
 		}
 
@@ -403,7 +412,7 @@ public class ValueExpressionQueryRewriter {
 		}
 
 		/**
-		 * Returns the query string produced by the intermediate SpEL expression collection step.
+		 * Returns the query string produced by the intermediate Value Expression collection step.
 		 *
 		 * @return
 		 */

--- a/src/main/java/org/springframework/data/spel/EvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/EvaluationContextProvider.java
@@ -17,6 +17,7 @@ package org.springframework.data.spel;
 
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.lang.Nullable;
 
 /**
  * Provides a way to access a centrally defined potentially shared {@link StandardEvaluationContext}.
@@ -44,7 +45,7 @@ public interface EvaluationContextProvider {
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @return
 	 */
-	EvaluationContext getEvaluationContext(Object rootObject);
+	EvaluationContext getEvaluationContext(@Nullable Object rootObject);
 
 	/**
 	 * Return a tailored {@link EvaluationContext} built using the given parameter values and considering
@@ -57,7 +58,7 @@ public interface EvaluationContextProvider {
 	 * @return
 	 * @since 2.4
 	 */
-	default EvaluationContext getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {
+	default EvaluationContext getEvaluationContext(@Nullable Object rootObject, ExpressionDependencies dependencies) {
 		return getEvaluationContext(rootObject);
 	}
 }

--- a/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
@@ -101,16 +101,17 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	}
 
 	@Override
-	public StandardEvaluationContext getEvaluationContext(Object rootObject) {
+	public StandardEvaluationContext getEvaluationContext(@Nullable Object rootObject) {
 		return doGetEvaluationContext(rootObject, getExtensions(Predicates.isTrue()));
 	}
 
 	@Override
-	public StandardEvaluationContext getEvaluationContext(Object rootObject, ExpressionDependencies dependencies) {
+	public StandardEvaluationContext getEvaluationContext(@Nullable Object rootObject,
+			ExpressionDependencies dependencies) {
 		return doGetEvaluationContext(rootObject, getExtensions(it -> dependencies.stream().anyMatch(it::provides)));
 	}
 
-	StandardEvaluationContext doGetEvaluationContext(Object rootObject,
+	StandardEvaluationContext doGetEvaluationContext(@Nullable Object rootObject,
 			Collection<? extends EvaluationContextExtension> extensions) {
 		StandardEvaluationContext context = new StandardEvaluationContext();
 
@@ -180,7 +181,6 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 	 * Creates {@link EvaluationContextExtensionAdapter}s for the given {@link EvaluationContextExtension}s.
 	 *
 	 * @param extensions
-	 * @param filter to remove unwanted extensions.
 	 * @return
 	 */
 	private List<EvaluationContextExtensionAdapter> toAdapters(

--- a/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveEvaluationContextProvider.java
@@ -18,6 +18,7 @@ package org.springframework.data.spel;
 import reactor.core.publisher.Mono;
 
 import org.springframework.expression.EvaluationContext;
+import org.springframework.lang.Nullable;
 
 /**
  * Provides a way to access a centrally defined potentially shared {@link EvaluationContext}.
@@ -33,7 +34,7 @@ public interface ReactiveEvaluationContextProvider extends EvaluationContextProv
 	 * @param rootObject the root object to set in the {@link EvaluationContext}.
 	 * @return a mono that emits exactly one {@link EvaluationContext}.
 	 */
-	Mono<? extends EvaluationContext> getEvaluationContextLater(Object rootObject);
+	Mono<? extends EvaluationContext> getEvaluationContextLater(@Nullable Object rootObject);
 
 	/**
 	 * Return a tailored {@link EvaluationContext} built using the given parameter values and considering
@@ -46,7 +47,7 @@ public interface ReactiveEvaluationContextProvider extends EvaluationContextProv
 	 * @return a mono that emits exactly one {@link EvaluationContext}.
 	 * @since 2.4
 	 */
-	default Mono<? extends EvaluationContext> getEvaluationContextLater(Object rootObject,
+	default Mono<? extends EvaluationContext> getEvaluationContextLater(@Nullable Object rootObject,
 			ExpressionDependencies dependencies) {
 		return getEvaluationContextLater(rootObject);
 	}

--- a/src/main/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ReactiveExtensionAwareEvaluationContextProvider.java
@@ -31,6 +31,7 @@ import org.springframework.data.util.Predicates;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.lang.Nullable;
 
 /**
  * A reactive {@link EvaluationContextProvider} that assembles an {@link EvaluationContext} from a list of
@@ -81,13 +82,13 @@ public class ReactiveExtensionAwareEvaluationContextProvider implements Reactive
 	}
 
 	@Override
-	public Mono<StandardEvaluationContext> getEvaluationContextLater(Object rootObject) {
+	public Mono<StandardEvaluationContext> getEvaluationContextLater(@Nullable Object rootObject) {
 		return getExtensions(Predicates.isTrue()) //
 				.map(it -> evaluationContextProvider.doGetEvaluationContext(rootObject, it));
 	}
 
 	@Override
-	public Mono<StandardEvaluationContext> getEvaluationContextLater(Object rootObject,
+	public Mono<StandardEvaluationContext> getEvaluationContextLater(@Nullable Object rootObject,
 			ExpressionDependencies dependencies) {
 
 		return getExtensions(it -> dependencies.stream().anyMatch(it::provides)) //

--- a/src/test/java/org/springframework/data/expression/ValueEvaluationUnitTests.java
+++ b/src/test/java/org/springframework/data/expression/ValueEvaluationUnitTests.java
@@ -28,7 +28,6 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.ParseException;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
@@ -86,8 +85,7 @@ public class ValueEvaluationUnitTests {
 	@Test // GH-2369
 	void shouldParseLiteral() {
 
-		ValueParserConfiguration parserContext = () -> new SpelExpressionParser();
-		ValueExpressionParser parser = ValueExpressionParser.create(parserContext);
+		ValueExpressionParser parser = ValueExpressionParser.create();
 
 		assertThat(parser.parse("#{'foo'}-${key.one}").isLiteral()).isFalse();
 		assertThat(parser.parse("foo").isLiteral()).isTrue();
@@ -132,9 +130,7 @@ public class ValueEvaluationUnitTests {
 
 	private String eval(String expressionString) {
 
-		ValueParserConfiguration parserContext = SpelExpressionParser::new;
-
-		ValueExpressionParser parser = ValueExpressionParser.create(parserContext);
+		ValueExpressionParser parser = ValueExpressionParser.create();
 		return (String) parser.parse(expressionString).evaluate(evaluationContext);
 	}
 

--- a/src/test/java/org/springframework/data/repository/query/ValueExpressionQueryRewriterUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ValueExpressionQueryRewriterUnitTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.data.expression.ValueExpressionParser;
+import org.springframework.data.spel.EvaluationContextProvider;
+
+/**
+ * Unit tests for {@link ValueExpressionQueryRewriter}.
+ *
+ * @author Mark Paluch
+ */
+class ValueExpressionQueryRewriterUnitTests {
+
+	static final BiFunction<Integer, String, String> PARAMETER_NAME_SOURCE = (index, spel) -> "EPP" + index;
+	static final BiFunction<String, String, String> REPLACEMENT_SOURCE = (prefix, name) -> prefix + name;
+	static final ValueExpressionParser PARSER = ValueExpressionParser.create();
+
+	@Test // GH-3049
+	void nullQueryThrowsException() {
+
+		var context = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> context.parse(null));
+	}
+
+	@Test // GH-3049
+	void emptyStringGetsParsedCorrectly() {
+
+		var context = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
+		var extractor = context.parse("");
+
+		assertThat(extractor.getQueryString()).isEqualTo("");
+		assertThat(extractor.getParameterMap()).isEmpty();
+	}
+
+	@Test // GH-3049
+	void findsAndReplacesExpressions() {
+
+		var context = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
+		var extractor = context.parse(":#{one} ?#{two} :${three} ?${four}");
+
+		assertThat(extractor.getQueryString()).isEqualTo(":EPP0 ?EPP1 :EPP2 ?EPP3");
+		assertThat(extractor.getParameterMap().entrySet()) //
+				.extracting(Map.Entry::getKey, it -> it.getValue().getExpressionString()) //
+				.containsExactlyInAnyOrder( //
+						Tuple.tuple("EPP0", "one"), //
+						Tuple.tuple("EPP1", "two"), //
+						Tuple.tuple("EPP2", "${three}"), //
+						Tuple.tuple("EPP3", "${four}") //
+				);
+
+	}
+
+	@Test // GH-3049
+	void keepsStringWhenNoMatchIsFound() {
+
+		var context = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
+		var extractor = context.parse("abcdef");
+
+		assertThat(extractor.getQueryString()).isEqualTo("abcdef");
+		assertThat(extractor.getParameterMap()).isEmpty();
+	}
+
+	@Test // GH-3049
+	void spelsInQuotesGetIgnored() {
+
+		var queries = Arrays.asList(//
+				"a'b:#{one}cd'ef", //
+				"a'b:#{o'ne}cdef", //
+				"ab':#{one}'cdef", //
+				"ab:'#{one}cd'ef", //
+				"ab:#'{one}cd'ef", //
+				"a'b:#{o'ne}cdef");
+
+		queries.forEach(this::checkNoExpressionIsFound);
+	}
+
+	private void checkNoExpressionIsFound(String query) {
+
+		var context = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
+		var extractor = context.parse(query);
+
+		assertThat(extractor.getQueryString()).describedAs(query).isEqualTo(query);
+		assertThat(extractor.getParameterMap()).describedAs(query).isEmpty();
+	}
+
+	@Test // GH-3049
+	void shouldEvaluateExpression() throws Exception {
+
+		ValueExpressionQueryRewriter rewriter = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE,
+				REPLACEMENT_SOURCE);
+		StandardEnvironment environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("synthetic", Map.of("foo", "world")));
+
+		QueryMethodValueEvaluationContextAccessor factory = new QueryMethodValueEvaluationContextAccessor(environment,
+				EvaluationContextProvider.DEFAULT);
+
+		Method method = ValueExpressionQueryRewriterUnitTests.MyRepository.class.getDeclaredMethod("simpleExpression",
+				String.class);
+		var extractor = rewriter.withEvaluationContextAccessor(factory).parse("SELECT :#{#value}, :${foo}",
+				new DefaultParameters(ParametersSource.of(method)));
+
+		assertThat(extractor.getQueryString()).isEqualTo("SELECT :EPP0, :EPP1");
+		assertThat(extractor.evaluate(new Object[] { "hello" })).containsEntry("EPP0", "hello").containsEntry("EPP1",
+				"world");
+	}
+
+	@Test // GH-3049
+	void shouldAllowNullValues() throws Exception {
+
+		ValueExpressionQueryRewriter rewriter = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE,
+				REPLACEMENT_SOURCE);
+		StandardEnvironment environment = new StandardEnvironment();
+
+		QueryMethodValueEvaluationContextAccessor factory = new QueryMethodValueEvaluationContextAccessor(environment,
+				EvaluationContextProvider.DEFAULT);
+
+		Method method = ValueExpressionQueryRewriterUnitTests.MyRepository.class.getDeclaredMethod("simpleExpression",
+				String.class);
+		var extractor = rewriter.withEvaluationContextAccessor(factory).parse("SELECT :#{#value}",
+				new DefaultParameters(ParametersSource.of(method)));
+
+		assertThat(extractor.getQueryString()).isEqualTo("SELECT :EPP0");
+		assertThat(extractor.evaluate(new Object[] { null })).containsEntry("EPP0", null);
+	}
+
+	interface MyRepository {
+
+		void simpleExpression(String value);
+
+	}
+}

--- a/src/test/java/org/springframework/data/repository/query/ValueExpressionQueryRewriterUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/query/ValueExpressionQueryRewriterUnitTests.java
@@ -74,7 +74,6 @@ class ValueExpressionQueryRewriterUnitTests {
 						Tuple.tuple("EPP2", "${three}"), //
 						Tuple.tuple("EPP3", "${four}") //
 				);
-
 	}
 
 	@Test // GH-3049
@@ -113,17 +112,20 @@ class ValueExpressionQueryRewriterUnitTests {
 	@Test // GH-3049
 	void shouldEvaluateExpression() throws Exception {
 
-		ValueExpressionQueryRewriter rewriter = ValueExpressionQueryRewriter.of(PARSER, PARAMETER_NAME_SOURCE,
-				REPLACEMENT_SOURCE);
 		StandardEnvironment environment = new StandardEnvironment();
 		environment.getPropertySources().addFirst(new MapPropertySource("synthetic", Map.of("foo", "world")));
 
-		QueryMethodValueEvaluationContextAccessor factory = new QueryMethodValueEvaluationContextAccessor(environment,
+		QueryMethodValueEvaluationContextAccessor contextAccessor = new QueryMethodValueEvaluationContextAccessor(
+				environment,
 				EvaluationContextProvider.DEFAULT);
+
+		ValueExpressionDelegate delegate = new ValueExpressionDelegate(contextAccessor, PARSER);
+		ValueExpressionQueryRewriter.EvaluatingValueExpressionQueryRewriter rewriter = ValueExpressionQueryRewriter
+				.of(delegate, PARAMETER_NAME_SOURCE, REPLACEMENT_SOURCE);
 
 		Method method = ValueExpressionQueryRewriterUnitTests.MyRepository.class.getDeclaredMethod("simpleExpression",
 				String.class);
-		var extractor = rewriter.withEvaluationContextAccessor(factory).parse("SELECT :#{#value}, :${foo}",
+		var extractor = rewriter.parse("SELECT :#{#value}, :${foo}",
 				new DefaultParameters(ParametersSource.of(method)));
 
 		assertThat(extractor.getQueryString()).isEqualTo("SELECT :EPP0, :EPP1");


### PR DESCRIPTION
Introduce `ValueExpressionQueryRewriter` as replacement for `SpelQueryContext`.

Closes #3049