### PR TITLE
Use mutable list to collect items from `Stream` for reversal

### DIFF
--- a/src/main/java/org/springframework/data/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/convert/CustomConversions.java
@@ -124,7 +124,7 @@ public class CustomConversions {
 				converterConfiguration.getStoreConversions(), converterConfiguration.getUserConverters()).stream()
 				.filter(this::isSupportedConverter).filter(this::shouldRegister)
 				.map(ConverterRegistrationIntent::getConverterRegistration).map(this::register).distinct()
-				.collect(Collectors.toList());
+				.collect(Collectors.toCollection(ArrayList::new));
 
 		Collections.reverse(registeredConverters);
 

--- a/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
+++ b/src/main/java/org/springframework/data/spel/ExtensionAwareEvaluationContextProvider.java
@@ -189,7 +189,7 @@ public class ExtensionAwareEvaluationContextProvider implements EvaluationContex
 		return extensions.stream()//
 				.sorted(AnnotationAwareOrderComparator.INSTANCE)//
 				.map(it -> new EvaluationContextExtensionAdapter(it, getOrCreateInformation(it))) //
-				.collect(Collectors.toList());
+				.collect(Collectors.toCollection(ArrayList::new));
 	}
 
 	/**


### PR DESCRIPTION
>> There are no guarantees on the type, mutability, serializability, or thread-safety of the List returned

`Collector.toList()` doesn't guarantee mutability, then passing it to `Collections.reverse()` is not safe.