### PR TITLE
Let Kotlin repository generics extend `Any`

### DIFF
--- a/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
@@ -24,4 +24,4 @@ package org.springframework.data.repository
  * @author Oscar Hernandez
  * @since 2.1.4
  */
-fun <T, ID: Any> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)
+fun <T: Any, ID: Any> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)

--- a/src/main/kotlin/org/springframework/data/repository/kotlin/CoroutineCrudRepository.kt
+++ b/src/main/kotlin/org/springframework/data/repository/kotlin/CoroutineCrudRepository.kt
@@ -37,7 +37,7 @@ import reactor.core.publisher.Mono
  * @see Flow
  */
 @NoRepositoryBean
-interface CoroutineCrudRepository<T, ID> : Repository<T, ID> {
+interface CoroutineCrudRepository<T: Any, ID: Any> : Repository<T, ID> {
 
 	/**
 	 * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the

--- a/src/main/kotlin/org/springframework/data/repository/kotlin/CoroutineSortingRepository.kt
+++ b/src/main/kotlin/org/springframework/data/repository/kotlin/CoroutineSortingRepository.kt
@@ -34,7 +34,7 @@ import org.springframework.data.repository.Repository
  * @see CoroutineCrudRepository
  */
 @NoRepositoryBean
-interface CoroutineSortingRepository<T, ID> : Repository<T, ID> {
+interface CoroutineSortingRepository<T: Any, ID: Any> : Repository<T, ID> {
 
 	/**
 	 * Returns all entities sorted by the given options.


### PR DESCRIPTION
The move to Kotlin 2.x introduces warnings in the Kotlin extensions for type arguments tha are not within their bounds (i.e. `Thing<T>` should be `Thing<T : Any>`). This commit fixes these cases and removes the warnings.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
