### PR TITLE
Fix property lookup for projections on Kotlin types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.x-GH-3127-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/projection/PropertyAccessingMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/projection/PropertyAccessingMethodInterceptor.java
@@ -33,6 +33,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Johannes Englmeier
+ * @author Christoph Strobl
  * @since 1.10
  */
 class PropertyAccessingMethodInterceptor implements MethodInterceptor {
@@ -54,12 +55,11 @@ class PropertyAccessingMethodInterceptor implements MethodInterceptor {
 	@Override
 	public Object invoke(@SuppressWarnings("null") MethodInvocation invocation) throws Throwable {
 
-		Method method = invocation.getMethod();
-
-		if (ReflectionUtils.isObjectMethod(method)) {
+		if (ReflectionUtils.isObjectMethod(invocation.getMethod())) {
 			return invocation.proceed();
 		}
 
+		Method method = lookupTargetMethod(invocation, target.getWrappedClass());
 		PropertyDescriptor descriptor = BeanUtils.findPropertyForMethod(method);
 
 		if (descriptor == null) {
@@ -80,5 +80,13 @@ class PropertyAccessingMethodInterceptor implements MethodInterceptor {
 
 	private static boolean isSetterMethod(Method method, PropertyDescriptor descriptor) {
 		return method.equals(descriptor.getWriteMethod());
+	}
+
+	private static Method lookupTargetMethod(MethodInvocation invocation, Class<?> targetType) {
+
+		Method method = BeanUtils.findMethod(targetType, invocation.getMethod().getName(),
+			invocation.getMethod().getParameterTypes());
+
+		return method != null ? method : invocation.getMethod();
 	}
 }

--- a/src/test/java/org/springframework/data/projection/PropertyAccessingMethodInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/projection/PropertyAccessingMethodInterceptorUnitTests.java
@@ -32,6 +32,7 @@ import org.springframework.beans.NotWritablePropertyException;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @ExtendWith(MockitoExtension.class)
 class PropertyAccessingMethodInterceptorUnitTests {
@@ -109,6 +110,15 @@ class PropertyAccessingMethodInterceptorUnitTests {
 
 		assertThatExceptionOfType(NotWritablePropertyException.class)
 				.isThrownBy(() -> new PropertyAccessingMethodInterceptor(new Source()).invoke(invocation));
+	}
+
+	@Test // GH-3127
+	void detectsKotlinPropertiesWithLeadingIsOnTargetType() throws Throwable {
+
+		var source = new WithIsNamedProperty(true);
+		when(invocation.getMethod()).thenReturn(WithIsNamedPropertyProjection.class.getMethod("isValid"));
+
+		assertThat(new PropertyAccessingMethodInterceptor(source).invoke(invocation)).isEqualTo(true);
 	}
 
 	static class Source {

--- a/src/test/kotlin/org/springframework/data/projection/WithIsNamedProperty.kt
+++ b/src/test/kotlin/org/springframework/data/projection/WithIsNamedProperty.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.projection
+
+interface WithIsNamedPropertyProjection {
+	val isValid: Boolean
+}
+
+class WithIsNamedProperty(val isValid : Boolean)


### PR DESCRIPTION
This commit makes sure to use the target objects method to determine the property used for the projection.

Resolves: #3127 