### PR TITLE
Fix internal typo of class name

### DIFF
--- a/src/main/java/org/springframework/data/web/config/EnableSpringDataWebSupport.java
+++ b/src/main/java/org/springframework/data/web/config/EnableSpringDataWebSupport.java
@@ -76,7 +76,7 @@ import org.springframework.util.ClassUtils;
 @Import({
 		EnableSpringDataWebSupport.SpringDataWebConfigurationImportSelector.class,
 		EnableSpringDataWebSupport.QuerydslActivator.class,
-		EnableSpringDataWebSupport.SpringDataWebSettingsRegistar.class
+		EnableSpringDataWebSupport.SpringDataWebSettingsRegistrar.class
 })
 public @interface EnableSpringDataWebSupport {
 
@@ -173,7 +173,7 @@ public @interface EnableSpringDataWebSupport {
 	 * @soundtrack Norah Jones - Chasing Pirates
 	 * @since 3.3
 	 */
-	static class SpringDataWebSettingsRegistar implements ImportBeanDefinitionRegistrar {
+	static class SpringDataWebSettingsRegistrar implements ImportBeanDefinitionRegistrar {
 
 		/*
 		 * (non-Javadoc)
@@ -199,4 +199,10 @@ public @interface EnableSpringDataWebSupport {
 			registry.registerBeanDefinition(beanName, definition);
 		}
 	}
+
+	/**
+	 * @see SpringDataWebSettingsRegistrar
+	 */
+	@Deprecated(since = "3.4", forRemoval = true)
+	static class SpringDataWebSettingsRegistar extends SpringDataWebSettingsRegistrar {}
 }


### PR DESCRIPTION
Hi there, I have noticed a small typo in the class SpringDataWebSettingsRegistar => SpringDataWebSettingsRegistrar

Because this is a public class, a simple rename could be breaking change. I have added an alias with deprecation hint for removal.

There is no test that covers such a typo. Since I did not change the functionality at all, I did not add myself.