### PR TITLE
Introduce `KIterablePropertyPath`

### DIFF
--- a/src/test/kotlin/org/springframework/data/mapping/KPropertyPathTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/KPropertyPathTests.kt
@@ -24,6 +24,7 @@ import org.junit.Test
  * @author Tjeu Kayim
  * @author Yoann de Martino
  * @author Mark Paluch
+ * @author Mikhail Polivakha
  */
 class KPropertyPathTests {
 
@@ -41,6 +42,14 @@ class KPropertyPathTests {
 		val property = (Book::author / Author::name).toDotPath()
 
 		assertThat(property).isEqualTo("author.name")
+	}
+
+	@Test // DATACMNS-3010
+	fun `Convert from Iterable nested KProperty to field name`() {
+
+		val property = (User::addresses / Address::street).toDotPath()
+
+		assertThat(property).isEqualTo("addresses.street")
 	}
 
 	@Test // DATACMNS-1835
@@ -106,4 +115,8 @@ class KPropertyPathTests {
 
 	class Book(val title: String, val author: Author)
 	class Author(val name: String)
+
+    class User(val addresses: List<Address>)
+
+    class Address(val street: String)
 }


### PR DESCRIPTION
Fixes #3010. Fixes the issue in the type safe way, so that this now works :

```
class User(val addresses: List<Address>)
class Address(val street: String)

User::addresses / Author::street contains "Austin" 
```

Where `toDotPath()` renders to `addresses.street`. In order to solve this ticket in the type safe way, without easing the generic boundary from `KProperty1<T, U>` to `KProperty1<Any, U>`, a new `KIterablePropertyPath` needs to be introduced. The solution with `KProperty1<Any, U>` allows for non type safe usages of the API, which is not generally a good idea to begin with.