### PR TITLE
Add `getRequiredName` and `hasName` API to `org.springframework.data.mapping.Parameter`.

### DIFF
--- a/src/main/java/org/springframework/data/mapping/Parameter.java
+++ b/src/main/java/org/springframework/data/mapping/Parameter.java
@@ -33,6 +33,7 @@ import org.springframework.util.StringUtils;
  * @param <T> the type of the parameter
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Chris Bono
  */
 public class Parameter<T, P extends PersistentProperty<P>> {
 
@@ -97,6 +98,31 @@ public class Parameter<T, P extends PersistentProperty<P>> {
 	@Nullable
 	public String getName() {
 		return name;
+	}
+
+	/**
+	 * Returns the required parameter name.
+	 *
+	 * @return the parameter name or throws {@link IllegalStateException} if the parameter does not have a name
+	 * @since 3.5
+	 */
+	public String getRequiredName() {
+
+		if (!hasName()) {
+			throw new IllegalStateException("No name associated with this parameter");
+		}
+
+		return getName();
+	}
+
+	/**
+	 * Returns whether the parameter has a name.
+	 *
+	 * @return whether the parameter has a name
+	 * @since 3.5
+	 */
+	public boolean hasName() {
+		return this.name != null;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/mapping/ParameterUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/ParameterUnitTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.util.TypeInformation;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Chris Bono
  */
 @ExtendWith(MockitoExtension.class)
 class ParameterUnitTests<P extends PersistentProperty<P>> {
@@ -147,6 +148,35 @@ class ParameterUnitTests<P extends PersistentProperty<P>> {
 		Parameter<StaticType, P> iFace = new Parameter<StaticType, P>("outer", TypeInformation.of(StaticType.class),
 				annotations, pe);
 		assertThat(iFace.isEnclosingClassParameter()).isFalse();
+	}
+
+	@Test // GH-3088
+	void getRequiredNameDoesNotThrowExceptionWhenHasName() {
+
+		var parameter = new Parameter<>("someName", type, annotations, entity);
+		assertThat(parameter.getRequiredName()).isEqualTo("someName");
+	}
+
+	@Test // GH-3088
+	void getRequiredNameThrowsExceptionWhenHasNoName() {
+
+		var parameter = new Parameter<>(null, type, annotations, entity);
+		assertThatIllegalStateException().isThrownBy(() -> parameter.getRequiredName())
+				.withMessage("No name associated with this parameter");
+	}
+
+	@Test // GH-3088
+	void hasNameReturnsTrueWhenHasName() {
+
+		var parameter = new Parameter<>("someName", type, annotations, entity);
+		assertThat(parameter.hasName()).isTrue();
+	}
+
+	@Test // GH-3088
+	void hasNameReturnsFalseWhenHasNoName() {
+
+		var parameter = new Parameter<>(null, type, annotations, entity);
+		assertThat(parameter.hasName()).isFalse();
 	}
 
 	interface IFace {


### PR DESCRIPTION
Introduces a more convenient API to simplify the caller side especially for conditionals that want to determine whether a parameter name is present.

Closes #3088

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
