### PR TITLE
Fix Add Multiple DeferredRepositoryInitializationListener in `Reposit…

### DIFF
--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationDelegate.java
@@ -92,7 +92,7 @@ public class RepositoryConfigurationDelegate {
 	 * @param environment must not be {@literal null}.
 	 */
 	public RepositoryConfigurationDelegate(RepositoryConfigurationSource configurationSource,
-			ResourceLoader resourceLoader, Environment environment) {
+										   ResourceLoader resourceLoader, Environment environment) {
 
 		this.isXml = configurationSource instanceof XmlRepositoryConfigurationSource;
 		boolean isAnnotation = configurationSource instanceof AnnotationRepositoryConfigurationSource;
@@ -117,7 +117,7 @@ public class RepositoryConfigurationDelegate {
 	 *         {@link Environment}.
 	 */
 	private static Environment defaultEnvironment(@Nullable Environment environment,
-			@Nullable ResourceLoader resourceLoader) {
+												  @Nullable ResourceLoader resourceLoader) {
 
 		if (environment != null) {
 			return environment;
@@ -136,7 +136,7 @@ public class RepositoryConfigurationDelegate {
 	 * @see org.springframework.beans.factory.support.BeanDefinitionRegistry
 	 */
 	public List<BeanComponentDefinition> registerRepositoriesIn(BeanDefinitionRegistry registry,
-			RepositoryConfigurationExtension extension) {
+																RepositoryConfigurationExtension extension) {
 
 		if (logger.isInfoEnabled()) {
 			logger.info(LogMessage.format("Bootstrapping Spring Data %s repositories in %s mode.", //
@@ -222,7 +222,7 @@ public class RepositoryConfigurationDelegate {
 	}
 
 	private void registerAotComponents(BeanDefinitionRegistry registry, RepositoryConfigurationExtension extension,
-			Map<String, RepositoryConfigurationAdapter<?>> metadataByRepositoryBeanName) {
+									   Map<String, RepositoryConfigurationAdapter<?>> metadataByRepositoryBeanName) {
 
 		BeanDefinitionBuilder repositoryAotProcessor = BeanDefinitionBuilder
 				.rootBeanDefinition(extension.getRepositoryAotProcessor()).setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
@@ -245,7 +245,7 @@ public class RepositoryConfigurationDelegate {
 	 * @param registry must not be {@literal null}.
 	 */
 	private static void potentiallyLazifyRepositories(Map<String, RepositoryConfiguration<?>> configurations,
-			BeanDefinitionRegistry registry, BootstrapMode mode) {
+													  BeanDefinitionRegistry registry, BootstrapMode mode) {
 
 		if (!DefaultListableBeanFactory.class.isInstance(registry) || BootstrapMode.DEFAULT.equals(mode)) {
 			return;
@@ -272,8 +272,10 @@ public class RepositoryConfigurationDelegate {
 
 			logger.debug("Registering deferred repository initialization listener.");
 
-			beanFactory.registerSingleton(DeferredRepositoryInitializationListener.class.getName(),
-					new DeferredRepositoryInitializationListener(beanFactory));
+			if (!beanFactory.containsBean(DeferredRepositoryInitializationListener.class.getName())) {
+				beanFactory.registerSingleton(DeferredRepositoryInitializationListener.class.getName(),
+						new DeferredRepositoryInitializationListener(beanFactory));
+			}
 		}
 	}
 

--- a/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationDelegateUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryConfigurationDelegateUnitTests.java
@@ -64,6 +64,7 @@ import org.springframework.data.repository.sample.ProductRepository;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author xeounxzxu
  * @soundtrack Richard Spaven - Tribute (Whole Other*)
  */
 @ExtendWith(MockitoExtension.class)
@@ -109,7 +110,16 @@ class RepositoryConfigurationDelegateUnitTests {
 		var beanFactory = assertLazyRepositoryBeanSetup(DeferredConfig.class);
 
 		assertThat(beanFactory.getBeanNamesForType(DeferredRepositoryInitializationListener.class)).isNotEmpty();
+	}
 
+	@Test
+	void registersMultiDeferredRepositoryInitializationListener() {
+
+		var beanFactory = assertLazyRepositoryBeanSetup(DeferredConfig.class, OtherDeferredConfig.class);
+
+		assertThat(beanFactory.getBeanNamesForType(DeferredRepositoryInitializationListener.class)).isNotEmpty();
+		assertThat(beanFactory.getBeanNamesForType(AddressRepository.class)).isNotEmpty();
+		assertThat(beanFactory.getBeanNamesForType(ProductRepository.class)).isNotEmpty();
 	}
 
 	@Test // DATACMNS-1832
@@ -276,9 +286,9 @@ class RepositoryConfigurationDelegateUnitTests {
 		assertThat(it.getGeneric(1).resolve()).isEqualTo(Person.class);
 	}
 
-	private static ListableBeanFactory assertLazyRepositoryBeanSetup(Class<?> configClass) {
+	private static ListableBeanFactory assertLazyRepositoryBeanSetup(Class<?>... componentClasses) {
 
-		var context = new AnnotationConfigApplicationContext(configClass);
+		var context = new AnnotationConfigApplicationContext(componentClasses);
 
 		assertThat(context.getDefaultListableBeanFactory().getAutowireCandidateResolver())
 				.isInstanceOf(LazyRepositoryInjectionPointResolver.class);
@@ -308,6 +318,12 @@ class RepositoryConfigurationDelegateUnitTests {
 			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = AddressRepository.class),
 			bootstrapMode = BootstrapMode.DEFERRED)
 	static class DeferredConfig {}
+
+	@ComponentScan(basePackageClasses = ProductRepository.class)
+	@EnableRepositories(basePackageClasses = ProductRepository.class,
+			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = AddressRepository.class),
+			bootstrapMode = BootstrapMode.DEFERRED)
+	static class OtherDeferredConfig {}
 
 	@EnableRepositories(basePackageClasses = MyOtherRepository.class,
 			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = MyOtherRepository.class),


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


@mp911de 

hello.

I changed the content for the following reasons.

issue:  https://github.com/spring-projects/spring-data-jpa/issues/3495

If you use two or more `EnableJpaRepositories` and use `DEFERRED` bootstrap mode, an error that the bean cannot be registered will occur. 

Logic was added to check the presence of a bean. And we ran a repository check as a test case. 

