### PR TITLE
GH-3121 Throw PropertyReferenceException for whitespace-starting Prop…

### DIFF
--- a/src/main/java/org/springframework/data/mapping/PropertyPath.java
+++ b/src/main/java/org/springframework/data/mapping/PropertyPath.java
@@ -47,7 +47,7 @@ public class PropertyPath implements Streamable<PropertyPath> {
 
 	private static final String PARSE_DEPTH_EXCEEDED = "Trying to parse a path with depth greater than 1000; This has been disabled for security reasons to prevent parsing overflows";
 
-	private static final String DELIMITERS = "_\\.";
+	private static final String DELIMITERS = "_."; // dot not need to be escaped in the character group
 	private static final Pattern SPLITTER = Pattern.compile("(?:[%s]?([%s]*?[^%s]+))".replaceAll("%s", DELIMITERS));
 	private static final Pattern SPLITTER_FOR_QUOTED = Pattern.compile("(?:[%s]?([%s]*?[^%s]+))".replaceAll("%s", "\\."));
 	private static final Pattern NESTED_PROPERTY_PATTERN = Pattern.compile("\\p{Lu}[\\p{Ll}\\p{Nd}]*$");
@@ -471,6 +471,10 @@ public class PropertyPath implements Streamable<PropertyPath> {
 				throw e;
 			}
 
+			if (source.isEmpty() || Character.isWhitespace(source.charAt(0))) {
+				throw e;
+			}
+
 			exception = e;
 		}
 
@@ -497,42 +501,5 @@ public class PropertyPath implements Streamable<PropertyPath> {
 		return String.format("%s.%s", owningType.getType().getSimpleName(), toDotPath());
 	}
 
-	private static final class Property {
-
-		private final TypeInformation<?> type;
-		private final String path;
-
-		private Property(TypeInformation<?> type, String path) {
-			this.type = type;
-			this.path = path;
-		}
-
-		@Override
-		public boolean equals(@Nullable Object obj) {
-
-			if (obj == this) {
-				return true;
-			}
-
-			if (!(obj instanceof Property that)) {
-				return false;
-			}
-
-			return Objects.equals(this.type, that.type) &&
-					Objects.equals(this.path, that.path);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(type, path);
-		}
-
-		@Override
-		public String toString() {
-
-			return "Key[" +
-					"type=" + type + ", " +
-					"path=" + path + ']';
-		}
-	}
+	private record Property(TypeInformation<?> type, String path) { }
 }

--- a/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/PropertyPathUnitTests.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.util.TypeInformation;
 
 /**
@@ -91,6 +93,12 @@ class PropertyPathUnitTests {
 		assertThat(reference.getSegment()).isEqualTo("user");
 		assertThat(reference.hasNext()).isTrue();
 		assertThat(reference.next()).isEqualTo(new PropertyPath("name", FooBar.class));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"user_ name", "user_ Name", "user. Name", "user. name"})
+	void testPathStartedWithWhitespaceAreNotValid(String source) {
+		assertThatThrownBy(() -> PropertyPath.from(source, Sample.class)).isInstanceOf(PropertyReferenceException.class);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #3121 

So, actually, the situation that is described in the original ticket is quite flawed in many ways.

My basic assumption is that `PropertyPath` cannot hold whitespace holding properties. Now, the way it works with `properties. key` as the PropertyPath in spring data mongodb - **it actually don't**, we still were unable to parse the `PropertyPath`, [but we handed the exception - the `PropertyReferenceException`](https://github.com/spring-projects/spring-data-mongodb/blob/main/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/QueryMapper.java#L1388). 

The mongodb can handles property references like `properties. key`, so the spring-data-mongodb just passed it literally as 

```
{ $set : { "properties. key" : "value" }  }
```

and the mongodb engine would figure it out.

Therefore, I think, that the only correct fix that can be applied here is to just throw a correct exception, which is `PropertyReferenceException`. The `properties. key` and `properties. Key` should not be considered valid `PropertyPath` instances. 

CC: @christophstrobl @mp911de 

