### PR TITLE
Add type name to `AbstractRepositoryMetadata` verification exception message

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -56,7 +56,7 @@ public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 	public AbstractRepositoryMetadata(Class<?> repositoryInterface) {
 
 		Assert.notNull(repositoryInterface, "Given type must not be null");
-		Assert.isTrue(repositoryInterface.isInterface(), "Given type must be an interface");
+		Assert.isTrue(repositoryInterface.isInterface(), "Given type ["+ repositoryInterface.getName()+"] must be an interface");
 
 		this.repositoryInterface = repositoryInterface;
 		this.typeInformation = TypeInformation.of(repositoryInterface);

--- a/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractRepositoryMetadata.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Konstntin Ignatyev
  */
 public abstract class AbstractRepositoryMetadata implements RepositoryMetadata {
 


### PR DESCRIPTION
Adding type info in the error message for easier troubleshooting. Got the error

```
java.lang.IllegalArgumentException: Given type must be an interface
	at org.springframework.util.Assert.isTrue(Assert.java:111)
	at org.springframework.data.repository.core.support.AbstractRepositoryMetadata.<init>(AbstractRepositoryMetadata.java:59)
	at org.springframework.data.repository.core.support.DefaultRepositoryMetadata.<init>(DefaultRepositoryMetadata.java:51)
	at org.springframework.data.repository.core.support.AbstractRepositoryMetadata.getMetadata(AbstractRepositoryMetadata.java:77)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.tryAdvance(AbstractList.java:708)
```

for the declaration (Kotlin)

```
@Service
@Transactional
class LitterBizSvc(val litterCollectionRepo: LitterCollectionRepo,
    val eventPub:ApplicationEventPublisher): CrudRepository<LitterCollection, String> by litterCollectionRepo {
```
