### PR TITLE
Corrected the definition of coroutines

### DIFF
--- a/src/main/antora/modules/ROOT/pages/kotlin/coroutines.adoc
+++ b/src/main/antora/modules/ROOT/pages/kotlin/coroutines.adoc
@@ -1,7 +1,7 @@
 [[kotlin.coroutines]]
 = Coroutines
 
-Kotlin https://kotlinlang.org/docs/reference/coroutines-overview.html[Coroutines] are lightweight threads allowing to write non-blocking code imperatively.
+Kotlin https://kotlinlang.org/docs/reference/coroutines-overview.html[Coroutines] are instances of suspendable computations allowing to write non-blocking code imperatively.
 On language side, `suspend` functions provides an abstraction for asynchronous operations while on library side https://github.com/Kotlin/kotlinx.coroutines[kotlinx.coroutines] provides functions like https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/async.html[`async { }`] and types like https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/index.html[`Flow`].
 
 Spring Data modules provide support for Coroutines on the following scope:


### PR DESCRIPTION
Corrected the definition of coroutines.

Coroutines are often compared to threads, as some of their characterists are similar. As result, coroutines are well described as lightweight threads in various references. This does not mean that coroutines are lightweight threads.
A single coroutine may work on more than a single thread throughout its lifecycle, being suspended and resumed. A single thread may run numerous coroutines sequentially.

[The official document of Kotlin Coroutines](https://kotlinlang.org/docs/coroutines-basics.html) also mentions this point. It describes as:
> A coroutine is an instance of a suspendable computation. It is conceptually similar to a thread, in the sense that it takes a block of code to run that works concurrently with the rest of the code. However, a coroutine is not bound to any particular thread. It may suspend its execution in one thread and resume in another one.
Coroutines can be thought of as light-weight threads, but there is a number of important differences that make their real-life usage very different from threads.