### PR TITLE
Refine Repository Composition retrieval during AOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.x-GH-3279-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/Parameter.java
+++ b/src/main/java/org/springframework/data/mapping/Parameter.java
@@ -118,6 +118,7 @@ public class Parameter<T, P extends PersistentProperty<P>> {
 	 * @since 3.5
 	 * @see org.springframework.core.ParameterNameDiscoverer
 	 */
+	@SuppressWarnings("NullAway")
 	public String getRequiredName() {
 
 		if (!hasName()) {

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilder.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilder.java
@@ -138,9 +138,8 @@ class AotRepositoryBuilder {
 		this.customizer.customize(repositoryInformation, generationMetadata, builder);
 		JavaFile javaFile = JavaFile.builder(packageName(), builder.build()).build();
 
-		// TODO: module identifier
 		AotRepositoryMetadata metadata = new AotRepositoryMetadata(repositoryInformation.getRepositoryInterface().getName(),
-				"", repositoryType, methodMetadata);
+			repositoryInformation.moduleName() != null ? repositoryInformation.moduleName() : "", repositoryType, methodMetadata);
 
 		return new AotBundle(javaFile, metadata.toJson());
 	}
@@ -148,14 +147,14 @@ class AotRepositoryBuilder {
 	private void contributeMethod(Method method, RepositoryComposition repositoryComposition,
 			List<AotRepositoryMethod> methodMetadata, TypeSpec.Builder builder) {
 
-		if (repositoryInformation.isCustomMethod(method) || repositoryInformation.isBaseClassMethod(method)) {
+		if (repositoryInformation.isCustomMethod(method) || (repositoryInformation.isBaseClassMethod(method) && !repositoryInformation.isQueryMethod(method))) {
 
 			RepositoryFragment<?> fragment = repositoryComposition.findFragment(method);
 
 			if (fragment != null) {
 				methodMetadata.add(getFragmentMetadata(method, fragment));
+				return;
 			}
-			return;
 		}
 
 		if (method.isBridge() || method.isDefault() || java.lang.reflect.Modifier.isStatic(method.getModifiers())) {

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilder.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilder.java
@@ -179,7 +179,7 @@ class AotRepositoryBuilder {
 				? AotRepositoryMetadata.RepositoryType.REACTIVE
 				: AotRepositoryMetadata.RepositoryType.IMPERATIVE;
 
-		String jsonModuleName = moduleName.replaceAll("Reactive", "").trim();
+		String jsonModuleName = moduleName != null ? moduleName.replaceAll("Reactive", "").trim() : null;
 
 		return new AotRepositoryMetadata(repositoryInformation.getRepositoryInterface().getName(), jsonModuleName,
 				repositoryType, methodMetadata);

--- a/src/main/java/org/springframework/data/repository/aot/generate/MethodContributor.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/MethodContributor.java
@@ -36,7 +36,7 @@ public abstract class MethodContributor<M extends QueryMethod> {
 	private final M queryMethod;
 	private final QueryMetadata metadata;
 
-	private MethodContributor(M queryMethod, QueryMetadata metadata) {
+	MethodContributor(M queryMethod, QueryMetadata metadata) {
 		this.queryMethod = queryMethod;
 		this.metadata = metadata;
 	}

--- a/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
@@ -32,7 +32,6 @@ import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.javapoet.JavaFile;
 import org.springframework.javapoet.TypeName;
 import org.springframework.javapoet.TypeSpec;
-import org.springframework.util.StringUtils;
 
 /**
  * Contributor for AOT repository fragments.
@@ -131,11 +130,7 @@ public class RepositoryContributor {
 	}
 
 	private static String getRepositoryJsonFileName(Class<?> repositoryInterface) {
-
-		String repositoryJsonName = repositoryInterface.getSimpleName() + ".json";
-		String repositoryJsonPath = repositoryInterface.getPackageName().replace('.', '/');
-
-		return StringUtils.hasText(repositoryJsonPath) ? repositoryJsonPath + "/" + repositoryJsonName : repositoryJsonName;
+		return repositoryInterface.getName().replace('.', '/') + ".json";
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/AnnotationRepositoryConfigurationSource.java
@@ -65,6 +65,7 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 	private static final String QUERY_LOOKUP_STRATEGY = "queryLookupStrategy";
 	private static final String REPOSITORY_FACTORY_BEAN_CLASS = "repositoryFactoryBeanClass";
 	private static final String REPOSITORY_BASE_CLASS = "repositoryBaseClass";
+	private static final String REPOSITORY_FRAGMENTS_CONTRIBUTOR_CLASS = "fragmentsContributor";
 	private static final String CONSIDER_NESTED_REPOSITORIES = "considerNestedRepositories";
 	private static final String BOOTSTRAP_MODE = "bootstrapMode";
 	private static final String BEAN_NAME_GENERATOR = "nameGenerator";
@@ -185,6 +186,16 @@ public class AnnotationRepositoryConfigurationSource extends RepositoryConfigura
 		Class<?> repositoryBaseClass = attributes.getClass(REPOSITORY_BASE_CLASS);
 		return DefaultRepositoryBaseClass.class.equals(repositoryBaseClass) ? Optional.empty()
 				: Optional.of(repositoryBaseClass.getName());
+	}
+
+	@Override
+	public Optional<String> getRepositoryFragmentsContributorClassName() {
+
+		if (!attributes.containsKey(REPOSITORY_FRAGMENTS_CONTRIBUTOR_CLASS)) {
+			return Optional.empty();
+		}
+
+		return Optional.of(attributes.getClass(REPOSITORY_FRAGMENTS_CONTRIBUTOR_CLASS).getName());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryBeanDefinitionPropertiesDecorator.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryBeanDefinitionPropertiesDecorator.java
@@ -55,7 +55,7 @@ class AotRepositoryBeanDefinitionPropertiesDecorator {
 		// bring in properties as usual
 		builder.add(inheritedProperties.get());
 
-		builder.add("beanDefinition.getPropertyValues().addPropertyValue(\"repositoryFragments\", new $T() {\n",
+		builder.add("beanDefinition.getPropertyValues().addPropertyValue(\"repositoryFragmentsFunction\", new $T() {\n",
 				RepositoryFactoryBeanSupport.RepositoryFragmentsFunction.class);
 		builder.indent();
 		builder.add("public $T getRepositoryFragments($T beanFactory, $T context) {\n",

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryContext.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryContext.java
@@ -16,9 +16,9 @@
 package org.springframework.data.repository.config;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.Set;
 
-import org.springframework.core.SpringProperties;
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.data.aot.AotContext;
 import org.springframework.data.repository.core.RepositoryInformation;
@@ -28,8 +28,9 @@ import org.springframework.data.repository.core.RepositoryInformation;
  *
  * @author Christoph Strobl
  * @author John Blum
- * @see AotContext
+ * @author Mark Paluch
  * @since 3.0
+ * @see AotContext
  */
 public interface AotRepositoryContext extends AotContext {
 
@@ -39,6 +40,12 @@ public interface AotRepositoryContext extends AotContext {
 	String getBeanName();
 
 	/**
+	 * @return the Spring Data module name, see {@link RepositoryConfigurationExtension#getModuleName()}.
+	 * @since 4.0
+	 */
+	String getModuleName();
+
+	/**
 	 * @return a {@link Set} of {@link String base packages} to search for repositories.
 	 */
 	Set<String> getBasePackages();
@@ -46,7 +53,7 @@ public interface AotRepositoryContext extends AotContext {
 	/**
 	 * @return the {@link Annotation} types used to identify domain types.
 	 */
-	Set<Class<? extends Annotation>> getIdentifyingAnnotations();
+	Collection<Class<? extends Annotation>> getIdentifyingAnnotations();
 
 	/**
 	 * @return {@link RepositoryInformation metadata} about the repository itself.
@@ -64,4 +71,5 @@ public interface AotRepositoryContext extends AotContext {
 	 * @return all {@link Class types} reachable from the repository.
 	 */
 	Set<Class<?>> getResolvedTypes();
+
 }

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryInformation.java
@@ -17,52 +17,40 @@ package org.springframework.data.repository.config;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.function.Supplier;
 
-import org.jspecify.annotations.Nullable;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryInformationSupport;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryComposition;
 import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
 import org.springframework.data.repository.core.support.RepositoryFragment;
-import org.springframework.data.util.Lazy;
 
 /**
  * {@link RepositoryInformation} based on {@link RepositoryMetadata} collected at build time.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 3.0
  */
-class AotRepositoryInformation extends RepositoryInformationSupport implements RepositoryInformation {
+public class AotRepositoryInformation extends RepositoryInformationSupport implements RepositoryInformation {
 
-	private final @Nullable String moduleName;
-	private final Supplier<Collection<RepositoryFragment<?>>> fragments;
+	private final RepositoryComposition fragmentsComposition;
+	private final RepositoryComposition baseComposition;
+	private final RepositoryComposition composition;
 
-	private final Lazy<RepositoryComposition> repositoryComposition;
-	private final Lazy<RepositoryComposition> baseComposition;
+	public AotRepositoryInformation(RepositoryMetadata repositoryMetadata, Class<?> repositoryBaseClass,
+			Collection<RepositoryFragment<?>> fragments) {
 
-	AotRepositoryInformation(@Nullable String moduleName, Supplier<RepositoryMetadata> repositoryMetadata,
-			Supplier<Class<?>> repositoryBaseClass, Supplier<Collection<RepositoryFragment<?>>> fragments) {
+		super(() -> repositoryMetadata, () -> repositoryBaseClass);
 
-		super(repositoryMetadata, repositoryBaseClass);
+		this.fragmentsComposition = RepositoryComposition.fromMetadata(getMetadata())
+				.append(RepositoryFragments.from(fragments));
+		this.baseComposition = RepositoryComposition.of(RepositoryFragment.structural(getRepositoryBaseClass())) //
+				.withArgumentConverter(this.fragmentsComposition.getArgumentConverter()) //
+				.withMethodLookup(this.fragmentsComposition.getMethodLookup());
 
-		this.moduleName = moduleName;
-		this.fragments = fragments;
-
-		this.repositoryComposition = Lazy
-				.of(() -> RepositoryComposition.fromMetadata(getMetadata()).append(RepositoryFragments.from(getFragments())));
-
-		this.baseComposition = Lazy.of(() -> {
-
-			RepositoryComposition targetRepoComposition = repositoryComposition.get();
-
-			return RepositoryComposition.of(RepositoryFragment.structural(getRepositoryBaseClass())) //
-					.withArgumentConverter(targetRepoComposition.getArgumentConverter()) //
-					.withMethodLookup(targetRepoComposition.getMethodLookup());
-		});
+		this.composition = this.fragmentsComposition.append(this.baseComposition.getFragments());
 	}
 
 	/**
@@ -71,31 +59,27 @@ class AotRepositoryInformation extends RepositoryInformationSupport implements R
 	 */
 	@Override
 	public Set<RepositoryFragment<?>> getFragments() {
-		return new LinkedHashSet<>(fragments.get());
+		return fragmentsComposition.getFragments().toSet();
 	}
 
 	@Override
 	public boolean isCustomMethod(Method method) {
-		return repositoryComposition.get().findMethod(method).isPresent();
+		return fragmentsComposition.findMethod(method).isPresent();
 	}
 
 	@Override
 	public boolean isBaseClassMethod(Method method) {
-		return baseComposition.get().findMethod(method).isPresent();
+		return baseComposition.findMethod(method).isPresent();
 	}
 
 	@Override
 	public Method getTargetClassMethod(Method method) {
-		return baseComposition.get().findMethod(method).orElse(method);
+		return baseComposition.findMethod(method).orElse(method);
 	}
 
 	@Override
 	public RepositoryComposition getRepositoryComposition() {
-		return repositoryComposition.get();
+		return composition;
 	}
 
-	@Override
-	public @Nullable String moduleName() {
-		return moduleName;
-	}
 }

--- a/src/main/java/org/springframework/data/repository/config/DefaultAotRepositoryContext.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultAotRepositoryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022. the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 package org.springframework.data.repository.config;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.RegisteredBean;
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.env.Environment;
 import org.springframework.data.aot.AotContext;
@@ -37,27 +37,40 @@ import org.springframework.data.util.TypeUtils;
  *
  * @author Christoph Strobl
  * @author John Blum
+ * @author Mark Paluch
  * @see AotRepositoryContext
  * @since 3.0
  */
 @SuppressWarnings("NullAway") // TODO
 class DefaultAotRepositoryContext implements AotRepositoryContext {
 
+	private final RegisteredBean bean;
+	private final String moduleName;
 	private final AotContext aotContext;
+	private final RepositoryInformation repositoryInformation;
 	private final Lazy<Set<MergedAnnotation<Annotation>>> resolvedAnnotations = Lazy.of(this::discoverAnnotations);
 	private final Lazy<Set<Class<?>>> managedTypes = Lazy.of(this::discoverTypes);
 
-	private @Nullable RepositoryInformation repositoryInformation;
-	private @Nullable Set<String> basePackages;
-	private @Nullable Set<Class<? extends Annotation>> identifyingAnnotations;
-	private @Nullable String beanName;
+	private Set<String> basePackages = Collections.emptySet();
+	private Collection<Class<? extends Annotation>> identifyingAnnotations = Collections.emptySet();
+	private String beanName;
 
-	public DefaultAotRepositoryContext(AotContext aotContext) {
+	public DefaultAotRepositoryContext(RegisteredBean bean, RepositoryInformation repositoryInformation,
+			String moduleName, AotContext aotContext) {
+		this.bean = bean;
+		this.repositoryInformation = repositoryInformation;
+		this.moduleName = moduleName;
 		this.aotContext = aotContext;
+		this.beanName = bean.getBeanName();
 	}
 
 	public AotContext getAotContext() {
 		return aotContext;
+	}
+
+	@Override
+	public String getModuleName() {
+		return moduleName;
 	}
 
 	@Override
@@ -72,7 +85,7 @@ class DefaultAotRepositoryContext implements AotRepositoryContext {
 
 	@Override
 	public Set<String> getBasePackages() {
-		return basePackages == null ? Collections.emptySet() : basePackages;
+		return basePackages;
 	}
 
 	public void setBasePackages(Set<String> basePackages) {
@@ -89,21 +102,17 @@ class DefaultAotRepositoryContext implements AotRepositoryContext {
 	}
 
 	@Override
-	public Set<Class<? extends Annotation>> getIdentifyingAnnotations() {
-		return identifyingAnnotations == null ? Collections.emptySet() : identifyingAnnotations;
+	public Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
+		return identifyingAnnotations;
 	}
 
-	public void setIdentifyingAnnotations(Set<Class<? extends Annotation>> identifyingAnnotations) {
+	public void setIdentifyingAnnotations(Collection<Class<? extends Annotation>> identifyingAnnotations) {
 		this.identifyingAnnotations = identifyingAnnotations;
 	}
 
 	@Override
 	public RepositoryInformation getRepositoryInformation() {
 		return repositoryInformation;
-	}
-
-	public void setRepositoryInformation(RepositoryInformation repositoryInformation) {
-		this.repositoryInformation = repositoryInformation;
 	}
 
 	@Override
@@ -132,24 +141,18 @@ class DefaultAotRepositoryContext implements AotRepositoryContext {
 				.flatMap(type -> TypeUtils.resolveUsedAnnotations(type).stream())
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 
-		if (repositoryInformation != null) {
-			annotations.addAll(TypeUtils.resolveUsedAnnotations(repositoryInformation.getRepositoryInterface()));
-		}
+		annotations.addAll(TypeUtils.resolveUsedAnnotations(repositoryInformation.getRepositoryInterface()));
 
 		return annotations;
 	}
 
 	protected Set<Class<?>> discoverTypes() {
 
-		Set<Class<?>> types = new LinkedHashSet<>();
+		Set<Class<?>> types = new LinkedHashSet<>(TypeCollector.inspect(repositoryInformation.getDomainType()).list());
 
-		if (repositoryInformation != null) {
-			types.addAll(TypeCollector.inspect(repositoryInformation.getDomainType()).list());
-
-			repositoryInformation.getQueryMethods().stream()
-					.flatMap(it -> TypeUtils.resolveTypesInSignature(repositoryInformation.getRepositoryInterface(), it).stream())
-					.flatMap(it -> TypeCollector.inspect(it).list().stream()).forEach(types::add);
-		}
+		repositoryInformation.getQueryMethods().stream()
+				.flatMap(it -> TypeUtils.resolveTypesInSignature(repositoryInformation.getRepositoryInterface(), it).stream())
+				.flatMap(it -> TypeCollector.inspect(it).list().stream()).forEach(types::add);
 
 		if (!getIdentifyingAnnotations().isEmpty()) {
 
@@ -160,4 +163,5 @@ class DefaultAotRepositoryContext implements AotRepositoryContext {
 
 		return types;
 	}
+
 }

--- a/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultRepositoryConfiguration.java
@@ -114,12 +114,17 @@ public class DefaultRepositoryConfiguration<T extends RepositoryConfigurationSou
 
 	@Override
 	public Optional<String> getRepositoryBaseClassName() {
-		return configurationSource.getRepositoryBaseClassName();
+		return configurationSource.getRepositoryBaseClassName()
+				.or(() -> Optional.ofNullable(extension.getRepositoryBaseClassName()));
+	}
+
+	@Override
+	public Optional<String> getRepositoryFragmentsContributorClassName() {
+		return configurationSource.getRepositoryFragmentsContributorClassName();
 	}
 
 	@Override
 	public String getRepositoryFactoryBeanClassName() {
-
 		return configurationSource.getRepositoryFactoryBeanClassName()
 				.orElseGet(extension::getRepositoryFactoryBeanClassName);
 	}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionBuilder.java
@@ -116,6 +116,11 @@ class RepositoryBeanDefinitionBuilder {
 				.rootBeanDefinition(configuration.getRepositoryFactoryBeanClassName());
 
 		builder.getRawBeanDefinition().setSource(configuration.getSource());
+
+		// AOT Repository hints
+		builder.getRawBeanDefinition().setAttribute(RepositoryConfiguration.class.getName(), configuration);
+		builder.getRawBeanDefinition().setAttribute(RepositoryConfigurationExtension.class.getName(), extension);
+
 		builder.addConstructorArgValue(configuration.getRepositoryInterface());
 		builder.addPropertyValue("queryLookupStrategyKey", configuration.getQueryLookupStrategyKey());
 		builder.addPropertyValue("lazyInit", configuration.isLazyInit());
@@ -124,6 +129,10 @@ class RepositoryBeanDefinitionBuilder {
 
 		configuration.getRepositoryBaseClassName()//
 				.ifPresent(it -> builder.addPropertyValue("repositoryBaseClass", it));
+
+		configuration.getRepositoryFragmentsContributorClassName()//
+				.ifPresent(it -> builder.addPropertyValue("repositoryFragmentsContributor",
+						BeanDefinitionBuilder.genericBeanDefinition(it).getRawBeanDefinition()));
 
 		NamedQueriesBeanDefinitionBuilder definitionBuilder = new NamedQueriesBeanDefinitionBuilder(
 				extension.getDefaultNamedQueryLocation());

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionReader.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionReader.java
@@ -15,139 +15,197 @@
  */
 package org.springframework.data.repository.config;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.PropertyValue;
+import org.springframework.beans.PropertyValues;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.RegisteredBean;
-import org.springframework.core.ResolvableType;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.repository.core.support.RepositoryFragment;
-import org.springframework.data.repository.core.support.RepositoryFragment.ImplementedRepositoryFragment;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Reader used to extract {@link RepositoryInformation} from {@link RepositoryConfiguration}.
  *
  * @author Christoph Strobl
  * @author John Blum
+ * @author Mark Paluch
  * @since 3.0
  */
 class RepositoryBeanDefinitionReader {
 
-	/**
-	 * @return
-	 */
-	static RepositoryInformation repositoryInformation(RepositoryConfiguration<?> repoConfig, RegisteredBean repoBean) {
-		return repositoryInformation(repoConfig, repoBean.getMergedBeanDefinition(), repoBean.getBeanFactory());
+	private final RootBeanDefinition beanDefinition;
+	private final ConfigurableListableBeanFactory beanFactory;
+	private final ClassLoader beanClassLoader;
+	private final @Nullable RepositoryConfiguration<?> configuration;
+	private final @Nullable RepositoryConfigurationExtensionSupport extension;
+
+	public RepositoryBeanDefinitionReader(RegisteredBean bean) {
+
+		this.beanDefinition = bean.getMergedBeanDefinition();
+		this.beanFactory = bean.getBeanFactory();
+		this.beanClassLoader = bean.getBeanClass().getClassLoader();
+		this.configuration = (RepositoryConfiguration<?>) beanDefinition
+				.getAttribute(RepositoryConfiguration.class.getName());
+		this.extension = (RepositoryConfigurationExtensionSupport) beanDefinition
+				.getAttribute(RepositoryConfigurationExtension.class.getName());
+	}
+
+	public @Nullable RepositoryConfiguration<?> getConfiguration() {
+		return this.configuration;
+	}
+
+	public @Nullable RepositoryConfigurationExtensionSupport getConfigurationExtension() {
+		return this.extension;
 	}
 
 	/**
-	 * @param source the RepositoryFactoryBeanSupport bean definition.
-	 * @param beanFactory
-	 * @return
+	 * @return the {@link RepositoryInformation} derived from the repository bean.
 	 */
-	@SuppressWarnings("NullAway")
-	static RepositoryInformation repositoryInformation(RepositoryConfiguration<?> repoConfig, BeanDefinition source,
-			ConfigurableListableBeanFactory beanFactory) {
+	public RepositoryInformation getRepositoryInformation() {
 
 		RepositoryMetadata metadata = AbstractRepositoryMetadata
-				.getMetadata(forName(repoConfig.getRepositoryInterface(), beanFactory));
-		Class<?> repositoryBaseClass = readRepositoryBaseClass(source, beanFactory);
-		List<RepositoryFragment<?>> fragmentList = readRepositoryFragments(source, beanFactory);
-		if (source.getPropertyValues().contains("customImplementation")) {
+				.getMetadata(forName(configuration.getRepositoryInterface()));
+		Class<?> repositoryBaseClass = getRepositoryBaseClass();
 
-			Object o = source.getPropertyValues().get("customImplementation");
-			if (o instanceof RuntimeBeanReference rbr) {
-				BeanDefinition customImplBeanDefintion = beanFactory.getBeanDefinition(rbr.getBeanName());
-				Class<?> beanType = forName(customImplBeanDefintion.getBeanClassName(), beanFactory);
-				ResolvableType[] interfaces = ResolvableType.forClass(beanType).getInterfaces();
-				if (interfaces.length == 1) {
-					fragmentList.add(new ImplementedRepositoryFragment(interfaces[0].toClass(), beanType));
-				} else {
-					boolean found = false;
-					for (ResolvableType i : interfaces) {
-						if (beanType.getSimpleName().contains(i.resolve().getSimpleName())) {
-							fragmentList.add(new ImplementedRepositoryFragment(interfaces[0].toClass(), beanType));
-							found = true;
-							break;
-						}
-					}
-					if (!found) {
-						fragmentList.add(RepositoryFragment.implemented(beanType));
-					}
-				}
+		List<RepositoryFragment<?>> fragments = new ArrayList<>();
+		fragments.addAll(readRepositoryFragments());
+		fragments.addAll(readContributedRepositoryFragments(metadata));
+
+		RepositoryFragment<?> customImplementation = getCustomImplementation();
+		if (customImplementation != null) {
+			fragments.add(0, customImplementation);
+		}
+
+		return new AotRepositoryInformation(metadata, repositoryBaseClass, fragments);
+	}
+
+	private @Nullable RepositoryFragment<?> getCustomImplementation() {
+
+		PropertyValues mpv = beanDefinition.getPropertyValues();
+		PropertyValue customImplementation = mpv.getPropertyValue("customImplementation");
+
+		if (customImplementation != null) {
+
+			if (customImplementation.getValue() instanceof RuntimeBeanReference rbr) {
+				BeanDefinition customImplementationBean = beanFactory.getBeanDefinition(rbr.getBeanName());
+				Class<?> beanType = getClass(customImplementationBean);
+				return RepositoryFragment.structural(beanType);
+			} else if (customImplementation.getValue() instanceof BeanDefinition bd) {
+				Class<?> beanType = getClass(bd);
+				return RepositoryFragment.structural(beanType);
 			}
 		}
 
-		String moduleName = (String) source.getPropertyValues().get("moduleName");
-		AotRepositoryInformation repositoryInformation = new AotRepositoryInformation(moduleName, () -> metadata,
-				() -> repositoryBaseClass, () -> fragmentList);
-		return repositoryInformation;
+		return null;
 	}
 
 	@SuppressWarnings("NullAway")
-	private static Class<?> readRepositoryBaseClass(BeanDefinition source, ConfigurableListableBeanFactory beanFactory) {
+	private Class<?> getRepositoryBaseClass() {
 
-		Object repoBaseClassName = source.getPropertyValues().get("repositoryBaseClass");
+		Object repoBaseClassName = beanDefinition.getPropertyValues().get("repositoryBaseClass");
+
 		if (repoBaseClassName != null) {
-			return forName(repoBaseClassName.toString(), beanFactory);
+			return forName(repoBaseClassName.toString());
 		}
-		if (source.getPropertyValues().contains("moduleBaseClass")) {
-			return forName((String) source.getPropertyValues().get("moduleBaseClass"), beanFactory);
-		}
+
 		return Dummy.class;
 	}
 
 	@SuppressWarnings("NullAway")
-	private static List<RepositoryFragment<?>> readRepositoryFragments(BeanDefinition source,
-			ConfigurableListableBeanFactory beanFactory) {
+	private List<RepositoryFragment<?>> readRepositoryFragments() {
 
-		RuntimeBeanReference beanReference = (RuntimeBeanReference) source.getPropertyValues().get("repositoryFragments");
+		RuntimeBeanReference beanReference = (RuntimeBeanReference) beanDefinition.getPropertyValues()
+				.get("repositoryFragments");
 		BeanDefinition fragments = beanFactory.getBeanDefinition(beanReference.getBeanName());
 
 		ValueHolder fragmentBeanNameList = fragments.getConstructorArgumentValues().getArgumentValue(0, List.class);
 		List<String> fragmentBeanNames = (List<String>) fragmentBeanNameList.getValue();
 
 		List<RepositoryFragment<?>> fragmentList = new ArrayList<>();
+
 		for (String beanName : fragmentBeanNames) {
 
 			BeanDefinition fragmentBeanDefinition = beanFactory.getBeanDefinition(beanName);
-			ValueHolder argumentValue = fragmentBeanDefinition.getConstructorArgumentValues().getArgumentValue(0,
-					String.class);
-			ValueHolder argumentValue1 = fragmentBeanDefinition.getConstructorArgumentValues().getArgumentValue(1, null, null,
-					null);
-			Object fragmentClassName = argumentValue.getValue();
+			ConstructorArgumentValues cv = fragmentBeanDefinition.getConstructorArgumentValues();
+			ValueHolder interfaceClassVh = cv.getArgumentValue(0, String.class);
+			ValueHolder implementationVh = cv.getArgumentValue(1, null, null, null);
 
-			try {
-				Class<?> type = ClassUtils.forName(fragmentClassName.toString(), beanFactory.getBeanClassLoader());
+			Object fragmentClassName = interfaceClassVh.getValue();
+			Class<?> interfaceClass = forName(fragmentClassName.toString());
 
-				if (argumentValue1 != null && argumentValue1.getValue() instanceof RuntimeBeanReference rbf) {
-					BeanDefinition implBeanDef = beanFactory.getBeanDefinition(rbf.getBeanName());
-					Class implClass = ClassUtils.forName(implBeanDef.getBeanClassName(), beanFactory.getBeanClassLoader());
-					fragmentList.add(new RepositoryFragment.ImplementedRepositoryFragment(type, implClass));
-				} else {
-					fragmentList.add(RepositoryFragment.structural(type));
-				}
-			} catch (ClassNotFoundException e) {
-				throw new RuntimeException(e);
+			if (implementationVh != null && implementationVh.getValue() instanceof RuntimeBeanReference rbf) {
+				BeanDefinition implBeanDef = beanFactory.getBeanDefinition(rbf.getBeanName());
+				Class<?> implClass = getClass(implBeanDef);
+				fragmentList.add(RepositoryFragment.structural(interfaceClass, implClass));
+			} else {
+				fragmentList.add(RepositoryFragment.structural(interfaceClass));
 			}
 		}
+
 		return fragmentList;
+	}
+
+	private List<RepositoryFragment<?>> readContributedRepositoryFragments(RepositoryMetadata metadata) {
+
+		RepositoryFragmentsContributor contributor = getFragmentsContributor(metadata.getRepositoryInterface());
+		return contributor.describe(metadata).stream().toList();
+	}
+
+	private RepositoryFragmentsContributor getFragmentsContributor(Class<?> repositoryInterface) {
+
+		Object repositoryFragmentsContributor = beanDefinition.getPropertyValues().get("repositoryFragmentsContributor");
+
+		if (repositoryFragmentsContributor instanceof BeanDefinition bd) {
+			return (RepositoryFragmentsContributor) BeanUtils.instantiateClass(getClass(bd));
+		}
+
+		Class<?> repositoryFactoryBean = forName(beanDefinition.getBeanClassName());
+		Constructor<?> constructor = ClassUtils.getConstructorIfAvailable(repositoryFactoryBean, Class.class);
+
+		if (constructor == null) {
+			throw new IllegalStateException("No constructor accepting Class in " + repositoryFactoryBean.getName());
+		}
+		RepositoryFactoryBeanSupport<?, ?, ?> factoryBean = (RepositoryFactoryBeanSupport<?, ?, ?>) BeanUtils
+				.instantiateClass(constructor, repositoryInterface);
+
+		return factoryBean.getRepositoryFragmentsContributor();
+	}
+
+	private Class<?> getClass(BeanDefinition definition) {
+
+		String beanClassName = definition.getBeanClassName();
+
+		if (ObjectUtils.isEmpty(beanClassName)) {
+			throw new IllegalStateException("No bean class name specified for %s".formatted(definition));
+		}
+
+		return forName(beanClassName);
 	}
 
 	static abstract class Dummy implements CrudRepository<Object, Object>, PagingAndSortingRepository<Object, Object> {}
 
-	static Class<?> forName(String name, ConfigurableListableBeanFactory beanFactory) {
+	private Class<?> forName(String name) {
 		try {
-			return ClassUtils.forName(name, beanFactory.getBeanClassLoader());
+			return ClassUtils.forName(name, beanClassLoader);
 		} catch (ClassNotFoundException cause) {
 			throw new TypeNotPresentException(name, cause);
 		}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionReader.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryBeanDefinitionReader.java
@@ -16,17 +16,21 @@
 package org.springframework.data.repository.config;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.core.ResolvableType;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.core.RepositoryInformation;
-import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFragment;
-import org.springframework.data.util.Lazy;
+import org.springframework.data.repository.core.support.RepositoryFragment.ImplementedRepositoryFragment;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -38,49 +42,108 @@ import org.springframework.util.ClassUtils;
  */
 class RepositoryBeanDefinitionReader {
 
-	static RepositoryInformation readRepositoryInformation(RepositoryConfiguration<?> metadata,
-			ConfigurableListableBeanFactory beanFactory) {
-
-		return new AotRepositoryInformation(metadataSupplier(metadata, beanFactory),
-				repositoryBaseClass(metadata, beanFactory), fragments(metadata, beanFactory));
+	/**
+	 * @return
+	 */
+	static RepositoryInformation repositoryInformation(RepositoryConfiguration<?> repoConfig, RegisteredBean repoBean) {
+		return repositoryInformation(repoConfig, repoBean.getMergedBeanDefinition(), repoBean.getBeanFactory());
 	}
 
-	private static Supplier<Collection<RepositoryFragment<?>>> fragments(RepositoryConfiguration<?> metadata,
+	/**
+	 * @param source the RepositoryFactoryBeanSupport bean definition.
+	 * @param beanFactory
+	 * @return
+	 */
+	@SuppressWarnings("NullAway")
+	static RepositoryInformation repositoryInformation(RepositoryConfiguration<?> repoConfig, BeanDefinition source,
 			ConfigurableListableBeanFactory beanFactory) {
 
-		if (metadata instanceof RepositoryFragmentConfigurationProvider provider) {
+		RepositoryMetadata metadata = AbstractRepositoryMetadata
+				.getMetadata(forName(repoConfig.getRepositoryInterface(), beanFactory));
+		Class<?> repositoryBaseClass = readRepositoryBaseClass(source, beanFactory);
+		List<RepositoryFragment<?>> fragmentList = readRepositoryFragments(source, beanFactory);
+		if (source.getPropertyValues().contains("customImplementation")) {
 
-			return Lazy.of(() -> {
-				return provider.getFragmentConfiguration().stream().flatMap(it -> {
-
-					List<RepositoryFragment<?>> fragments = new ArrayList<>(1);
-
-					fragments.add(RepositoryFragment.implemented(forName(it.getClassName(), beanFactory)));
-
-					if (it.getInterfaceName() != null) {
-						fragments.add(RepositoryFragment.structural(forName(it.getInterfaceName(), beanFactory)));
+			Object o = source.getPropertyValues().get("customImplementation");
+			if (o instanceof RuntimeBeanReference rbr) {
+				BeanDefinition customImplBeanDefintion = beanFactory.getBeanDefinition(rbr.getBeanName());
+				Class<?> beanType = forName(customImplBeanDefintion.getBeanClassName(), beanFactory);
+				ResolvableType[] interfaces = ResolvableType.forClass(beanType).getInterfaces();
+				if (interfaces.length == 1) {
+					fragmentList.add(new ImplementedRepositoryFragment(interfaces[0].toClass(), beanType));
+				} else {
+					boolean found = false;
+					for (ResolvableType i : interfaces) {
+						if (beanType.getSimpleName().contains(i.resolve().getSimpleName())) {
+							fragmentList.add(new ImplementedRepositoryFragment(interfaces[0].toClass(), beanType));
+							found = true;
+							break;
+						}
 					}
-
-					return fragments.stream();
-				}).collect(Collectors.toList());
-			});
+					if (!found) {
+						fragmentList.add(RepositoryFragment.implemented(beanType));
+					}
+				}
+			}
 		}
 
-		return Lazy.of(Collections::emptyList);
+		String moduleName = (String) source.getPropertyValues().get("moduleName");
+		AotRepositoryInformation repositoryInformation = new AotRepositoryInformation(moduleName, () -> metadata,
+				() -> repositoryBaseClass, () -> fragmentList);
+		return repositoryInformation;
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private static Supplier<Class<?>> repositoryBaseClass(RepositoryConfiguration metadata,
+	@SuppressWarnings("NullAway")
+	private static Class<?> readRepositoryBaseClass(BeanDefinition source, ConfigurableListableBeanFactory beanFactory) {
+
+		Object repoBaseClassName = source.getPropertyValues().get("repositoryBaseClass");
+		if (repoBaseClassName != null) {
+			return forName(repoBaseClassName.toString(), beanFactory);
+		}
+		if (source.getPropertyValues().contains("moduleBaseClass")) {
+			return forName((String) source.getPropertyValues().get("moduleBaseClass"), beanFactory);
+		}
+		return Dummy.class;
+	}
+
+	@SuppressWarnings("NullAway")
+	private static List<RepositoryFragment<?>> readRepositoryFragments(BeanDefinition source,
 			ConfigurableListableBeanFactory beanFactory) {
 
-		return Lazy.of(() -> (Class<?>) metadata.getRepositoryBaseClassName().map(it -> forName(it.toString(), beanFactory))
-				.orElse(Object.class));
+		RuntimeBeanReference beanReference = (RuntimeBeanReference) source.getPropertyValues().get("repositoryFragments");
+		BeanDefinition fragments = beanFactory.getBeanDefinition(beanReference.getBeanName());
+
+		ValueHolder fragmentBeanNameList = fragments.getConstructorArgumentValues().getArgumentValue(0, List.class);
+		List<String> fragmentBeanNames = (List<String>) fragmentBeanNameList.getValue();
+
+		List<RepositoryFragment<?>> fragmentList = new ArrayList<>();
+		for (String beanName : fragmentBeanNames) {
+
+			BeanDefinition fragmentBeanDefinition = beanFactory.getBeanDefinition(beanName);
+			ValueHolder argumentValue = fragmentBeanDefinition.getConstructorArgumentValues().getArgumentValue(0,
+					String.class);
+			ValueHolder argumentValue1 = fragmentBeanDefinition.getConstructorArgumentValues().getArgumentValue(1, null, null,
+					null);
+			Object fragmentClassName = argumentValue.getValue();
+
+			try {
+				Class<?> type = ClassUtils.forName(fragmentClassName.toString(), beanFactory.getBeanClassLoader());
+
+				if (argumentValue1 != null && argumentValue1.getValue() instanceof RuntimeBeanReference rbf) {
+					BeanDefinition implBeanDef = beanFactory.getBeanDefinition(rbf.getBeanName());
+					Class implClass = ClassUtils.forName(implBeanDef.getBeanClassName(), beanFactory.getBeanClassLoader());
+					fragmentList.add(new RepositoryFragment.ImplementedRepositoryFragment(type, implClass));
+				} else {
+					fragmentList.add(RepositoryFragment.structural(type));
+				}
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return fragmentList;
 	}
 
-	private static Supplier<org.springframework.data.repository.core.RepositoryMetadata> metadataSupplier(
-			RepositoryConfiguration<?> metadata, ConfigurableListableBeanFactory beanFactory) {
-		return Lazy.of(() -> new DefaultRepositoryMetadata(forName(metadata.getRepositoryInterface(), beanFactory)));
-	}
+	static abstract class Dummy implements CrudRepository<Object, Object>, PagingAndSortingRepository<Object, Object> {}
 
 	static Class<?> forName(String name, ConfigurableListableBeanFactory beanFactory) {
 		try {

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfiguration.java
@@ -79,6 +79,15 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	Optional<String> getRepositoryBaseClassName();
 
 	/**
+	 * Returns the name of the repository fragments contributor class to be used or {@link Optional#empty()} if the store
+	 * specific defaults shall be applied.
+	 *
+	 * @return
+	 * @since 4.0
+	 */
+	Optional<String> getRepositoryFragmentsContributorClassName();
+
+	/**
 	 * Returns the name of the repository factory bean class to be used.
 	 *
 	 * @return
@@ -157,11 +166,12 @@ public interface RepositoryConfiguration<T extends RepositoryConfigurationSource
 	ImplementationLookupConfiguration toLookupConfiguration(MetadataReaderFactory factory);
 
 	/**
-	 * Returns a human readable description of the repository interface declaration for error reporting purposes.
+	 * Returns a human-readable description of the repository interface declaration for error reporting purposes.
 	 *
 	 * @return can be {@literal null}.
 	 * @since 2.3
 	 */
 	@Nullable
 	String getResourceDescription();
+
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationAdapter.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationAdapter.java
@@ -72,6 +72,11 @@ class RepositoryConfigurationAdapter<T extends RepositoryConfigurationSource>
 	}
 
 	@Override
+	public Optional<String> getRepositoryFragmentsContributorClassName() {
+		return repositoryConfiguration.getRepositoryFragmentsContributorClassName();
+	}
+
+	@Override
 	public String getRepositoryFactoryBeanClassName() {
 		return repositoryConfiguration.getRepositoryFactoryBeanClassName();
 	}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationExtension.java
@@ -18,7 +18,7 @@ package org.springframework.data.repository.config;
 import java.util.Collection;
 import java.util.Locale;
 
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.aot.BeanRegistrationAotProcessor;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -63,7 +63,6 @@ public interface RepositoryConfigurationExtension {
 	 * @see org.springframework.beans.factory.aot.BeanRegistrationAotProcessor
 	 * @since 3.0
 	 */
-	@NonNull
 	default Class<? extends BeanRegistrationAotProcessor> getRepositoryAotProcessor() {
 		return RepositoryRegistrationAotProcessor.class;
 	}
@@ -89,6 +88,16 @@ public interface RepositoryConfigurationExtension {
 	 * @return will never be {@literal null}.
 	 */
 	String getDefaultNamedQueryLocation();
+
+	/**
+	 * Returns the {@link String name} of the repository base class to be used.
+	 *
+	 * @return can be {@literal null} if the base class cannot be provided.
+	 * @since 4.0
+	 */
+	default @Nullable String getRepositoryBaseClassName() {
+		return null;
+	}
 
 	/**
 	 * Returns the {@link String name} of the repository factory class to be used.

--- a/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryConfigurationSource.java
@@ -82,6 +82,15 @@ public interface RepositoryConfigurationSource {
 	Optional<String> getRepositoryBaseClassName();
 
 	/**
+	 * Returns the name of the repository fragments contributor class to be used or {@link Optional#empty()} if the store
+	 * specific defaults shall be applied.
+	 *
+	 * @return
+	 * @since 4.0
+	 */
+	Optional<String> getRepositoryFragmentsContributorClassName();
+
+	/**
 	 * Returns the name of the repository factory bean class or {@link Optional#empty()} if not defined in the source.
 	 *
 	 * @return

--- a/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
@@ -69,6 +69,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author John Blum
+ * @author Mark Paluch
  * @since 3.0
  */
 public class RepositoryRegistrationAotProcessor
@@ -123,11 +124,16 @@ public class RepositoryRegistrationAotProcessor
 		return getConfigMap().containsKey(bean.getBeanName());
 	}
 
-	protected RepositoryRegistrationAotContribution newRepositoryRegistrationAotContribution(
+	protected @Nullable RepositoryRegistrationAotContribution newRepositoryRegistrationAotContribution(
 			RegisteredBean repositoryBean) {
 
-		RepositoryRegistrationAotContribution contribution = RepositoryRegistrationAotContribution.fromProcessor(this)
-				.forBean(repositoryBean);
+		RepositoryRegistrationAotContribution contribution = RepositoryRegistrationAotContribution.load(this,
+				repositoryBean);
+
+		// cannot contribute a repository bean.
+		if (contribution == null) {
+			return null;
+		}
 
 		//TODO: add the hook for customizing bean initialization code here!
 

--- a/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
+++ b/src/main/java/org/springframework/data/repository/config/XmlRepositoryConfigurationSource.java
@@ -145,6 +145,11 @@ public class XmlRepositoryConfigurationSource extends RepositoryConfigurationSou
 	}
 
 	@Override
+	public Optional<String> getRepositoryFragmentsContributorClassName() {
+		return Optional.empty();
+	}
+
+	@Override
 	public Optional<String> getRepositoryFactoryBeanClassName() {
 		return getNullDefaultedAttribute(element, REPOSITORY_FACTORY_BEAN_CLASS_NAME);
 	}

--- a/src/main/java/org/springframework/data/repository/core/RepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/RepositoryInformation.java
@@ -18,6 +18,7 @@ package org.springframework.data.repository.core;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.repository.core.support.RepositoryComposition;
 
 /**
@@ -104,5 +105,9 @@ public interface RepositoryInformation extends RepositoryMetadata {
 	 * @since 4.0
 	 */
 	RepositoryComposition getRepositoryComposition();
+
+	default @Nullable String moduleName() {
+		return null;
+	}
 
 }

--- a/src/main/java/org/springframework/data/repository/core/RepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/RepositoryInformation.java
@@ -18,7 +18,6 @@ package org.springframework.data.repository.core;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import org.jspecify.annotations.Nullable;
 import org.springframework.data.repository.core.support.RepositoryComposition;
 
 /**
@@ -105,9 +104,5 @@ public interface RepositoryInformation extends RepositoryMetadata {
 	 * @since 4.0
 	 */
 	RepositoryComposition getRepositoryComposition();
-
-	default @Nullable String moduleName() {
-		return null;
-	}
 
 }

--- a/src/main/java/org/springframework/data/repository/core/RepositoryInformationSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/RepositoryInformationSupport.java
@@ -184,7 +184,7 @@ public abstract class RepositoryInformationSupport implements RepositoryInformat
 		return true;
 	}
 
-	private RepositoryMetadata getMetadata() {
+	protected RepositoryMetadata getMetadata() {
 		return metadata.get();
 	}
 

--- a/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/DefaultRepositoryInformation.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryInformationSupport;
 import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.util.Lazy;
 import org.springframework.lang.Contract;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
@@ -44,6 +45,7 @@ class DefaultRepositoryInformation extends RepositoryInformationSupport implemen
 
 	private final RepositoryComposition composition;
 	private final RepositoryComposition baseComposition;
+	private final Lazy<RepositoryComposition> fullComposition;
 
 	/**
 	 * Creates a new {@link DefaultRepositoryMetadata} for the given repository interface and repository base class.
@@ -62,6 +64,8 @@ class DefaultRepositoryInformation extends RepositoryInformationSupport implemen
 		this.baseComposition = RepositoryComposition.of(RepositoryFragment.structural(repositoryBaseClass)) //
 				.withArgumentConverter(composition.getArgumentConverter()) //
 				.withMethodLookup(composition.getMethodLookup());
+
+		this.fullComposition = Lazy.of(() -> composition.append(baseComposition.getFragments()));
 	}
 
 	@Override
@@ -106,7 +110,6 @@ class DefaultRepositoryInformation extends RepositoryInformationSupport implemen
 	@Override
 	protected boolean isQueryMethodCandidate(Method method) {
 
-		// FIXME - that should be simplified
 		boolean queryMethodCandidate = super.isQueryMethodCandidate(method);
 		if(!isQueryAnnotationPresentOn(method)) {
 			return queryMethodCandidate;
@@ -133,7 +136,7 @@ class DefaultRepositoryInformation extends RepositoryInformationSupport implemen
 
 	@Override
 	public RepositoryComposition getRepositoryComposition() {
-		return composition.append(baseComposition.getFragments());
+		return fullComposition.get();
 	}
 
 }

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
@@ -95,10 +95,6 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	private @Nullable Lazy<T> repository;
 	private @Nullable RepositoryMetadata repositoryMetadata;
 
-	// AOT bean factory hint?
-	private @Nullable String moduleBaseClass;
-	private @Nullable String moduleName;
-
 	/**
 	 * Creates a new {@link RepositoryFactoryBeanSupport} for the given repository interface.
 	 *
@@ -261,14 +257,6 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 		this.publisher = publisher;
 	}
 
-	public void setModuleBaseClass(String moduleBaseClass) {
-		this.moduleBaseClass = moduleBaseClass;
-	}
-
-	public void setModuleName(String moduleName) {
-		this.moduleName = moduleName;
-	}
-
 	@Override
 	@SuppressWarnings("unchecked")
 	public EntityInformation<S, ID> getEntityInformation() {
@@ -279,6 +267,11 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	@Override
 	public RepositoryInformation getRepositoryInformation() {
 		return getRequiredFactory().getRepositoryInformation(getRequiredRepositoryMetadata(), cachedFragments);
+	}
+
+	@Override
+	public RepositoryFragmentsContributor getRepositoryFragmentsContributor() {
+		return RepositoryFragmentsContributor.empty();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryBeanSupport.java
@@ -95,6 +95,10 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	private @Nullable Lazy<T> repository;
 	private @Nullable RepositoryMetadata repositoryMetadata;
 
+	// AOT bean factory hint?
+	private @Nullable String moduleBaseClass;
+	private @Nullable String moduleName;
+
 	/**
 	 * Creates a new {@link RepositoryFactoryBeanSupport} for the given repository interface.
 	 *
@@ -155,7 +159,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	 * @param repositoryFragments
 	 */
 	public void setRepositoryFragments(RepositoryFragments repositoryFragments) {
-		setRepositoryFragments(RepositoryFragmentsFunction.just(repositoryFragments));
+		setRepositoryFragmentsFunction(RepositoryFragmentsFunction.just(repositoryFragments));
 	}
 
 	/**
@@ -165,7 +169,7 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	 * @param fragmentsFunction
 	 * @since 4.0
 	 */
-	public void setRepositoryFragments(RepositoryFragmentsFunction fragmentsFunction) {
+	public void setRepositoryFragmentsFunction(RepositoryFragmentsFunction fragmentsFunction) {
 		this.fragments.add(fragmentsFunction);
 	}
 
@@ -255,6 +259,14 @@ public abstract class RepositoryFactoryBeanSupport<T extends Repository<S, ID>, 
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
 		this.publisher = publisher;
+	}
+
+	public void setModuleBaseClass(String moduleBaseClass) {
+		this.moduleBaseClass = moduleBaseClass;
+	}
+
+	public void setModuleName(String moduleName) {
+		this.moduleName = moduleName;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFactoryInformation.java
@@ -47,6 +47,15 @@ public interface RepositoryFactoryInformation<T, ID> {
 	RepositoryInformation getRepositoryInformation();
 
 	/**
+	 * Returns the {@link RepositoryFragmentsContributor} that is used to contribute additional fragments based on the
+	 * repository declaration.
+	 *
+	 * @return
+	 * @since 4.0
+	 */
+	RepositoryFragmentsContributor getRepositoryFragmentsContributor();
+
+	/**
 	 * Returns the {@link PersistentEntity} managed by the underlying repository. Can be {@literal null} in case the
 	 * underlying persistence mechanism does not expose a {@link MappingContext}.
 	 *

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFragment.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFragment.java
@@ -265,7 +265,7 @@ public interface RepositoryFragment<T> {
 
 			Assert.notNull(implementation, "Implementation object must not be null");
 
-			if (interfaceClass != null) {
+			if (interfaceClass != null && !(implementation instanceof Class)) {
 
 				Assert
 						.isTrue(ClassUtils.isAssignableValue(interfaceClass, implementation),

--- a/src/main/java/org/springframework/data/repository/core/support/RepositoryFragmentsContributor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/RepositoryFragmentsContributor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.core.support;
+
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
+
+/**
+ * Strategy interface support allowing to contribute a {@link RepositoryFragments} based on {@link RepositoryMetadata}.
+ * <p>
+ * Fragments contributors enhance repository functionality based on a repository declaration and activate additional
+ * fragments if a repository defines them, such as extending a built-in fragment interface (e.g.
+ * {@code QuerydslPredicateExecutor}, {@code QueryByExampleExecutor}).
+ * <p>
+ * This interface is a base-interface serving as a contract for repository fragment introspection. The actual
+ * implementation and methods to contribute fragments to be used within the repository instance are store-specific and
+ * require typically access to infrastructure such as a database connection hence those methods must be defined within
+ * the particular store module.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+public interface RepositoryFragmentsContributor {
+
+	/**
+	 * Empty {@code RepositoryFragmentsContributor} that does not contribute any fragments.
+	 *
+	 * @return empty {@code RepositoryFragmentsContributor} that does not contribute any fragments.
+	 */
+	public static RepositoryFragmentsContributor empty() {
+		return metadata -> RepositoryFragments.empty();
+	}
+
+	/**
+	 * Describe fragments that are contributed by {@link RepositoryMetadata}. Fragment description reports typically
+	 * structural fragments that are not suitable for invocation but can be used to introspect the repository structure.
+	 *
+	 * @param metadata the repository metadata describing the repository interface.
+	 * @return fragments to be (structurally) contributed to the repository.
+	 */
+	RepositoryFragments describe(RepositoryMetadata metadata);
+
+}

--- a/src/main/java/org/springframework/data/repository/query/Parameter.java
+++ b/src/main/java/org/springframework/data/repository/query/Parameter.java
@@ -125,6 +125,7 @@ public class Parameter {
 	 *
 	 * @return
 	 */
+	@SuppressWarnings("NullAway")
 	public String getPlaceholder() {
 
 		if (isNamedParameter()) {

--- a/src/main/java/org/springframework/data/repository/support/Repositories.java
+++ b/src/main/java/org/springframework/data/repository/support/Repositories.java
@@ -35,6 +35,7 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.util.ProxyUtils;
 import org.springframework.util.Assert;
@@ -362,6 +363,11 @@ public class Repositories implements Iterable<Class<?>> {
 
 		@Override
 		public RepositoryInformation getRepositoryInformation() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public RepositoryFragmentsContributor getRepositoryFragmentsContributor() {
 			throw new UnsupportedOperationException();
 		}
 

--- a/src/test/java/example/UserRepositoryExtension.java
+++ b/src/test/java/example/UserRepositoryExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,9 @@ package example;
 
 import example.UserRepository.User;
 
-import java.util.List;
-
-import org.springframework.data.repository.CrudRepository;
-
 /**
  * @author Christoph Strobl
  */
-public interface UserRepository extends CrudRepository<User, Long>, UserRepositoryExtension {
-
-	User findByFirstname(String firstname);
-
-	List<User> findByFirstnameIn(List<String> firstnames);
-
-	Long countAllByLastname(String lastname);
-
-	Long countAll();
-
-	void doSomething();
-
-	default Long theDefaultMethod() {
-		return countAll();
-	}
-
-	class User {
-		String firstname;
-	}
+public interface UserRepositoryExtension {
+    User findUserByExtensionMethod();
 }

--- a/src/test/java/example/UserRepositoryExtensionImpl.java
+++ b/src/test/java/example/UserRepositoryExtensionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,13 @@ package example;
 
 import example.UserRepository.User;
 
-import java.util.List;
-
-import org.springframework.data.repository.CrudRepository;
-
 /**
  * @author Christoph Strobl
  */
-public interface UserRepository extends CrudRepository<User, Long>, UserRepositoryExtension {
+public class UserRepositoryExtensionImpl implements UserRepositoryExtension {
 
-	User findByFirstname(String firstname);
-
-	List<User> findByFirstnameIn(List<String> firstnames);
-
-	Long countAllByLastname(String lastname);
-
-	Long countAll();
-
-	void doSomething();
-
-	default Long theDefaultMethod() {
-		return countAll();
-	}
-
-	class User {
-		String firstname;
+	@Override
+	public User findUserByExtensionMethod() {
+		return null;
 	}
 }

--- a/src/test/java/org/springframework/data/aot/sample/ConfigWithCustomRepositoryBaseClass.java
+++ b/src/test/java/org/springframework/data/aot/sample/ConfigWithCustomRepositoryBaseClass.java
@@ -22,13 +22,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.aot.sample.ConfigWithCustomRepositoryBaseClass.RepoBaseClass;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.config.EnableRepositories;
+import org.springframework.data.repository.config.EnableRepositoriesWithContributor;
 
 /**
  * @author Christoph Strobl
  */
 @Configuration
-@EnableRepositories(repositoryBaseClass = RepoBaseClass.class, considerNestedRepositories = true,
+@EnableRepositoriesWithContributor(repositoryBaseClass = RepoBaseClass.class, considerNestedRepositories = true,
 		includeFilters = { @Filter(type = FilterType.REGEX, pattern = ".*CustomerRepositoryWithCustomBaseRepo$") })
 public class ConfigWithCustomRepositoryBaseClass {
 

--- a/src/test/java/org/springframework/data/aot/sample/ConfigWithSimpleCrudRepository.java
+++ b/src/test/java/org/springframework/data/aot/sample/ConfigWithSimpleCrudRepository.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.aot.sample;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.aot.sample.ConfigWithSimpleCrudRepository.MyRepo;
@@ -34,7 +36,7 @@ public class ConfigWithSimpleCrudRepository {
 
 	public static class Person {
 
-		@javax.annotation.Nullable
+		@Nullable
 		Address address;
 
 	}

--- a/src/test/java/org/springframework/data/repository/aot/RepositoryRegistrationAotProcessorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/RepositoryRegistrationAotProcessorIntegrationTests.java
@@ -55,6 +55,7 @@ import org.springframework.data.repository.aot.RepositoryRegistrationAotProcesso
 import org.springframework.data.repository.config.EnableRepositories;
 import org.springframework.data.repository.config.RepositoryRegistrationAotContribution;
 import org.springframework.data.repository.config.RepositoryRegistrationAotProcessor;
+import org.springframework.data.repository.config.SampleRepositoryFragmentsContributor;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 import org.springframework.transaction.interceptor.TransactionalProxy;
 
@@ -237,10 +238,11 @@ public class RepositoryRegistrationAotProcessorIntegrationTests {
 
 		assertThatContribution(repositoryBeanContribution) //
 				.targetRepositoryTypeIs(ConfigWithCustomRepositoryBaseClass.CustomerRepositoryWithCustomBaseRepo.class) //
-				.hasNoFragments() //
+				.hasFragments() //
 				.codeContributionSatisfies(contribution -> { //
 					// interface
 					contribution
+							.contributesReflectionFor(SampleRepositoryFragmentsContributor.class) // repository structural fragment
 							.contributesReflectionFor(ConfigWithCustomRepositoryBaseClass.CustomerRepositoryWithCustomBaseRepo.class) // repository
 							.contributesReflectionFor(ConfigWithCustomRepositoryBaseClass.RepoBaseClass.class) // base repo class
 							.contributesReflectionFor(ConfigWithCustomRepositoryBaseClass.Person.class); // repository domain type

--- a/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilderUnitTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot.generate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import example.UserRepository;
+import example.UserRepository.User;
+
+import java.util.TimeZone;
+
+import javax.lang.model.element.Modifier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.geo.Metric;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.javapoet.MethodSpec;
+import org.springframework.javapoet.TypeName;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author Christoph Strobl
+ */
+class AotRepositoryBuilderUnitTests {
+
+	RepositoryInformation repositoryInformation;
+
+	@BeforeEach
+	void beforeEach() {
+
+		repositoryInformation = mock(RepositoryInformation.class);
+		doReturn(UserRepository.class).when(repositoryInformation).getRepositoryInterface();
+	}
+
+	@Test // GH-3279
+	void writesClassSkeleton() {
+
+		AotRepositoryBuilder repoBuilder = AotRepositoryBuilder.forRepository(repositoryInformation,
+				new SpelAwareProxyProjectionFactory());
+		assertThat(repoBuilder.build().javaFile().toString())
+				.contains("package %s;".formatted(UserRepository.class.getPackageName())) // same package as source repo
+				.contains("@Generated") // marked as generated source
+				.contains("public class %sImpl__Aot".formatted(UserRepository.class.getSimpleName())) // target name
+				.contains("public UserRepositoryImpl__Aot()"); // default constructor if not arguments to wire
+	}
+
+	@Test // GH-3279
+	void appliesCtorArguments() {
+
+		AotRepositoryBuilder repoBuilder = AotRepositoryBuilder.forRepository(repositoryInformation,
+				new SpelAwareProxyProjectionFactory());
+		repoBuilder.withConstructorCustomizer(ctor -> {
+			ctor.addParameter("param1", Metric.class);
+			ctor.addParameter("param2", String.class);
+			ctor.addParameter("ctorScoped", TypeName.OBJECT, false);
+		});
+		assertThat(repoBuilder.build().javaFile().toString()) //
+				.contains("private final Metric param1;") //
+				.contains("private final String param2;") //
+				.doesNotContain("private final Object ctorScoped;") //
+				.contains("public UserRepositoryImpl__Aot(Metric param1, String param2, Object ctorScoped)") //
+				.contains("this.param1 = param1") //
+				.contains("this.param2 = param2") //
+				.doesNotContain("this.ctorScoped = ctorScoped");
+	}
+
+	@Test // GH-3279
+	void appliesCtorCodeBlock() {
+
+		AotRepositoryBuilder repoBuilder = AotRepositoryBuilder.forRepository(repositoryInformation,
+				new SpelAwareProxyProjectionFactory());
+		repoBuilder.withConstructorCustomizer(ctor -> {
+			ctor.customize((info, code) -> {
+				code.addStatement("throw new $T($S)", IllegalStateException.class, "initialization error");
+			});
+		});
+		assertThat(repoBuilder.build().javaFile().toString()).containsIgnoringWhitespaces(
+				"UserRepositoryImpl__Aot() { throw new IllegalStateException(\"initialization error\"); }");
+	}
+
+	@Test // GH-3279
+	void appliesClassCustomizations() {
+
+		AotRepositoryBuilder repoBuilder = AotRepositoryBuilder.forRepository(repositoryInformation,
+				new SpelAwareProxyProjectionFactory());
+
+		repoBuilder.withClassCustomizer((info, metadata, clazz) -> {
+
+			clazz.addField(Float.class, "f", Modifier.PRIVATE, Modifier.STATIC);
+			clazz.addField(Double.class, "d", Modifier.PUBLIC);
+			clazz.addField(TimeZone.class, "t", Modifier.FINAL);
+
+			clazz.addAnnotation(Repository.class);
+
+			clazz.addMethod(MethodSpec.methodBuilder("oops").build());
+		});
+
+		assertThat(repoBuilder.build().javaFile().toString()) //
+				.contains("@Repository") //
+				.contains("private static Float f;") //
+				.contains("public Double d;") //
+				.contains("final TimeZone t;") //
+				.containsIgnoringWhitespaces("void oops() { }");
+	}
+
+	@Test // GH-3279
+	void appliesQueryMethodContributor() {
+
+		AotRepositoryBuilder repoBuilder = AotRepositoryBuilder.forRepository(repositoryInformation,
+				new SpelAwareProxyProjectionFactory());
+
+		when(repositoryInformation.isQueryMethod(Mockito.argThat(arg -> arg.getName().equals("findByFirstname"))))
+				.thenReturn(true);
+		doReturn(TypeInformation.of(User.class)).when(repositoryInformation).getReturnType(any());
+
+		repoBuilder.withQueryMethodContributor((method, info) -> {
+
+			return new MethodContributor<>(mock(QueryMethod.class), null) {
+
+				@Override
+				public MethodSpec contribute(AotQueryMethodGenerationContext context) {
+					return MethodSpec.methodBuilder("oops").build();
+				}
+
+				@Override
+				public boolean contributesMethodSpec() {
+					return true;
+				}
+			};
+		});
+
+		assertThat(repoBuilder.build().javaFile().toString()) //
+				.containsIgnoringWhitespaces("void oops() { }");
+	}
+}

--- a/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryMethodBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryMethodBuilderUnitTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot.generate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import example.UserRepository;
+import example.UserRepository.User;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.ResolvableType;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.javapoet.ParameterSpec;
+import org.springframework.javapoet.ParameterizedTypeName;
+
+/**
+ * @author Christoph Strobl
+ */
+class AotRepositoryMethodBuilderUnitTests {
+
+	RepositoryInformation repositoryInformation;
+	AotQueryMethodGenerationContext methodGenerationContext;
+
+	@BeforeEach
+	void beforeEach() {
+		repositoryInformation = Mockito.mock(RepositoryInformation.class);
+		methodGenerationContext = Mockito.mock(AotQueryMethodGenerationContext.class);
+
+		when(methodGenerationContext.getRepositoryInformation()).thenReturn(repositoryInformation);
+	}
+
+	@Test // GH-3279
+	void generatesMethodSkeletonBasedOnGenerationMetadata() throws NoSuchMethodException {
+
+		Method method = UserRepository.class.getMethod("findByFirstname", String.class);
+		when(methodGenerationContext.getMethod()).thenReturn(method);
+		when(methodGenerationContext.getReturnType()).thenReturn(ResolvableType.forClass(User.class));
+		doReturn(TypeInformation.of(User.class)).when(repositoryInformation).getReturnType(any());
+		MethodMetadata methodMetadata = new MethodMetadata(repositoryInformation, method);
+		methodMetadata.addParameter(ParameterSpec.builder(String.class, "firstname").build());
+		when(methodGenerationContext.getTargetMethodMetadata()).thenReturn(methodMetadata);
+
+		AotRepositoryMethodBuilder builder = new AotRepositoryMethodBuilder(methodGenerationContext);
+		assertThat(builder.buildMethod().toString()) //
+				.containsPattern("public .*User findByFirstname\\(.*String firstname\\)");
+	}
+
+	@Test // GH-3279
+	void generatesMethodWithGenerics() throws NoSuchMethodException {
+
+		Method method = UserRepository.class.getMethod("findByFirstnameIn", List.class);
+		when(methodGenerationContext.getMethod()).thenReturn(method);
+		when(methodGenerationContext.getReturnType())
+				.thenReturn(ResolvableType.forClassWithGenerics(List.class, User.class));
+		doReturn(TypeInformation.of(User.class)).when(repositoryInformation).getReturnType(any());
+		MethodMetadata methodMetadata = new MethodMetadata(repositoryInformation, method);
+		methodMetadata
+				.addParameter(ParameterSpec.builder(ParameterizedTypeName.get(List.class, String.class), "firstnames").build());
+		when(methodGenerationContext.getTargetMethodMetadata()).thenReturn(methodMetadata);
+
+		AotRepositoryMethodBuilder builder = new AotRepositoryMethodBuilder(methodGenerationContext);
+		assertThat(builder.buildMethod().toString()) //
+				.containsPattern("public .*List<.*User> findByFirstnameIn\\(") //
+				.containsPattern(".*List<.*String> firstnames\\)");
+	}
+}

--- a/src/test/java/org/springframework/data/repository/aot/generate/DummyModuleAotRepositoryContext.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/DummyModuleAotRepositoryContext.java
@@ -44,6 +44,11 @@ class DummyModuleAotRepositoryContext implements AotRepositoryContext {
 	}
 
 	@Override
+	public String getModuleName() {
+		return "Commons";
+	}
+
+	@Override
 	public ConfigurableListableBeanFactory getBeanFactory() {
 		return null;
 	}

--- a/src/test/java/org/springframework/data/repository/aot/generate/MethodCapturingRepositoryContributor.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/MethodCapturingRepositoryContributor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot.generate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.assertj.core.api.MapAssert;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.repository.config.AotRepositoryContext;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Christoph Strobl
+ */
+public class MethodCapturingRepositoryContributor extends RepositoryContributor {
+
+	MultiValueMap<String, Method> capturedInvocations;
+
+	public MethodCapturingRepositoryContributor(AotRepositoryContext repositoryContext) {
+		super(repositoryContext);
+		this.capturedInvocations = new LinkedMultiValueMap<>(3);
+	}
+
+	@Override
+	protected @Nullable MethodContributor<? extends QueryMethod> contributeQueryMethod(Method method,
+			RepositoryInformation repositoryInformation) {
+		capturedInvocations.add(method.getName(), method);
+		return null;
+	}
+
+	void verifyContributionFor(String methodName) {
+		assertThat(capturedInvocations).containsKey(methodName);
+	}
+
+	MapAssert<String, List<Method>> verifyContributedMethods() {
+		return assertThat(capturedInvocations);
+	}
+}

--- a/src/test/java/org/springframework/data/repository/aot/generate/RepositoryContributorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/RepositoryContributorUnitTests.java
@@ -15,31 +15,45 @@
  */
 package org.springframework.data.repository.aot.generate;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
 
 import example.UserRepository;
+import example.UserRepositoryExtension;
+import example.UserRepositoryExtensionImpl;
 
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-
+import org.mockito.Mockito;
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.core.test.tools.TestCompiler;
 import org.springframework.data.aot.CodeContributionAssert;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.config.AotRepositoryContext;
 import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments;
+import org.springframework.data.repository.core.support.RepositoryFragment;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.javapoet.CodeBlock;
 import org.springframework.util.ClassUtils;
 
 /**
+ * Unit tests targeting {@link RepositoryContributor}.
+ *
  * @author Christoph Strobl
  */
 class RepositoryContributorUnitTests {
 
-	@Test
-	void testCompile() {
+	@Test // GH-3279
+	void createsCompilableClassStub() {
 
 		DummyModuleAotRepositoryContext aotContext = new DummyModuleAotRepositoryContext(UserRepository.class, null);
 		RepositoryContributor repositoryContributor = new RepositoryContributor(aotContext) {
@@ -55,8 +69,7 @@ class RepositoryContributorUnitTests {
 							public Map<String, Object> serialize() {
 								return Map.of();
 							}
-						})
-						.contribute(context -> {
+						}).contribute(context -> {
 
 							CodeBlock.Builder builder = CodeBlock.builder();
 							if (!ClassUtils.isVoidType(method.getReturnType())) {
@@ -81,4 +94,146 @@ class RepositoryContributorUnitTests {
 		new CodeContributionAssert(generationContext).contributesReflectionFor(expectedTypeName);
 	}
 
+	@Test // GH-3279
+	void callsMethodContributionForQueryMethod() {
+
+		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
+		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+
+		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
+		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
+		when(repositoryInformation.isQueryMethod(argThat(it -> it.getName().equals("findByFirstname")))).thenReturn(true);
+
+		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
+		contributor.contribute(new TestGenerationContext(UserRepository.class));
+
+		contributor.verifyContributionFor("findByFirstname");
+	}
+
+	@Test // GH-3279
+	void doesNotContributeBaseClassMethods() {
+
+		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
+		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+
+		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
+		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
+		when(repositoryInformation.getRepositoryComposition())
+				.thenReturn(RepositoryComposition.of(RepositoryFragment.structural(RepoBaseClass.class)));
+		when(repositoryInformation.isBaseClassMethod(argThat(it -> it.getName().equals("findByFirstname"))))
+				.thenReturn(true);
+		when(repositoryInformation.isQueryMethod(argThat(it -> !it.getName().equals("findByFirstname")))).thenReturn(true);
+
+		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
+		contributor.contribute(new TestGenerationContext(UserRepository.class));
+
+		contributor.verifyContributedMethods().isNotEmpty().doesNotContainKey("findByFirstname");
+	}
+
+	@Test // GH-3279
+	void doesNotContributeFragmentMethod() {
+
+		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
+		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+
+		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
+		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
+		when(repositoryInformation.getRepositoryComposition())
+				.thenReturn(RepositoryComposition.of(RepositoryFragment.structural(UserRepository.class))
+						.append(RepositoryFragments
+								.from(Set.of(new RepositoryFragment.ImplementedRepositoryFragment(UserRepositoryExtension.class,
+										UserRepositoryExtensionImpl.class)))));
+
+		when(repositoryInformation.isCustomMethod(argThat(it -> it.getName().equals("findUserByExtensionMethod"))))
+				.thenReturn(true);
+		when(repositoryInformation.isQueryMethod(argThat(it -> it.getName().equals("findByFirstname")))).thenReturn(true);
+
+		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
+		contributor.contribute(new TestGenerationContext(UserRepository.class));
+
+		contributor.verifyContributedMethods().isNotEmpty().doesNotContainKey("findUserByExtensionMethod");
+	}
+
+	@Test // GH-3279
+	void contributesBaseClassMethodIfQueryMethod() {
+
+		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
+		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+
+		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
+		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
+		when(repositoryInformation.getRepositoryComposition())
+				.thenReturn(RepositoryComposition.of(RepositoryFragment.structural(RepoBaseClass.class)));
+		when(repositoryInformation.isBaseClassMethod(argThat(it -> it.getName().equals("findByFirstname"))))
+				.thenReturn(true);
+		when(repositoryInformation.isQueryMethod(any())).thenReturn(true);
+
+		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
+		contributor.contribute(new TestGenerationContext(UserRepository.class));
+
+		contributor.verifyContributedMethods().containsKey("findByFirstname").hasSizeGreaterThan(1);
+	}
+
+	static class RepoBaseClass<T, ID> implements CrudRepository<T, ID> {
+
+		private CrudRepository<T, ID> delegate;
+
+		public <S extends T> S save(S entity) {
+			return this.delegate.save(entity);
+		}
+
+		@Override
+		public <S extends T> Iterable<S> saveAll(Iterable<S> entities) {
+			return this.delegate.saveAll(entities);
+		}
+
+		public Optional<T> findById(ID id) {
+			return this.delegate.findById(id);
+		}
+
+		@Override
+		public boolean existsById(ID id) {
+			return this.delegate.existsById(id);
+		}
+
+		@Override
+		public Iterable<T> findAll() {
+			return this.delegate.findAll();
+		}
+
+		@Override
+		public Iterable<T> findAllById(Iterable<ID> ids) {
+			return this.delegate.findAllById(ids);
+		}
+
+		@Override
+		public long count() {
+			return this.delegate.count();
+		}
+
+		@Override
+		public void deleteById(ID id) {
+			this.delegate.deleteById(id);
+		}
+
+		@Override
+		public void delete(T entity) {
+			this.delegate.delete(entity);
+		}
+
+		@Override
+		public void deleteAllById(Iterable<? extends ID> ids) {
+			this.delegate.deleteAllById(ids);
+		}
+
+		@Override
+		public void deleteAll(Iterable<? extends T> entities) {
+			this.delegate.deleteAll(entities);
+		}
+
+		@Override
+		public void deleteAll() {
+			this.delegate.deleteAll();
+		}
+	}
 }

--- a/src/test/java/org/springframework/data/repository/aot/generate/RepositoryContributorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/RepositoryContributorUnitTests.java
@@ -15,10 +15,9 @@
  */
 package org.springframework.data.repository.aot.generate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import example.UserRepository;
 import example.UserRepositoryExtension;
@@ -31,7 +30,7 @@ import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.core.test.tools.TestCompiler;
 import org.springframework.data.aot.CodeContributionAssert;
@@ -97,8 +96,8 @@ class RepositoryContributorUnitTests {
 	@Test // GH-3279
 	void callsMethodContributionForQueryMethod() {
 
-		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
-		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+		AotRepositoryContext repositoryContext = mock(AotRepositoryContext.class);
+		RepositoryInformation repositoryInformation = mock(RepositoryInformation.class);
 
 		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
 		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
@@ -113,8 +112,9 @@ class RepositoryContributorUnitTests {
 	@Test // GH-3279
 	void doesNotContributeBaseClassMethods() {
 
-		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
-		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+		AotRepositoryContext repositoryContext = mock(AotRepositoryContext.class);
+		when(repositoryContext.getModuleName()).thenReturn("Commons");
+		RepositoryInformation repositoryInformation = mock(RepositoryInformation.class);
 
 		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
 		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
@@ -133,8 +133,9 @@ class RepositoryContributorUnitTests {
 	@Test // GH-3279
 	void doesNotContributeFragmentMethod() {
 
-		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
-		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+		AotRepositoryContext repositoryContext = mock(AotRepositoryContext.class);
+		when(repositoryContext.getModuleName()).thenReturn("Commons");
+		RepositoryInformation repositoryInformation = mock(RepositoryInformation.class);
 
 		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
 		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);
@@ -157,8 +158,9 @@ class RepositoryContributorUnitTests {
 	@Test // GH-3279
 	void contributesBaseClassMethodIfQueryMethod() {
 
-		AotRepositoryContext repositoryContext = Mockito.mock(AotRepositoryContext.class);
-		RepositoryInformation repositoryInformation = Mockito.mock(RepositoryInformation.class);
+		AotRepositoryContext repositoryContext = mock(AotRepositoryContext.class);
+		when(repositoryContext.getModuleName()).thenReturn("Commons");
+		RepositoryInformation repositoryInformation = mock(RepositoryInformation.class);
 
 		when(repositoryContext.getRepositoryInformation()).thenReturn(repositoryInformation);
 		when(repositoryInformation.getRepositoryInterface()).thenReturn((Class) UserRepository.class);

--- a/src/test/java/org/springframework/data/repository/config/DummyRegistrarWithContributor.java
+++ b/src/test/java/org/springframework/data/repository/config/DummyRegistrarWithContributor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.core.io.DefaultResourceLoader;
+
+/**
+ * @author Mark Paluch
+ */
+class DummyRegistrarWithContributor extends RepositoryBeanDefinitionRegistrarSupport {
+
+	DummyRegistrarWithContributor() {
+		setResourceLoader(new DefaultResourceLoader());
+	}
+
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableRepositoriesWithContributor.class;
+	}
+
+	@Override
+	protected RepositoryConfigurationExtension getExtension() {
+		return new DummyConfigurationExtension();
+	}
+}

--- a/src/test/java/org/springframework/data/repository/config/EnableRepositoriesWithContributor.java
+++ b/src/test/java/org/springframework/data/repository/config/EnableRepositoriesWithContributor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.core.support.DummyRepositoryFactoryBean;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Import(DummyRegistrarWithContributor.class)
+@Inherited
+public @interface EnableRepositoriesWithContributor {
+
+	String[] value() default {};
+
+	String[] basePackages() default {};
+
+	Class<?>[] basePackageClasses() default {};
+
+	Filter[] includeFilters() default {};
+
+	Filter[] excludeFilters() default {};
+
+	Class<?> repositoryFactoryBeanClass() default DummyRepositoryFactoryBean.class;
+
+	Class<? extends RepositoryFragmentsContributor> fragmentsContributor() default SampleRepositoryFragmentsContributor.class;
+
+	Class<?> repositoryBaseClass() default PagingAndSortingRepository.class;
+
+	Class<? extends BeanNameGenerator> nameGenerator() default BeanNameGenerator.class;
+
+	String namedQueriesLocation() default "";
+
+	String repositoryImplementationPostfix() default "Impl";
+
+	boolean considerNestedRepositories() default false;
+
+	boolean limitImplementationBasePackages() default true;
+
+	BootstrapMode bootstrapMode() default BootstrapMode.DEFAULT;
+}

--- a/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionReaderTests.java
+++ b/src/test/java/org/springframework/data/repository/config/RepositoryBeanDefinitionReaderTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.aot.sample.ConfigWithCustomImplementation;
+import org.springframework.data.aot.sample.ConfigWithCustomRepositoryBaseClass;
+import org.springframework.data.aot.sample.ConfigWithCustomRepositoryBaseClass.CustomerRepositoryWithCustomBaseRepo;
+import org.springframework.data.aot.sample.ConfigWithSimpleCrudRepository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+
+/**
+ * @author Christoph Strobl
+ */
+class RepositoryBeanDefinitionReaderTests {
+
+	@Test // GH-3279
+	void readsSimpleConfigFromBeanFactory() {
+
+		RegisteredBean repoFactoryBean = repositoryFactory(ConfigWithSimpleCrudRepository.class);
+
+		RepositoryConfiguration<?> repoConfig = mock(RepositoryConfiguration.class);
+		Mockito.when(repoConfig.getRepositoryInterface()).thenReturn(ConfigWithSimpleCrudRepository.MyRepo.class.getName());
+
+		RepositoryInformation repositoryInformation = RepositoryBeanDefinitionReader.repositoryInformation(repoConfig,
+				repoFactoryBean.getMergedBeanDefinition(), repoFactoryBean.getBeanFactory());
+
+		assertThat(repositoryInformation.getRepositoryInterface()).isEqualTo(ConfigWithSimpleCrudRepository.MyRepo.class);
+		assertThat(repositoryInformation.getDomainType()).isEqualTo(ConfigWithSimpleCrudRepository.Person.class);
+		assertThat(repositoryInformation.getFragments()).isEmpty();
+	}
+
+	@Test // GH-3279
+	void readsCustomRepoBaseClassFromBeanFactory() {
+
+		RegisteredBean repoFactoryBean = repositoryFactory(ConfigWithCustomRepositoryBaseClass.class);
+
+		RepositoryConfiguration<?> repoConfig = mock(RepositoryConfiguration.class);
+		Class<?> repositoryInterfaceType = CustomerRepositoryWithCustomBaseRepo.class;
+		Mockito.when(repoConfig.getRepositoryInterface()).thenReturn(repositoryInterfaceType.getName());
+
+		RepositoryInformation repositoryInformation = RepositoryBeanDefinitionReader.repositoryInformation(repoConfig,
+				repoFactoryBean.getMergedBeanDefinition(), repoFactoryBean.getBeanFactory());
+
+		assertThat(repositoryInformation.getRepositoryBaseClass())
+				.isEqualTo(ConfigWithCustomRepositoryBaseClass.RepoBaseClass.class);
+	}
+
+	@Test // GH-3279
+	void readsFragmentsFromBeanFactory() {
+
+		RegisteredBean repoFactoryBean = repositoryFactory(ConfigWithCustomImplementation.class);
+
+		RepositoryConfiguration<?> repoConfig = mock(RepositoryConfiguration.class);
+		Class<?> repositoryInterfaceType = ConfigWithCustomImplementation.RepositoryWithCustomImplementation.class;
+		Mockito.when(repoConfig.getRepositoryInterface()).thenReturn(repositoryInterfaceType.getName());
+
+		RepositoryInformation repositoryInformation = RepositoryBeanDefinitionReader.repositoryInformation(repoConfig,
+				repoFactoryBean.getMergedBeanDefinition(), repoFactoryBean.getBeanFactory());
+
+		assertThat(repositoryInformation.getFragments()).satisfiesExactly(fragment -> {
+			assertThat(fragment.getSignatureContributor())
+					.isEqualTo(ConfigWithCustomImplementation.CustomImplInterface.class);
+		});
+	}
+
+	@Test // GH-3279
+	void fallsBackToModuleBaseClassIfSetAndNoRepoBaseDefined() {
+
+		RegisteredBean repoFactoryBean = repositoryFactory(ConfigWithSimpleCrudRepository.class);
+		RootBeanDefinition rootBeanDefinition = repoFactoryBean.getMergedBeanDefinition().cloneBeanDefinition();
+		// need to unset because its defined as non default
+		rootBeanDefinition.getPropertyValues().removePropertyValue("repositoryBaseClass");
+		rootBeanDefinition.getPropertyValues().add("moduleBaseClass", ModuleBase.class.getName());
+
+		RepositoryConfiguration<?> repoConfig = mock(RepositoryConfiguration.class);
+		Mockito.when(repoConfig.getRepositoryInterface()).thenReturn(ConfigWithSimpleCrudRepository.MyRepo.class.getName());
+
+		RepositoryInformation repositoryInformation = RepositoryBeanDefinitionReader.repositoryInformation(repoConfig,
+				rootBeanDefinition, repoFactoryBean.getBeanFactory());
+
+		assertThat(repositoryInformation.getRepositoryBaseClass()).isEqualTo(ModuleBase.class);
+	}
+
+	static RegisteredBean repositoryFactory(Class<?> configClass) {
+
+		AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+		applicationContext.register(configClass);
+		applicationContext.refreshForAotProcessing(new RuntimeHints());
+
+		String[] beanNamesForType = applicationContext.getBeanNamesForType(RepositoryFactoryBeanSupport.class);
+		if (beanNamesForType.length != 1) {
+			throw new IllegalStateException("Unable to find repository FactoryBean");
+		}
+
+		return RegisteredBean.of(applicationContext.getBeanFactory(), beanNamesForType[0]);
+	}
+
+	static class ModuleBase {}
+}

--- a/src/test/java/org/springframework/data/repository/config/SampleRepositoryFragmentsContributor.java
+++ b/src/test/java/org/springframework/data/repository/config/SampleRepositoryFragmentsContributor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.data.repository.core.support.RepositoryFragment;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
+
+/**
+ * @author Mark Paluch
+ */
+public class SampleRepositoryFragmentsContributor implements RepositoryFragmentsContributor {
+
+	@Override
+	public RepositoryComposition.RepositoryFragments describe(RepositoryMetadata metadata) {
+		return RepositoryComposition.RepositoryFragments
+				.of(RepositoryFragment.structural(SampleRepositoryFragmentsContributor.class));
+	}
+}

--- a/src/test/java/org/springframework/data/repository/core/support/DummyRepositoryFactoryBean.java
+++ b/src/test/java/org/springframework/data/repository/core/support/DummyRepositoryFactoryBean.java
@@ -29,6 +29,7 @@ public class DummyRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 		extends RepositoryFactoryBeanSupport<T, S, ID> {
 
 	private final T repository;
+	private RepositoryFragmentsContributor repositoryFragmentsContributor = RepositoryFragmentsContributor.empty();
 
 	public DummyRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
 
@@ -36,6 +37,19 @@ public class DummyRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 
 		this.repository = mock(repositoryInterface);
 		setMappingContext(new SampleMappingContext());
+	}
+
+	public T getRepository() {
+		return repository;
+	}
+
+	@Override
+	public RepositoryFragmentsContributor getRepositoryFragmentsContributor() {
+		return repositoryFragmentsContributor;
+	}
+
+	public void setRepositoryFragmentsContributor(RepositoryFragmentsContributor repositoryFragmentsContributor) {
+		this.repositoryFragmentsContributor = repositoryFragmentsContributor;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/repository/support/RepositoriesUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/support/RepositoriesUnitTests.java
@@ -46,6 +46,7 @@ import org.springframework.data.repository.core.support.DummyEntityInformation;
 import org.springframework.data.repository.core.support.DummyRepositoryFactoryBean;
 import org.springframework.data.repository.core.support.DummyRepositoryInformation;
 import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
+import org.springframework.data.repository.core.support.RepositoryFragmentsContributor;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.ClassUtils;
@@ -288,6 +289,11 @@ class RepositoriesUnitTests {
 		@Override
 		public RepositoryInformation getRepositoryInformation() {
 			return new DummyRepositoryInformation(repositoryMetadata);
+		}
+
+		@Override
+		public RepositoryFragmentsContributor getRepositoryFragmentsContributor() {
+			return RepositoryFragmentsContributor.empty();
 		}
 
 		@Override


### PR DESCRIPTION
Add module identifier and base repository implementation properties (seeks better alternative, maybe).
Fix fragment function previously overriding already set property due to name clash.
Extend tests for bean definition resolution and code block creation.