### PR TITLE
Explore including generated `PersistentPropertyAccessorFactory` and `EntityInstantiator` classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-GH-2595-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/aot/AotMappingContext.java
+++ b/src/main/java/org/springframework/data/aot/AotMappingContext.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aot;
+
+import org.springframework.data.mapping.Association;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.context.AbstractMappingContext;
+import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
+import org.springframework.data.mapping.model.BasicPersistentEntity;
+import org.springframework.data.mapping.model.ClassGeneratingPropertyAccessorFactory;
+import org.springframework.data.mapping.model.EntityInstantiator;
+import org.springframework.data.mapping.model.EntityInstantiators;
+import org.springframework.data.mapping.model.PersistentEntityClassInitializer;
+import org.springframework.data.mapping.model.Property;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.util.TypeInformation;
+
+/**
+ * Simple {@link AbstractMappingContext} for processing of AOT contributions.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+public class AotMappingContext extends
+		AbstractMappingContext<BasicPersistentEntity<?, AotMappingContext.BasicPersistentProperty>, AotMappingContext.BasicPersistentProperty> {
+
+	private final EntityInstantiators instantiators = new EntityInstantiators();
+	private final ClassGeneratingPropertyAccessorFactory propertyAccessorFactory = new ClassGeneratingPropertyAccessorFactory();
+
+	/**
+	 * Contribute entity instantiators and property accessors for the given {@link PersistentEntity} that are captured
+	 * through Spring's {@code CglibClassHandler}. Otherwise, this is a no-op if contributions are not ran through
+	 * {@code CglibClassHandler}.
+	 *
+	 * @param entity
+	 */
+	public void contribute(PersistentEntity<?, ?> entity) {
+		EntityInstantiator instantiator = instantiators.getInstantiatorFor(entity);
+		if (instantiator instanceof PersistentEntityClassInitializer pec) {
+			pec.initialize(entity);
+		}
+		propertyAccessorFactory.initialize(entity);
+	}
+
+	@Override
+	protected <T> BasicPersistentEntity<?, BasicPersistentProperty> createPersistentEntity(
+			TypeInformation<T> typeInformation) {
+		return new BasicPersistentEntity<>(typeInformation);
+	}
+
+	@Override
+	protected BasicPersistentProperty createPersistentProperty(Property property,
+			BasicPersistentEntity<?, BasicPersistentProperty> owner, SimpleTypeHolder simpleTypeHolder) {
+		return new BasicPersistentProperty(property, owner, simpleTypeHolder);
+	}
+
+	static class BasicPersistentProperty extends AnnotationBasedPersistentProperty<BasicPersistentProperty> {
+
+		public BasicPersistentProperty(Property property, PersistentEntity<?, BasicPersistentProperty> owner,
+				SimpleTypeHolder simpleTypeHolder) {
+			super(property, owner, simpleTypeHolder);
+		}
+
+		@Override
+		protected Association<BasicPersistentProperty> createAssociation() {
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
@@ -36,6 +36,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.data.domain.ManagedTypes;
+import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.util.Lazy;
 import org.springframework.data.util.QTypeContributor;
 import org.springframework.data.util.TypeContributor;
@@ -56,6 +57,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	private final Log logger = LogFactory.getLog(getClass());
 	private @Nullable String moduleIdentifier;
 	private Lazy<Environment> environment = Lazy.of(StandardEnvironment::new);
+	private final AotMappingContext aotMappingContext = new AotMappingContext();
 
 	public void setModuleIdentifier(@Nullable String moduleIdentifier) {
 		this.moduleIdentifier = moduleIdentifier;
@@ -149,6 +151,11 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 		Class<?> resolvedType = type.toClass();
 		TypeContributor.contribute(resolvedType, annotationNamespaces, generationContext);
 		QTypeContributor.contributeEntityPath(resolvedType, generationContext, resolvedType.getClassLoader());
+
+		PersistentEntity<?, ?> entity = aotMappingContext.getPersistentEntity(resolvedType);
+		if (entity != null) {
+			aotMappingContext.contribute(entity);
+		}
 
 		TypeUtils.resolveUsedAnnotations(resolvedType).forEach(
 				annotation -> TypeContributor.contribute(annotation.getType(), annotationNamespaces, generationContext));

--- a/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/AbstractMappingContext.java
@@ -56,7 +56,6 @@ import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.mapping.PropertyPath;
-import org.springframework.data.mapping.model.BeanWrapperPropertyAccessorFactory;
 import org.springframework.data.mapping.model.ClassGeneratingPropertyAccessorFactory;
 import org.springframework.data.mapping.model.EntityInstantiators;
 import org.springframework.data.mapping.model.InstantiationAwarePropertyAccessorFactory;
@@ -125,7 +124,7 @@ public abstract class AbstractMappingContext<E extends MutablePersistentEntity<?
 
 		EntityInstantiators instantiators = new EntityInstantiators();
 		PersistentPropertyAccessorFactory accessorFactory = NativeDetector.inNativeImage()
-				? BeanWrapperPropertyAccessorFactory.INSTANCE
+				? new ReflectionFallbackPersistentPropertyAccessorFactory()
 				: new ClassGeneratingPropertyAccessorFactory();
 
 		this.persistentPropertyAccessorFactory = new InstantiationAwarePropertyAccessorFactory(accessorFactory,

--- a/src/main/java/org/springframework/data/mapping/context/ReflectionFallbackPersistentPropertyAccessorFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/ReflectionFallbackPersistentPropertyAccessorFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.context;
+
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.model.BeanWrapperPropertyAccessorFactory;
+import org.springframework.data.mapping.model.ClassGeneratingPropertyAccessorFactory;
+import org.springframework.data.mapping.model.PersistentPropertyAccessorFactory;
+
+/**
+ * {@link PersistentPropertyAccessorFactory} that uses {@link ClassGeneratingPropertyAccessorFactory} if
+ * {@link ClassGeneratingPropertyAccessorFactory#isSupported(PersistentEntity) supported} and falls back to reflection.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+class ReflectionFallbackPersistentPropertyAccessorFactory implements PersistentPropertyAccessorFactory {
+
+	private final ClassGeneratingPropertyAccessorFactory accessorFactory = new ClassGeneratingPropertyAccessorFactory();
+
+	@Override
+	public <T> PersistentPropertyAccessor<T> getPropertyAccessor(PersistentEntity<?, ?> entity, T bean) {
+
+		if (accessorFactory.isSupported(entity)) {
+			return accessorFactory.getPropertyAccessor(entity, bean);
+		}
+
+		return BeanWrapperPropertyAccessorFactory.INSTANCE.getPropertyAccessor(entity, bean);
+	}
+
+	@Override
+	public boolean isSupported(PersistentEntity<?, ?> entity) {
+		return true;
+	}
+}

--- a/src/main/java/org/springframework/data/mapping/model/PersistentEntityClassInitializer.java
+++ b/src/main/java/org/springframework/data/mapping/model/PersistentEntityClassInitializer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.mapping.model;
+
+import org.springframework.data.mapping.PersistentEntity;
+
+/**
+ * @author Mark Paluch
+ */
+public interface PersistentEntityClassInitializer {
+
+	void initialize(PersistentEntity<?, ?> entity);
+}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotContribution.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotContribution.java
@@ -43,6 +43,8 @@ import org.springframework.core.DecoratingProxy;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.data.aot.AotContext;
+import org.springframework.data.aot.AotMappingContext;
+import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.projection.EntityProjectionIntrospector;
 import org.springframework.data.projection.TargetAware;
 import org.springframework.data.repository.Repository;
@@ -71,6 +73,8 @@ public class RepositoryRegistrationAotContribution implements BeanRegistrationAo
 	private static final Log logger = LogFactory.getLog(RepositoryRegistrationAotContribution.class);
 
 	private static final String KOTLIN_COROUTINE_REPOSITORY_TYPE_NAME = "org.springframework.data.repository.kotlin.CoroutineCrudRepository";
+
+	private final AotMappingContext aotMappingContext = new AotMappingContext();
 
 	private final RepositoryRegistrationAotProcessor aotProcessor;
 
@@ -277,32 +281,15 @@ public class RepositoryRegistrationAotContribution implements BeanRegistrationAo
 		QTypeContributor.contributeEntityPath(repositoryInformation.getDomainType(), contribution,
 				repositoryContext.getClassLoader());
 
-		// Repository Fragments
-		for (RepositoryFragment<?> fragment : getRepositoryInformation().getFragments()) {
-
-			Class<?> repositoryFragmentType = fragment.getSignatureContributor();
-			Optional<Class<?>> implementation = fragment.getImplementationClass();
-
-			contribution.getRuntimeHints().reflection().registerType(repositoryFragmentType, hint -> {
-
-				hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
-
-				if (!repositoryFragmentType.isInterface()) {
-					hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
-				}
-			});
-
-			implementation.ifPresent(typeToRegister -> {
-				contribution.getRuntimeHints().reflection().registerType(typeToRegister, hint -> {
-
-					hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
-
-					if (!typeToRegister.isInterface()) {
-						hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
-					}
-				});
-			});
+		// TODO: what about embedded types or entity types that are entity types references from properties?
+		PersistentEntity<?, ?> persistentEntity = aotMappingContext
+				.getPersistentEntity(repositoryInformation.getDomainType());
+		if (persistentEntity != null) {
+			aotMappingContext.contribute(persistentEntity);
 		}
+
+		// Repository Fragments
+		contributeFragments(contribution);
 
 		// Repository Proxy
 		contribution.getRuntimeHints().proxies().registerJdkProxy(repositoryInformation.getRepositoryInterface(),
@@ -343,6 +330,34 @@ public class RepositoryRegistrationAotContribution implements BeanRegistrationAo
 						contributeProjection(type, contribution);
 					}
 				});
+	}
+
+	private void contributeFragments(GenerationContext contribution) {
+		for (RepositoryFragment<?> fragment : getRepositoryInformation().getFragments()) {
+
+			Class<?> repositoryFragmentType = fragment.getSignatureContributor();
+			Optional<Class<?>> implementation = fragment.getImplementationClass();
+
+			contribution.getRuntimeHints().reflection().registerType(repositoryFragmentType, hint -> {
+
+				hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
+
+				if (!repositoryFragmentType.isInterface()) {
+					hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+				}
+			});
+
+			implementation.ifPresent(typeToRegister -> {
+				contribution.getRuntimeHints().reflection().registerType(typeToRegister, hint -> {
+
+					hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
+
+					if (!typeToRegister.isInterface()) {
+						hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+					}
+				});
+			});
+		}
 	}
 
 	private boolean isComponentAnnotatedRepository(RepositoryInformation repositoryInformation) {

--- a/src/test/java/org/springframework/data/aot/CodeContributionAssert.java
+++ b/src/test/java/org/springframework/data/aot/CodeContributionAssert.java
@@ -15,15 +15,18 @@
  */
 package org.springframework.data.aot;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.AbstractAssert;
+
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.JdkProxyHint;
+import org.springframework.aot.hint.TypeHint;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 
@@ -33,6 +36,7 @@ import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
  *
  * @author Christoph Strobl
  * @author John Blum
+ * @author Mark Paluch
  * @since 3.0
  */
 @SuppressWarnings("UnusedReturnValue")
@@ -48,6 +52,19 @@ public class CodeContributionAssert extends AbstractAssert<CodeContributionAsser
 			assertThat(this.actual.getRuntimeHints()).describedAs("No reflection entry found for [%s]", type)
 					.matches(RuntimeHintsPredicates.reflection().onType(type));
 		}
+
+		return this;
+	}
+
+	public CodeContributionAssert contributesReflectionFor(TypeReference typeReference) {
+
+		assertThat(this.actual.getRuntimeHints()).describedAs(() -> {
+
+			return "Existing hints: " + System.lineSeparator() + this.actual().getRuntimeHints().reflection().typeHints()
+					.map(TypeHint::toString).map(" - "::concat).collect(Collectors.joining(System.lineSeparator()));
+
+		}).matches(RuntimeHintsPredicates.reflection().onType(typeReference),
+				String.format("No reflection entry found for [%s]", typeReference));
 
 		return this;
 	}

--- a/src/test/java/org/springframework/data/repository/aot/AotUtil.java
+++ b/src/test/java/org/springframework/data/repository/aot/AotUtil.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.repository.config.RepositoryRegistrationAotContribution;
+import org.springframework.data.repository.config.RepositoryRegistrationAotProcessor;
+
+/**
+ * Utility class to create {@link RepositoryRegistrationAotContribution} instances for a given configuration class.
+ *
+ * @author Mark Paluch
+ */
+class AotUtil {
+
+	static RepositoryRegistrationAotContributionBuilder contributionFor(Class<?> configuration) {
+		return contributionFor(configuration, new AnnotationConfigApplicationContext());
+	}
+
+	static RepositoryRegistrationAotContributionBuilder contributionFor(Class<?> configuration,
+			AnnotationConfigApplicationContext applicationContext) {
+
+		applicationContext.register(configuration);
+		applicationContext.refreshForAotProcessing(new RuntimeHints());
+
+		return repositoryType -> {
+
+			String[] repositoryBeanNames = applicationContext.getBeanNamesForType(repositoryType);
+
+			assertThat(repositoryBeanNames)
+					.describedAs("Unable to find repository [%s] in configuration [%s]", repositoryType, configuration)
+					.hasSize(1);
+
+			String repositoryBeanName = repositoryBeanNames[0];
+
+			ConfigurableListableBeanFactory beanFactory = applicationContext.getDefaultListableBeanFactory();
+
+			RepositoryRegistrationAotProcessor repositoryAotProcessor = applicationContext
+					.getBean(RepositoryRegistrationAotProcessor.class);
+
+			repositoryAotProcessor.setBeanFactory(beanFactory);
+
+			RegisteredBean bean = RegisteredBean.of(beanFactory, repositoryBeanName);
+
+			BeanRegistrationAotContribution beanContribution = repositoryAotProcessor.processAheadOfTime(bean);
+
+			assertThat(beanContribution).isInstanceOf(RepositoryRegistrationAotContribution.class);
+
+			return (RepositoryRegistrationAotContribution) beanContribution;
+		};
+	}
+
+	@FunctionalInterface
+	interface RepositoryRegistrationAotContributionBuilder {
+		RepositoryRegistrationAotContribution forRepository(Class<?> repositoryInterface);
+	}
+}

--- a/src/test/java/org/springframework/data/repository/aot/GeneratedClassesCaptureIntegrationTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/GeneratedClassesCaptureIntegrationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot;
+
+import static org.springframework.data.repository.aot.RepositoryRegistrationAotContributionAssert.*;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.config.EnableRepositories;
+import org.springframework.data.repository.config.RepositoryRegistrationAotContribution;
+import org.springframework.data.repository.config.RepositoryRegistrationAotProcessor;
+
+/**
+ * Integration Tests for {@link RepositoryRegistrationAotProcessor} to verify capturing generated instantiations and
+ * property accessors.
+ *
+ * @author Mark Paluch
+ */
+public class GeneratedClassesCaptureIntegrationTests {
+
+	@Test // GH-2595
+	void registersGeneratedPropertyAccessorsEntityInstantiators() {
+
+		RepositoryRegistrationAotContribution repositoryBeanContribution = AotUtil.contributionFor(Config.class)
+				.forRepository(Config.MyRepo.class);
+
+		assertThatContribution(repositoryBeanContribution) //
+				.codeContributionSatisfies(contribution -> {
+					contribution.contributesReflectionFor(TypeReference.of(
+							"org.springframework.data.repository.aot.GeneratedClassesCaptureIntegrationTests$Config$Person__Accessor_xj7ohs"));
+					contribution.contributesReflectionFor(TypeReference.of(
+							"org.springframework.data.repository.aot.GeneratedClassesCaptureIntegrationTests$Config$Person__Instantiator_xj7ohs"));
+
+					// TODO: These should also appear
+					/*
+					contribution.contributesReflectionFor(TypeReference.of(
+							"org.springframework.data.repository.aot.GeneratedClassesCaptureIntegrationTests$Config$Address__Accessor_xj7ohs"));
+					contribution.contributesReflectionFor(TypeReference.of(
+							"org.springframework.data.repository.aot.GeneratedClassesCaptureIntegrationTests$Config$Address__Instantiator_xj7ohs"));
+					 */
+				});
+	}
+
+	@EnableRepositories(includeFilters = { @Filter(type = FilterType.ASSIGNABLE_TYPE, value = Config.MyRepo.class) },
+			basePackageClasses = Config.class, considerNestedRepositories = true)
+	public class Config {
+
+		public interface MyRepo extends CrudRepository<Person, String> {
+
+		}
+
+		public static class Person {
+
+			@Nullable Address address;
+
+		}
+
+		public static class Address {
+			String street;
+		}
+
+	}
+
+}


### PR DESCRIPTION
We now pre-initialize `ClassGeneratingPropertyAccessorFactory` and `ClassGeneratingEntityInstantiator` infrastructure to generate bytecode for their respective classes so that we include the generated code for the target AOT package. Also, we check for presence of these types to conditionally load generated classes if these are on the classpath.

This change required a stable class name therefore, we're `hashing` the fully-qualified class name and have aligned the class name from `_Accessor` to __Accessor (two underscores instead of one, same for Instantiator).

Closes #2595