### PR TITLE
Add ExpressionMarker abstraction for obtaining enclosing method in AOT generated code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.x-AOT-EXPRESSION-MARKER-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotQueryMethodGenerationContext.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotQueryMethodGenerationContext.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
-
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.MergedAnnotation;
@@ -50,6 +49,7 @@ public class AotQueryMethodGenerationContext {
 	private final AotRepositoryFragmentMetadata targetTypeMetadata;
 	private final MethodMetadata targetMethodMetadata;
 	private final VariableNameFactory variableNameFactory;
+	private final ExpressionMarker expressionMarker;
 
 	protected AotQueryMethodGenerationContext(RepositoryInformation repositoryInformation, Method method,
 			QueryMethod queryMethod, AotRepositoryFragmentMetadata targetTypeMetadata) {
@@ -61,6 +61,7 @@ public class AotQueryMethodGenerationContext {
 		this.targetTypeMetadata = targetTypeMetadata;
 		this.targetMethodMetadata = new MethodMetadata(repositoryInformation, method);
 		this.variableNameFactory = LocalVariableNameFactory.forMethod(targetMethodMetadata);
+		this.expressionMarker = new ExpressionMarker();
 	}
 
 	MethodMetadata getTargetMethodMetadata() {
@@ -342,4 +343,13 @@ public class AotQueryMethodGenerationContext {
 		return getParameterName(queryMethod.getParameters().getScoreRangeIndex());
 	}
 
+	/**
+	 * Obtain the {@link ExpressionMarker} for the current method. Will add a local class within the method that can be
+	 * referenced via {@link ExpressionMarker#enclosingMethod()}.
+	 * 
+	 * @return the {@link ExpressionMarker} for this particular method.
+	 */
+	public ExpressionMarker getExpressionMarker() {
+		return expressionMarker;
+	}
 }

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryMethodBuilder.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryMethodBuilder.java
@@ -96,6 +96,9 @@ class AotRepositoryMethodBuilder {
 				context.getMethod().getName(), StringUtils.collectionToCommaDelimitedString(context.getTargetMethodMetadata()
 						.getMethodArguments().values().stream().map(it -> it.type.toString()).collect(Collectors.toList())));
 		context.getTargetMethodMetadata().getMethodArguments().forEach((name, spec) -> builder.addParameter(spec));
+		if(context.getExpressionMarker().isInUse()) {
+			builder.addCode(context.getExpressionMarker().declaration());
+		}
 		builder.addCode(methodBody);
 		customizer.accept(context, builder);
 

--- a/src/main/java/org/springframework/data/repository/aot/generate/ExpressionMarker.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/ExpressionMarker.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.aot.generate;
+
+import org.springframework.javapoet.CodeBlock;
+
+/**
+ * ExpressionMarker is used to add a dedicated type to AOT generated methods that can be used to determine the current
+ * method by calling {@link Class#getEnclosingMethod()} on it. This can be useful when working with expressions (eg.
+ * SpEL) that need to be evaluated in a given context.
+ * <p>
+ * {@link ExpressionMarker} is intended to be used via {@link AotQueryMethodGenerationContext} to maintain usage info,
+ * making sure the code is only added ({@link #isInUse()}) when {@link #enclosingMethod()} was called for generating
+ * code.
+ * 
+ * <pre class="code">
+ * ExpressionMarker marker = context.getExpressionMarker();
+ * CodeBlock.builder().add("evaluate($L, $S, $L)", marker.enclosingMethod(), queryString, parameters);
+ * </pre>
+ * 
+ * @author Christoph Strobl
+ * @since 4.0
+ */
+public class ExpressionMarker {
+
+	private final String typeName;
+	private boolean inUse = false;
+
+	ExpressionMarker() {
+		this("ExpressionMarker");
+	}
+
+	ExpressionMarker(String typeName) {
+		this.typeName = typeName;
+	}
+
+	/**
+	 * @return {@code class ExpressionMarker}.
+	 */
+	CodeBlock declaration() {
+		return CodeBlock.of("class $L{};\n", typeName);
+	}
+
+	/**
+	 * Calling this method sets the {@link ExpressionMarker} as {@link #isInUse() in-use}.
+	 *
+	 * @return {@code ExpressionMarker.class}.
+	 */
+	public CodeBlock marker() {
+
+		if (!inUse) {
+			inUse = true;
+		}
+		return CodeBlock.of("$L.class", typeName);
+	}
+
+	/**
+	 * Calling this method sets the {@link ExpressionMarker} as {@link #isInUse() in-use}.
+	 *
+	 * @return {@code ExpressionMarker.class.getEnclosingMethod()}
+	 */
+	public CodeBlock enclosingMethod() {
+		return CodeBlock.of("$L.getEnclosingMethod()", marker());
+	}
+
+	/**
+	 * @return if the marker is in use.
+	 */
+	public boolean isInUse() {
+		return inUse;
+	}
+}


### PR DESCRIPTION
ExpressionMarker is a stateful abstraction that helps creating local classes used to obtain the enclosing method. The code generation will only add the local class when needed. Prior to this change markers would have been added unconditionally to each and every method by the implementing modules themselves.