### PR TITLE
refactor: extract magic number 0L to constant for new entity check

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/AbstractEntityInformation.java
+++ b/src/main/java/org/springframework/data/repository/core/support/AbstractEntityInformation.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractEntityInformation<T, ID> implements EntityInformation<T, ID> {
 
+	public static final long NEW_ID = 0L;
 	private final Class<T> domainClass;
 
 	public AbstractEntityInformation(Class<T> domainClass) {
@@ -50,7 +51,7 @@ public abstract class AbstractEntityInformation<T, ID> implements EntityInformat
 		}
 
 		if (id instanceof Number n) {
-			return n.longValue() == 0L;
+			return n.longValue() == NEW_ID;
 		}
 
 		throw new IllegalArgumentException(String.format("Unsupported primitive id type %s", idType));

--- a/src/test/java/org/springframework/data/repository/core/support/AbstractEntityInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/AbstractEntityInformationUnitTests.java
@@ -49,7 +49,7 @@ class AbstractEntityInformationUnitTests {
 	}
 
 	@Test // DATACMNS-357
-	void detectsNewStateForPrimitiveIds() {
+	void detectsNewStateForZeroIds() {
 
 		var fooEn = new CustomEntityInformation<PrimitiveIdEntity, Serializable>(
 				PrimitiveIdEntity.class);
@@ -59,6 +59,16 @@ class AbstractEntityInformationUnitTests {
 
 		entity.id = 5L;
 		assertThat(fooEn.isNew(entity)).isFalse();
+	}
+
+	@Test // DATACMNS-357
+	void detectsNewStateForPrimitiveIds() {
+
+		var fooEn = new CustomEntityInformation<PrimitiveWithIdEntity, Serializable>(
+				PrimitiveWithIdEntity.class);
+
+		var entity = new PrimitiveWithIdEntity(0L);
+		assertThat(fooEn.isNew(entity)).isTrue();
 	}
 
 	@Test // DATACMNS-357
@@ -83,6 +93,16 @@ class AbstractEntityInformationUnitTests {
 		assertThatIllegalArgumentException()//
 				.isThrownBy(() -> information.isNew(new UnsupportedPrimitiveIdEntity()))//
 				.withMessageContaining(boolean.class.getName());
+	}
+
+	static class PrimitiveWithIdEntity {
+
+		@Id long id;
+
+
+		public PrimitiveWithIdEntity(long id) {
+			this.id = id;
+		}
 	}
 
 	static class PrimitiveIdEntity {


### PR DESCRIPTION
### Motivation

Replaced the hardcoded value `0L` with a named constant to clarify its meaning as a marker for new (unsaved) entities.

Even though the value was only used in a single location, extracting it improves code readability and prevents potential misuse.

### Changes

- Introduced a private static final constant `NEW_ID = 0L`
- Replaced inline `0L` usage in new entity check


### Checklists
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
