### PR TITLE
Add support for `BeanNameGenerator` configuration in `Enable…Repositories`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-3082-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
@@ -66,6 +66,8 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	private static final String CONSIDER_NESTED_REPOSITORIES = "considerNestedRepositories";
 	private static final String BOOTSTRAP_MODE = "bootstrapMode";
 	private static final String BEAN_NAME_GENERATOR = "nameGenerator";
+	private static final String INCLUDE_FILTERS = "includeFilters";
+	private static final String EXCLUDE_FILTERS = "excludeFilters";
 
 	private final AnnotationMetadata configMetadata;
 	private final AnnotationMetadata enableAnnotationMetadata;
@@ -175,12 +177,12 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 
 	@Override
 	protected Iterable<TypeFilter> getIncludeFilters() {
-		return parseFilters("includeFilters");
+		return parseFilters(INCLUDE_FILTERS);
 	}
 
 	@Override
 	public Streamable<TypeFilter> getExcludeFilters() {
-		return parseFilters("excludeFilters");
+		return parseFilters(EXCLUDE_FILTERS);
 	}
 
 	@Override
@@ -304,7 +306,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	 */
 	private static boolean hasExplicitFilters(AnnotationAttributes attributes) {
 
-		return Stream.of("includeFilters", "excludeFilters") //
+		return Stream.of(INCLUDE_FILTERS, EXCLUDE_FILTERS) //
 				.anyMatch(it -> attributes.getAnnotationArray(it).length > 0);
 	}
 
@@ -333,13 +335,15 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	 * customized.
 	 *
 	 * @param generator can be {@literal null}.
-	 * @return
+	 * @return the configured {@link BeanNameGenerator} if it is not
+	 *         {@link ConfigurationClassPostProcessor#IMPORT_BEAN_NAME_GENERATOR} or {@link AnnotationBeanNameGenerator}
+	 *         otherwise.
 	 * @since 2.2
 	 */
 	private static BeanNameGenerator defaultBeanNameGenerator(@Nullable BeanNameGenerator generator) {
 
 		return generator == null || ConfigurationClassPostProcessor.IMPORT_BEAN_NAME_GENERATOR.equals(generator) //
-				? new AnnotationBeanNameGenerator() //
+				? AnnotationBeanNameGenerator.INSTANCE //
 				: generator;
 	}
 

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
@@ -174,7 +174,7 @@ public interface RepositoryConfigurationSource {
 	BootstrapMode getBootstrapMode();
 
 	/**
-	 * Returns a human readable description of the repository configuration source for error reporting purposes.
+	 * Returns a human-readable description of the repository configuration source for error reporting purposes.
 	 *
 	 * @return can be {@literal null}.
 	 * @since 2.3

--- a/src/test/java/org/springframework/data/repository/config/EnableRepositories.java
+++ b/src/test/java/org/springframework/data/repository/config/EnableRepositories.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -42,6 +43,8 @@ public @interface EnableRepositories {
 	Class<?> repositoryFactoryBeanClass() default DummyRepositoryFactoryBean.class;
 
 	Class<?> repositoryBaseClass() default PagingAndSortingRepository.class;
+
+	Class<? extends BeanNameGenerator> nameGenerator() default BeanNameGenerator.class;
 
 	String namedQueriesLocation() default "";
 


### PR DESCRIPTION
We now accept a dedicated `BeanNameGenerator` in our `Enable…Repositories` annotations to override the importBeanNameGenerator.

Closes #3082 