### PR TITLE
Do not create persistent properties for `Map` and `Collection`-like entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.2.4-SNAPSHOT</version>
+	<version>3.2.4-GH-3056-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
+++ b/src/main/java/org/springframework/data/mapping/model/AbstractPersistentProperty.java
@@ -157,15 +157,6 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 
 	@Override
 	public Iterable<? extends TypeInformation<?>> getPersistentEntityTypeInformation() {
-
-		if (isMap() || isCollectionLike()) {
-			return entityTypeInformation.get();
-		}
-
-		if (!isEntity()) {
-			return Collections.emptySet();
-		}
-
 		return entityTypeInformation.get();
 	}
 
@@ -292,6 +283,7 @@ public abstract class AbstractPersistentProperty<P extends PersistentProperty<P>
 		return getActualTypeInformation().getType();
 	}
 
+	@Override
 	public boolean usePropertyAccess() {
 		return usePropertyAccess.get();
 	}

--- a/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/AbstractMappingContextUnitTests.java
@@ -22,14 +22,7 @@ import static org.mockito.Mockito.*;
 import groovy.lang.MetaClass;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +42,7 @@ import org.springframework.data.mapping.ShadowingPropertyTypeWithCtor;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.StreamUtils;
+import org.springframework.data.util.Streamable;
 import org.springframework.data.util.TypeInformation;
 
 /**
@@ -283,6 +277,20 @@ class AbstractMappingContextUnitTests {
 
 		assertThat(context.getPersistentEntities()).map(it -> (Class) it.getType()).contains(Base.class)
 				.doesNotContain(List.class, ArrayList.class);
+	}
+
+	@Test // GH-2390
+	void doesNotCreatePropertiesForMapAndCollectionTypes() {
+
+		assertThat(context.getPersistentEntity(HashSet.class)).isEmpty();
+		assertThat(context.getPersistentEntity(HashMap.class)).isEmpty();
+	}
+
+	@Test // GH-2390
+	void createsPropertiesForStreamableAndIterableTypes() {
+
+		assertThat(context.getPersistentEntity(MyStreamable.class)).hasSize(1);
+		assertThat(context.getPersistentEntity(MyIterable.class)).hasSize(1);
 	}
 
 	@Test // GH-2390
@@ -531,6 +539,30 @@ class AbstractMappingContextUnitTests {
 	}
 
 	static abstract class Base$$SpringProxy$873fa2e extends Base implements SpringProxy, Advised {
+
+	}
+
+	static class MyIterable implements Iterable<StreamComponent> {
+
+		String name;
+
+		@Override
+		public Iterator<StreamComponent> iterator() {
+			return Collections.emptyIterator();
+		}
+	}
+
+	static class MyStreamable implements Streamable<StreamComponent> {
+
+		String name;
+
+		@Override
+		public Iterator<StreamComponent> iterator() {
+			return Collections.emptyIterator();
+		}
+	}
+
+	record StreamComponent(String name) {
 
 	}
 


### PR DESCRIPTION
These types are expected to behave like maps and collections and should not carry properties.

The only exception are types implementing Streamable as Streamable can be used in domain types.

Closes #3056