### PR TITLE
Remove redundant code in `DefaultEntityCallbacks#callback`

### DIFF
--- a/src/main/java/org/springframework/data/mapping/callback/DefaultEntityCallbacks.java
+++ b/src/main/java/org/springframework/data/mapping/callback/DefaultEntityCallbacks.java
@@ -67,8 +67,7 @@ class DefaultEntityCallbacks implements EntityCallbacks {
 
 		Assert.notNull(entity, "Entity must not be null");
 
-		Class<T> entityType = (Class<T>) (entity != null ? ClassUtils.getUserClass(entity.getClass())
-				: callbackDiscoverer.resolveDeclaredEntityType(callbackType).getRawClass());
+		Class<T> entityType = (Class<T>) ClassUtils.getUserClass(entity.getClass());
 
 		Method callbackMethod = callbackMethodCache.computeIfAbsent(callbackType, it -> {
 


### PR DESCRIPTION
Resolves #3055 

I have found `org.springframework.data.mapping.callback.DefaultEntityCallbacks#callback` method exists redunant code.

`entity` is checked `not null`, then don't need to call `callbackDiscoverer.resolveDeclaredEntityType(callbackType).getRawClass())`.

current code:
```java
@Override
public <T> T callback(Class<? extends EntityCallback> callbackType, T entity, Object... args) {

    Assert.notNull(entity, "Entity must not be null");
    // redunant code 
    Class<T> entityType = (Class<T>) (entity != null ? ClassUtils.getUserClass(entity.getClass())
		: callbackDiscoverer.resolveDeclaredEntityType(callbackType).getRawClass());
    ......
}
```

after:
```java
@Override
public <T> T callback(Class<? extends EntityCallback> callbackType, T entity, Object... args) {

    Assert.notNull(entity, "Entity must not be null");
    
    Class<T> entityType = (Class<T>) ClassUtils.getUserClass(entity.getClass());
    ......
}
```
