### PR TITLE
fix typo in example code

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
@@ -533,7 +533,7 @@ The following example shows how to limit the query size:
 .Limiting the result size of a query with `Top` and `First`
 [source,java]
 ----
-List<User> findByLastname(Limit limit);
+List<User> findByLastname(String lastname, Limit limit);
 
 User findFirstByOrderByLastnameAsc();
 


### PR DESCRIPTION
fixed missing parameter in example code

Before
```java
List<User> findByLastname(Limit limit);
```

After
```java
List<User> findByLastname(String lastname, Limit limit);
```