### PR TITLE
Changed the access level of AbstractAggregateRoot's methods to public

### DIFF
--- a/src/main/java/org/springframework/data/domain/AbstractAggregateRoot.java
+++ b/src/main/java/org/springframework/data/domain/AbstractAggregateRoot.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mikhail Polivakha
  * @since 1.13
  */
 public class AbstractAggregateRoot<A extends AbstractAggregateRoot<A>> {
@@ -44,7 +45,7 @@ public class AbstractAggregateRoot<A extends AbstractAggregateRoot<A>> {
 	 * @return the event that has been added.
 	 * @see #andEvent(Object)
 	 */
-	protected <T> T registerEvent(T event) {
+	public <T> T registerEvent(T event) {
 
 		Assert.notNull(event, "Domain event must not be null");
 
@@ -76,7 +77,7 @@ public class AbstractAggregateRoot<A extends AbstractAggregateRoot<A>> {
 	 * @return the aggregate
 	 */
 	@SuppressWarnings("unchecked")
-	protected final A andEventsFrom(A aggregate) {
+	public final A andEventsFrom(A aggregate) {
 
 		Assert.notNull(aggregate, "Aggregate must not be null");
 
@@ -95,7 +96,7 @@ public class AbstractAggregateRoot<A extends AbstractAggregateRoot<A>> {
 	 * @see #registerEvent(Object)
 	 */
 	@SuppressWarnings("unchecked")
-	protected final A andEvent(Object event) {
+	public final A andEvent(Object event) {
 
 		registerEvent(event);
 

--- a/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
+++ b/src/main/java/org/springframework/data/repository/query/SpelQueryContext.java
@@ -285,7 +285,6 @@ public class SpelQueryContext {
 		Map<String, String> getParameterMap() {
 			return expressions;
 		}
-
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/spel/ExpressionDependencies.java
+++ b/src/main/java/org/springframework/data/spel/ExpressionDependencies.java
@@ -102,7 +102,7 @@ public class ExpressionDependencies implements Streamable<ExpressionDependencies
 	 * @return a set of {@link ExpressionDependencies}.
 	 */
 	public static ExpressionDependencies discover(Expression expression) {
-		return expression instanceof SpelExpression ? discover(((SpelExpression) expression).getAST(), true) : none();
+		return expression instanceof SpelExpression spel ? discover(spel.getAST(), true) : none();
 	}
 
 	/**


### PR DESCRIPTION
This PR consists of two things:

1. Changing the access level of API methods to public in `AbstractAggregateRoot`. The problem is that this class is supposed to be extended, but because the API access level is `protected` [the following is required](https://github.com/mipo256/spring-data-features-we-do-not-know-about/blob/master/src/main/java/io/mpolivaha/domain_events/CargoEntity.java#L40). That is a bit awkward to override the method to just call the `super` implementation. 

2. I've created a single instance of the `IllegalStateException` exception to throw in case of domain events change. This is to optimize the stacktrace creation and thus the performance of this case. Since the exception was pure for control flow, it does not break the contract or change the behavior. [Reference](https://shipilev.net/blog/2014/exceptional-performance/#Rationale).   