### PR TITLE
Polish README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,7 +73,7 @@ https://github.com/spring-projects/spring-data-commons/issues[issue tracker] to 
 
 == Building from Source
 
-You don’t need to build from source to use Spring Data (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Data can be easily built with the https://github.com/takari/maven-wrapper[maven wrapper].
+You don’t need to build from source to use Spring Data (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Data can be easily built with the https://github.com/apache/maven-wrapper[maven wrapper].
 You also need JDK 17 or above.
 
 [source,bash]
@@ -83,7 +83,9 @@ You also need JDK 17 or above.
 
 If you want to build with the regular `mvn` command, you will need https://maven.apache.org/run-maven/index.html[Maven v3.5.0 or above].
 
-_Also see link:CONTRIBUTING.adoc[CONTRIBUTING.adoc] if you wish to submit pull requests, and in particular please sign the https://cla.pivotal.io/sign/spring[Contributor’s Agreement] before your first non-trivial change._
+_Also see link:CONTRIBUTING.adoc[CONTRIBUTING.adoc] if you wish to submit pull requests._
+All commits must include a __Signed-off-by__ trailer at the end of each commit message to indicate that the contributor agrees to the Developer Certificate of Origin.
+For additional details, please refer to the blog post https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring[Hello DCO, Goodbye CLA: Simplifying Contributions to Spring].
 
 === Building reference documentation
 


### PR DESCRIPTION
I've tried to build the documentation on my local machine, but it didn't work.

https://github.com/spring-projects/spring-data-commons?tab=readme-ov-file#building-reference-documentatio

It only worked when I added `antora:antora` at the end, and the generated documentation was available at `/target/site/index.html`.
I'm using Windows OS, so there might be differences compared to other OS.

Please check, and if it's correct, I will update it in this PR.