### PR TITLE
Fix broken docs caused by incorrect `feature-scroll` usage in Antora

### DIFF
--- a/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/src/main/antora/modules/ROOT/pages/index.adoc
@@ -3,7 +3,6 @@
 Oliver Gierke; Thomas Darimont; Christoph Strobl; Mark Pollack; Thomas Risberg; Mark Paluch; Jay Bryant
 :revnumber: {version}
 :revdate: {localdate}
-:feature-scroll: true
 
 (C) 2008-2025 The original authors.
 

--- a/src/main/antora/modules/ROOT/pages/repositories/core-concepts.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/core-concepts.adoc
@@ -1,5 +1,6 @@
 [[repositories.core-concepts]]
 = Core concepts
+:feature-scroll:
 
 The central interface in the Spring Data repository abstraction is `Repository`.
 It takes the domain class to manage as well as the identifier type of the domain class as type arguments.

--- a/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
@@ -1,5 +1,6 @@
 [[repositories.query-methods.details]]
 = Defining Query Methods
+:feature-scroll:
 
 The repository proxy has two ways to derive a store-specific query from the method name:
 
@@ -457,10 +458,10 @@ ifdef::feature-scroll[]
 | `limit + 1` at `OffsetScrollPosition.getOffset()`
 | One to many queries fetching data starting at `OffsetScrollPosition.getOffset()` applying limiting.
 a| A `Window` can only navigate to the next `Window`.
-endif::[]
 
 * `Window` provides details whether there is more data to fetch.
 * Offset-based queries becomes inefficient when the offset is too large because the database still has to materialize the full result.
+endif::[]
 
 | `Page<T>`
 | `Pageable.getPageSize()`  at `Pageable.getOffset()`
@@ -518,8 +519,6 @@ QSort sort = QSort.by(QPerson.firstname.asc())
   .and(QSort.by(QPerson.lastname.desc()));
 ----
 
-ifdef::feature-scroll[]
-endif::[]
 
 [[repositories.limit-query-result]]
 === Limiting Query Results


### PR DESCRIPTION
There are a couple of issues with the `feature-scroll` attribute in the Antora docs:

- The `endif::[]` for the _Offset-based Window<T>_ table row is placed incorrectly:
https://github.com/spring-projects/spring-data-commons/blob/f4e9581d23472fb40f45346ec1ed2e5cb0a878e0/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc?plain=1#L455-L464
This causes the table to break when `feature-scroll` [is not set](https://docs.spring.io/spring-data/commons/reference/repositories/query-methods-details.html#repositories.scrolling.guidance):
<img width="1501" alt="Screenshot 2025-03-29 at 22 02 53" src="https://github.com/user-attachments/assets/7190b487-a3d0-424c-9dcf-7d3e4343e27e" />

- Defining `:feature-scroll: true` in [index.adoc](https://github.com/spring-projects/spring-data-commons/blob/f4e9581d23472fb40f45346ec1ed2e5cb0a878e0/src/main/antora/modules/ROOT/pages/index.adoc?plain=1#L6) has no effect because attributes set on one page are [not visible to other pages](https://docs.antora.org/antora/latest/playbook/asciidoc-attributes/#precedence-rules). Additionally, setting the attribute value to `true` is redundant — `ifdef` blocks are evaluated based on whether the attribute is defined, regardless of its value ([source](https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/)).

**As a result, Scroll API-related content is always hidden in the documentation.**

This PR fixes the above by explicitly defining the `:feature-scroll:` attribute in the two pages where it's used:

- [query-methods-details.adoc](https://github.com/spring-projects/spring-data-commons/blob/main/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc)
- [core-concepts.adoc](https://github.com/spring-projects/spring-data-commons/blob/main/src/main/antora/modules/ROOT/pages/repositories/core-concepts.adoc)