### PR TITLE
Expose query method metadata

### DIFF
--- a/src/main/java/org/springframework/data/repository/query/Parameters.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameters.java
@@ -38,6 +38,8 @@ import org.springframework.util.Assert;
 /**
  * Abstracts method parameters that have to be bound to query parameters or applied to the query independently.
  *
+ * @param <T> The exact type of {@link Parameter} inside {@link Parameters}
+ * @param <S> The exact type of {@link Parameters} to be used. Generified to allow for recursive generics.
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Johannes Englmeier

--- a/src/main/java/org/springframework/data/repository/query/QueryMethod.java
+++ b/src/main/java/org/springframework/data/repository/query/QueryMethod.java
@@ -86,7 +86,7 @@ public class QueryMethod {
 		this.method = method;
 		this.unwrappedReturnType = potentiallyUnwrapReturnTypeFor(metadata, method);
 		this.metadata = metadata;
-		this.parameters = createParameters(method, metadata.getDomainTypeInformation());
+		this.parameters = createParameters(ParametersSource.of(getMetadata(), method));
 
 		this.domainClass = Lazy.of(() -> {
 
@@ -316,11 +316,11 @@ public class QueryMethod {
 		return resultProcessor;
 	}
 
-	RepositoryMetadata getMetadata() {
+	public RepositoryMetadata getMetadata() {
 		return metadata;
 	}
 
-	Method getMethod() {
+	public Method getMethod() {
 		return method;
 	}
 
@@ -329,7 +329,7 @@ public class QueryMethod {
 		return method.toString();
 	}
 
-	private static Class<? extends Object> potentiallyUnwrapReturnTypeFor(RepositoryMetadata metadata, Method method) {
+	private static Class<?> potentiallyUnwrapReturnTypeFor(RepositoryMetadata metadata, Method method) {
 
 		TypeInformation<?> returnType = metadata.getReturnType(method);
 		if (QueryExecutionConverters.supports(returnType.getType())


### PR DESCRIPTION
I think it is worth to make the accessors `public` (or `protected` maybe) for method and `RepositoryMetadata`. The Spring Data JDBC for instance, because it cannot access the `method` field in the `QueryMethod` [has to re-declare it inside the `JdbcQueryMethod`](https://github.com/spring-projects/spring-data-relational/blob/main/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethod.java#L58), so it is clearly redundant, since the method already is present in the parent.

P.S: This is also would help us implemented the `YdbQueryMethod` in the [Spring Data JDBC dialect for YDB database](https://github.com/ydb-platform/ydb-java-dialects/issues/173). 

CC: @mp911de 