### PR TITLE
Avoid matching multipart parameters annotated with @ModelAttribute

### DIFF
--- a/src/main/java/org/springframework/data/web/ProjectedPayload.java
+++ b/src/main/java/org/springframework/data/web/ProjectedPayload.java
@@ -15,11 +15,10 @@
  */
 package org.springframework.data.web;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
-
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -27,11 +26,12 @@ import java.lang.annotation.Target;
  * response payloads to.
  *
  * @author Oliver Gierke
+ * @author Chris Bono
  * @soundtrack
  * @since 1.13
  */
 @Documented
-@Retention(RUNTIME)
-@Target(TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.PARAMETER })
 public @interface ProjectedPayload {
 }

--- a/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
@@ -36,11 +36,13 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.annotation.ModelAttributeMethodProcessor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.multipart.support.MultipartResolutionDelegate;
 
 /**
  * {@link HandlerMethodArgumentResolver} to create Proxy instances for interface based controller method parameters.
  *
  * @author Oliver Gierke
+ * @author Chris Bono
  * @since 1.10
  */
 public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodProcessor
@@ -88,9 +90,9 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 			return false;
 		}
 
-		// Annotated parameter
-		if (parameter.getParameterAnnotation(ProjectedPayload.class) != null
-				|| parameter.getParameterAnnotation(ModelAttribute.class) != null) {
+		// Annotated parameter (excluding multipart @ModelAttribute)
+		if (parameter.hasParameterAnnotation(ProjectedPayload.class) ||
+				(parameter.hasParameterAnnotation(ModelAttribute.class) && !MultipartResolutionDelegate.isMultipartArgument(parameter))) {
 			return true;
 		}
 

--- a/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
@@ -90,9 +90,9 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 			return false;
 		}
 
-		// Annotated parameter (excluding multipart @ModelAttribute)
-		if (parameter.hasParameterAnnotation(ProjectedPayload.class) ||
-				(parameter.hasParameterAnnotation(ModelAttribute.class) && !MultipartResolutionDelegate.isMultipartArgument(parameter))) {
+		// Annotated parameter (excluding multipart)
+		if ((parameter.hasParameterAnnotation(ProjectedPayload.class) || parameter.hasParameterAnnotation(
+				ModelAttribute.class)) && !MultipartResolutionDelegate.isMultipartArgument(parameter)) {
 			return true;
 		}
 

--- a/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
@@ -27,11 +27,13 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * Unit tests for {@link ProxyingHandlerMethodArgumentResolver}.
  *
  * @author Oliver Gierke
+ * @author Chris Bono
  * @soundtrack Karlijn Langendijk & Sönke Meinen - Englishman In New York (Sting,
  *             https://www.youtube.com/watch?v=O7LZsqrnaaA)
  */
@@ -88,6 +90,14 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		assertThat(resolver.supportsParameter(parameter)).isTrue();
 	}
 
+	@Test // GH-3258
+	void doesNotSupportAtModelAttributeForMultipartParam() throws Exception {
+
+		var parameter = getParameter("withModelAttributeMultipart", MultipartFile.class);
+
+		assertThat(resolver.supportsParameter(parameter)).isFalse();
+	}
+
 	private static MethodParameter getParameter(String methodName, Class<?> parameterType) {
 
 		var method = ReflectionUtils.findMethod(Controller.class, methodName, parameterType);
@@ -112,5 +122,7 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		void withForeignAnnotation(@Autowired SampleInterface param);
 
 		void withModelAttribute(@ModelAttribute SampleInterface param);
+
+		void withModelAttributeMultipart(@ModelAttribute MultipartFile file);
 	}
 }

--- a/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
@@ -98,6 +98,22 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		assertThat(resolver.supportsParameter(parameter)).isFalse();
 	}
 
+	@Test // GH-3258
+	void doesSupportAtProjectedPayload() throws Exception {
+
+		var parameter = getParameter("withProjectedPayload", SampleInterface.class);
+
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
+	}
+
+	@Test // GH-3258
+	void doesNotSupportAtProjectedPayloadForMultipartParam() throws Exception {
+
+		var parameter = getParameter("withProjectedPayloadMultipart", MultipartFile.class);
+
+		assertThat(resolver.supportsParameter(parameter)).isFalse();
+	}
+
 	private static MethodParameter getParameter(String methodName, Class<?> parameterType) {
 
 		var method = ReflectionUtils.findMethod(Controller.class, methodName, parameterType);
@@ -124,5 +140,9 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		void withModelAttribute(@ModelAttribute SampleInterface param);
 
 		void withModelAttributeMultipart(@ModelAttribute MultipartFile file);
+
+		void withProjectedPayload(@ProjectedPayload SampleInterface param);
+
+		void withProjectedPayloadMultipart(@ProjectedPayload MultipartFile file);
 	}
 }


### PR DESCRIPTION
The ProxyHandlerMethodArgumentResolver now avoids matching multipart parameters annotated with @ModelAttribute. This allows multipart parameters to be handled by RequestParamMethodArgumentResolver which properly handles multipart arguments.

In 3.3.3 the `ProxyingHandlerMethodArgumentResolver` would report that it **does not** support the `@ModelAttribute MultipartFile file` parameter and then the next handler in the chain (`RequestParamMethodArgumentResolver`) was able to properly handle the multipart file arg.

In 3.3.4 ([commit](https://github.com/mipo256/spring-data-commons/commit/8ab55e4a195691202ec9fe8d510135443fed1353#diff-49193f625b12d1a6678bf4aa6b5a8eedd6edcbc3a208da6e8f4f8f8bfe302f09R32-R93)) the `ProxyingHandlerMethodArgumentResolver` reports that it **does** support the `@ModelAttribute MultipartFile file` parameter and then it fails to properly handle the multipart file arg.

Fixes #3258
Related tickets #2937

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
