### PR TITLE
Respect oneIndexedParameters property when serialising Page to JSON

### DIFF
--- a/src/main/java/org/springframework/data/web/PagedModel.java
+++ b/src/main/java/org/springframework/data/web/PagedModel.java
@@ -33,22 +33,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @author Oliver Drotbohm
  * @author Greg Turnquist
+ * @author Lazar Radinović
  * @since 3.3
  */
 public class PagedModel<T> {
 
 	private final Page<T> page;
 
+	private final boolean oneIndexedParameters;
+
 	/**
 	 * Creates a new {@link PagedModel} for the given {@link Page}.
 	 *
-	 * @param page must not be {@literal null}.
+	 * @param page                must not be {@literal null}.
+	 * @param oneIndexedParameters indicates weather to serialize page number by adding 0 or 1
 	 */
-	public PagedModel(Page<T> page) {
+	public PagedModel(Page<T> page, boolean oneIndexedParameters) {
 
 		Assert.notNull(page, "Page must not be null");
 
 		this.page = page;
+		this.oneIndexedParameters = oneIndexedParameters;
 	}
 
 	@JsonProperty
@@ -59,7 +64,7 @@ public class PagedModel<T> {
 	@Nullable
 	@JsonProperty("page")
 	public PageMetadata getMetadata() {
-		return new PageMetadata(page.getSize(), page.getNumber(), page.getTotalElements(),
+		return new PageMetadata(page.getSize(), page.getNumber() + (oneIndexedParameters ? 1 : 0), page.getTotalElements(),
 				page.getTotalPages());
 	}
 

--- a/src/main/java/org/springframework/data/web/config/PageModuleCustomizer.java
+++ b/src/main/java/org/springframework/data/web/config/PageModuleCustomizer.java
@@ -1,0 +1,19 @@
+package org.springframework.data.web.config;
+
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link SpringDataJacksonConfiguration.PageModule} configuration.
+ *
+ * @author Lazar Radinović
+ * @since 3.4.0
+ */
+public interface PageModuleCustomizer {
+    /**
+     * Customize the given {@link SpringDataJacksonConfiguration.PageModule}.
+     *
+     * @param pageModule the {@link SpringDataJacksonConfiguration.PageModule} to customize, will never be {@literal null}.
+     */
+    void customize(SpringDataJacksonConfiguration.PageModule pageModule);
+}


### PR DESCRIPTION
I have noticed when using Spring Data in my project, I can set property `spring.data.web.one-indexed-parameters` to true and have my page numbering start from 1 in my API. However when returning Page<T> from controller, this value is not respected and it will always return page number decreased by 1. 

This PR fixes that by adding `oneIndexedParameters` attribute to `SpringDataJacksonConfiguration.PageModule` class. I have also added `PageModuleCustomizer` to be used to define wether PageModule will assume 1-based page number indexes in the request parameters

In order to respect this property, a PageModuleCustomizer needs to be defined:

```
@Bean 
public PageModuleCustomizer pageModuleCustomizer() {
    return pageModule -> {
        pageModule.setOneIndexedParameters(true); 
    }
}
```

Also this bean can be defined in Spring Boot Autoconfigure project, so spring will automatically take care of this.