### PR TITLE
Log a warning if param not annotated with `@ProjectedPayload`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-GH-3300-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
@@ -167,7 +167,7 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 
 			if (this.loggedParameters.putIfAbsent(parameter, Boolean.TRUE) == null) {
 				var paramName = parameter.getParameterName();
-				var paramNameOrEmpty = paramName != null ? (" " + paramName + " ") : " ";
+				var paramNameOrEmpty = paramName != null ? (" '" + paramName + "' ") : " ";
 				var methodName = parameter.getMethod() != null ? parameter.getMethod().getName() : "constructor";
 				LOGGER.warn(() -> MESSAGE.formatted(paramNameOrEmpty, parameter.getParameterIndex(), parameter.getContainingClass().getName(), methodName));
 			}

--- a/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
@@ -16,16 +16,21 @@
 package org.springframework.data.web;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import example.SampleInterface;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.data.web.ProxyingHandlerMethodArgumentResolver.ProjectedPayloadDeprecationLogger;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.multipart.MultipartFile;
@@ -113,6 +118,25 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		var parameter = getParameter("withProjectedPayloadMultipart", MultipartFile.class);
 
 		assertThat(resolver.supportsParameter(parameter)).isFalse();
+	}
+
+	@Test // GH-3300
+	@SuppressWarnings("unchecked")
+	void deprecationLoggerOnlyLogsOncePerParameter() {
+
+		var parameter = getParameter("withModelAttribute", SampleInterface.class);
+
+		// Spy on the actual logger in the helper class
+		var deprecationLogger = (ProjectedPayloadDeprecationLogger) ReflectionTestUtils.getField(resolver, "deprecationLogger");
+		var actualLogger = (LogAccessor) ReflectionTestUtils.getField(deprecationLogger, "logger");
+		var actualLoggerSpy = spy(actualLogger);
+		ReflectionTestUtils.setField(deprecationLogger, "logger", actualLoggerSpy);
+
+		// Invoke twice but should only log the first time
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
+		verify(actualLoggerSpy, times(1)).warn(any(Supplier.class));
+		assertThat(resolver.supportsParameter(parameter)).isTrue();
+		verifyNoMoreInteractions(actualLoggerSpy);
 	}
 
 	private static MethodParameter getParameter(String methodName, Class<?> parameterType) {

--- a/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.log.LogAccessor;
-import org.springframework.data.web.ProxyingHandlerMethodArgumentResolver.ProjectedPayloadDeprecationLogger;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -126,11 +125,10 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 
 		var parameter = getParameter("withModelAttribute", SampleInterface.class);
 
-		// Spy on the actual logger in the helper class
-		var deprecationLogger = (ProjectedPayloadDeprecationLogger) ReflectionTestUtils.getField(resolver, "deprecationLogger");
-		var actualLogger = (LogAccessor) ReflectionTestUtils.getField(deprecationLogger, "logger");
+		// Spy on the actual logger
+		var actualLogger = (LogAccessor) ReflectionTestUtils.getField(ProxyingHandlerMethodArgumentResolver.class, "LOGGER");
 		var actualLoggerSpy = spy(actualLogger);
-		ReflectionTestUtils.setField(deprecationLogger, "logger", actualLoggerSpy);
+		ReflectionTestUtils.setField(ProxyingHandlerMethodArgumentResolver.class, "LOGGER", actualLoggerSpy, LogAccessor.class);
 
 		// Invoke twice but should only log the first time
 		assertThat(resolver.supportsParameter(parameter)).isTrue();


### PR DESCRIPTION
This commit introduces a warning log if a parameter is not annotated with `@ProjectedPayload` that this style is deprecated and that we will drop support for projections if a parameter is not annotated with `@ProjectedPayload`.

Resolves #3300

The output log message looks as follows:
> 2025-05-29 15:20:58,924  WARN eb.ProxyingHandlerMethodArgumentResolver: 271 - Parameter  (method 'withModelAttribute' parameter 0) is not annotated with @ProjectedPayload - support for parameters not explicitly annotated with @ProjectedPayload (at the parameter or type level) will be dropped in a future version.


> [!NOTE]
> If the parameter actually has a name (`MethodParameter.getName() != null`) then it will be included just before `(method 'withModelAttribute' parameter...` 


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
