### PR TITLE
Remove outdated information from Javadoc for PageableHandlerMethodArgumentResolver[Support]

### DIFF
--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolver.java
@@ -26,8 +26,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
  * Extracts paging information from web requests and thus allows injecting {@link Pageable} instances into controller
- * methods. Request properties to be parsed can be configured. Default configuration uses request parameters beginning
- * with {@link #DEFAULT_PAGE_PARAMETER}{@link #DEFAULT_QUALIFIER_DELIMITER}.
+ * methods. Request properties to be parsed can be configured.
  *
  * @author Oliver Gierke
  * @author Nick Williams

--- a/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverSupport.java
+++ b/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverSupport.java
@@ -34,8 +34,7 @@ import org.springframework.util.StringUtils;
 /**
  * Base class providing methods for handler method argument resolvers to create paging information from web requests and
  * thus allows injecting {@link Pageable} instances into controller methods. Request properties to be parsed can be
- * configured. Default configuration uses request parameters beginning with
- * {@link #DEFAULT_PAGE_PARAMETER}{@link #DEFAULT_QUALIFIER_DELIMITER}.
+ * configured.
  *
  * @author Mark Paluch
  * @author Vedran Pavic


### PR DESCRIPTION
The information about default parameter prefix seems outdated. It looks like that portion of the comment was added back in the days when the paging parameters were named `page.page` and `page.size` by default and now they are just `page` and `size` by default. Also there is a missing whitespace between identifiers in HTML docs:
<img width="1195" alt="Screenshot 2024-10-25 at 00 09 54" src="https://github.com/user-attachments/assets/6596ac85-56b6-41c8-a92e-ef8026036c13">


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
