### PR TITLE
Fix NPE in `CrudRepositoryExtensions`

### DIFF
--- a/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
@@ -21,6 +21,7 @@ package org.springframework.data.repository
  * @param id the entity id.
  * @return the entity with the given id or `null` if none found
  * @author Sebastien Deleuze
+ * @author Oscar Hernandez
  * @since 2.1.4
  */
 fun <T, ID: Any> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)

--- a/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
@@ -23,4 +23,4 @@ package org.springframework.data.repository
  * @author Sebastien Deleuze
  * @since 2.1.4
  */
-fun <T, ID> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id!!).orElse(null)
+fun <T, ID: Any> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)


### PR DESCRIPTION
Erasure of nullability information was causing NPEs in the forced non-null assertion, as it allowed to pass a nullable value, see following snippet that would pass compilation correctly, but throw an unexpected NPE:

```
interface Repo : ListCrudRepository<User, String>

	val repo: Repo = mockk()

	@Test
	fun `CrudRepository#findByIdOrNull() extension should not throw NPE`() {
		val id: String? = null
		// compiler allows null value to be passed to findByIdOrNull, so NPE is thrown
		// I believe this is we lose the non-null type info when the repo extends a java interface,
		// which extends CrudRepository
		repo.findByIdOrNull(id)
	}
```

The fix enforces the generic `ID` type to be a not-null type, therefore the above code no longer compiles. 
![image](https://github.com/user-attachments/assets/18c40afa-a539-439e-a915-4294c972cbe2)


Not sure how to add a test for this, since the fix is on a static-type level and the problematic code no longer compiles. Could add in a comment, I guess?