### PR TITLE
Use generated classname for writing aot repository content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.x-GH-3339-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryFragmentMetadata.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryFragmentMetadata.java
@@ -37,12 +37,10 @@ import org.springframework.javapoet.TypeName;
  */
 public class AotRepositoryFragmentMetadata {
 
-	private final ClassName className;
 	private final Map<String, FieldSpec> fields = new HashMap<>(3);
 	private final Map<String, ConstructorArgument> constructorArguments = new LinkedHashMap<>(3);
 
-	public AotRepositoryFragmentMetadata(ClassName className) {
-		this.className = className;
+	public AotRepositoryFragmentMetadata() {
 	}
 
 	/**
@@ -63,10 +61,6 @@ public class AotRepositoryFragmentMetadata {
 		}
 
 		return null;
-	}
-
-	public ClassName getTargetTypeName() {
-		return className;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
+
 import org.springframework.aot.generate.GeneratedClass;
 import org.springframework.aot.generate.GeneratedTypeReference;
 import org.springframework.aot.generate.GenerationContext;
@@ -31,7 +32,6 @@ import org.springframework.data.repository.aot.generate.AotRepositoryBuilder.Aot
 import org.springframework.data.repository.config.AotRepositoryContext;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.query.QueryMethod;
-import org.springframework.javapoet.ClassName;
 import org.springframework.javapoet.TypeName;
 
 /**
@@ -46,8 +46,7 @@ public class RepositoryContributor {
 	private static final Log logger = LogFactory.getLog(RepositoryContributor.class);
 	private static final String FEATURE_NAME = "AotRepository";
 
-	private AotRepositoryBuilder builder;
-	private final AotRepositoryContext repositoryContext;
+	private final AotRepositoryBuilder builder;
 	private @Nullable TypeReference contributedTypeName;
 
 	/**
@@ -57,7 +56,6 @@ public class RepositoryContributor {
 	 */
 	public RepositoryContributor(AotRepositoryContext repositoryContext) {
 
-		this.repositoryContext = repositoryContext;
 		builder = AotRepositoryBuilder.forRepository(repositoryContext.getRepositoryInformation(),
 				repositoryContext.getModuleName(), createProjectionFactory());
 	}
@@ -99,38 +97,38 @@ public class RepositoryContributor {
 				.withQueryMethodContributor(this::contributeQueryMethod); //
 
 		GeneratedClass generatedClass = generationContext.getGeneratedClasses().getOrAddForFeatureComponent(FEATURE_NAME,
-				ClassName.bestGuess(builder.intendedTargetClassName().getCanonicalName()), targetTypeSpec -> {
+				builder.getClassName(), targetTypeSpec -> {
+
+					// capture the actual type name early on so that we can use it in the constructor.
+					builder.withClassName(targetTypeSpec.build().name());
 
 					AotBundle aotBundle = builder.build(targetTypeSpec);
-					{
-						Class<?> repositoryInterface = getRepositoryInformation().getRepositoryInterface();
-						String repositoryJsonFileName = getRepositoryJsonFileName(repositoryInterface);
-						String repositoryJson;
-						try {
-							repositoryJson = aotBundle.metadata().toJson().toString(2);
-						} catch (JSONException e) {
-							throw new RuntimeException(e);
-						}
-
-						if (logger.isTraceEnabled()) {
-							logger.trace("""
-									------ AOT Repository.json: %s ------
-									%s
-									-------------------
-									""".formatted(repositoryJsonFileName, repositoryJson));
-
-							logger.trace("""
-									------ AOT Generated Repository: %s ------
-									%s
-									-------------------
-									""".formatted(null, aotBundle.javaFile()));
-						}
-
-						generationContext.getGeneratedFiles().addResourceFile(repositoryJsonFileName, repositoryJson);
+					Class<?> repositoryInterface = getRepositoryInformation().getRepositoryInterface();
+					String repositoryJsonFileName = getRepositoryJsonFileName(repositoryInterface);
+					String repositoryJson;
+					try {
+						repositoryJson = aotBundle.metadata().toJson().toString(2);
+					} catch (JSONException e) {
+						throw new RuntimeException(e);
 					}
+
+					if (logger.isTraceEnabled()) {
+						logger.trace("""
+								------ AOT Repository.json: %s ------
+								%s
+								-------------------
+								""".formatted(repositoryJsonFileName, repositoryJson));
+
+						logger.trace("""
+								------ AOT Generated Repository: %s ------
+								%s
+								-------------------
+								""".formatted(null, aotBundle.javaFile()));
+					}
+
+					generationContext.getGeneratedFiles().addResourceFile(repositoryJsonFileName, repositoryJson);
 				});
 
-		builder.prepare(generatedClass.getName()); // initialize ctor argument resolution and set type name to target
 		this.contributedTypeName = GeneratedTypeReference.of(generatedClass.getName());
 
 		// generate native runtime hints - needed cause we're using the repository proxy

--- a/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
@@ -96,6 +96,12 @@ public class RepositoryContributor {
 				.withConstructorCustomizer(this::customizeConstructor) //
 				.withQueryMethodContributor(this::contributeQueryMethod); //
 
+		// TODO: temporary fix until we have a better representation of constructor arguments
+		// decouple the description of arguments from the actual code used in the constructor initialization, super calls,
+		// etc.
+		RepositoryConstructorBuilder constructorBuilder = new RepositoryConstructorBuilder(builder.getGenerationMetadata());
+		customizeConstructor(constructorBuilder);
+
 		GeneratedClass generatedClass = generationContext.getGeneratedClasses().getOrAddForFeatureComponent(FEATURE_NAME,
 				builder.getClassName(), targetTypeSpec -> {
 

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryBeanDefinitionPropertiesDecorator.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryBeanDefinitionPropertiesDecorator.java
@@ -52,7 +52,7 @@ class AotRepositoryBeanDefinitionPropertiesDecorator {
 	 */
 	public CodeBlock decorate() {
 
-		Assert.notNull(repositoryContributor.getContributedTypeName(), "contributed type name must not be null");
+		Assert.notNull(repositoryContributor.getContributedTypeName(), "Contributed type name must not be null");
 
 		CodeBlock.Builder builder = CodeBlock.builder();
 		// bring in properties as usual

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryBeanDefinitionPropertiesDecorator.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryBeanDefinitionPropertiesDecorator.java
@@ -24,6 +24,7 @@ import org.springframework.data.repository.core.support.RepositoryComposition;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.javapoet.CodeBlock;
 import org.springframework.javapoet.TypeName;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -50,6 +51,8 @@ class AotRepositoryBeanDefinitionPropertiesDecorator {
 	 * @return the decorated code block.
 	 */
 	public CodeBlock decorate() {
+
+		Assert.notNull(repositoryContributor.getContributedTypeName(), "contributed type name must not be null");
 
 		CodeBlock.Builder builder = CodeBlock.builder();
 		// bring in properties as usual
@@ -78,7 +81,7 @@ class AotRepositoryBeanDefinitionPropertiesDecorator {
 		}
 
 		builder.addStatement("return RepositoryComposition.RepositoryFragments.just(new $L($L))",
-				repositoryContributor.getContributedTypeName(),
+				repositoryContributor.getContributedTypeName().getCanonicalName(),
 				StringUtils.collectionToDelimitedString(repositoryContributor.requiredArgs().keySet(), ", "));
 		builder.unindent();
 		builder.add("}\n");

--- a/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryBuilderUnitTests.java
@@ -38,7 +38,6 @@ import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.AnnotationRepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFragment;
 import org.springframework.data.repository.query.QueryMethod;
-import org.springframework.javapoet.ClassName;
 import org.springframework.javapoet.MethodSpec;
 import org.springframework.javapoet.TypeName;
 import org.springframework.stereotype.Repository;
@@ -82,7 +81,7 @@ class AotRepositoryBuilderUnitTests {
 			ctor.addParameter("param2", String.class);
 			ctor.addParameter("ctorScoped", TypeName.get(Object.class), false);
 		});
-		assertThat(repoBuilder.prepare(null).build().javaFile().toString()) //
+		assertThat(repoBuilder.withClassName(null).build().javaFile().toString()) //
 				.contains("private final Metric param1;") //
 				.contains("private final String param2;") //
 				.doesNotContain("private final Object ctorScoped;") //
@@ -102,7 +101,7 @@ class AotRepositoryBuilderUnitTests {
 				code.addStatement("throw new $T($S)", IllegalStateException.class, "initialization error");
 			});
 		});
-		repoBuilder.prepare(null);
+		repoBuilder.withClassName(null);
 		assertThat(repoBuilder.build().javaFile().toString()).containsIgnoringWhitespaces(
 				"UserRepositoryImpl() { throw new IllegalStateException(\"initialization error\"); }");
 	}
@@ -196,7 +195,7 @@ class AotRepositoryBuilderUnitTests {
 
 		TypeReference targetType = TypeReference.of("%s__AotPostfix".formatted(UserRepository.class.getCanonicalName()));
 
-		assertThat(repoBuilder.prepare(ClassName.bestGuess(targetType.getCanonicalName())).build().javaFile().toString()) //
+		assertThat(repoBuilder.withClassName(targetType.getSimpleName()).build().javaFile().toString()) //
 			.contains("class %s".formatted(targetType.getSimpleName())) //
 			.contains("public %s(Metric param1, String param2, Object ctorScoped)".formatted(targetType.getSimpleName()));
 	}

--- a/src/test/java/org/springframework/data/repository/aot/generate/RepositoryContributorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/RepositoryContributorUnitTests.java
@@ -87,7 +87,7 @@ class RepositoryContributorUnitTests {
 		repositoryContributor.contribute(generationContext);
 		generationContext.writeGeneratedContent();
 
-		String expectedTypeName = "example.UserRepositoryImpl__Aot";
+		String expectedTypeName = "example.UserRepositoryImpl__AotRepository";
 
 		TestCompiler.forSystem().with(generationContext).compile(compiled -> {
 			assertThat(compiled.getAllCompiledClasses()).map(Class::getName).contains(expectedTypeName);
@@ -132,7 +132,7 @@ class RepositoryContributorUnitTests {
 		repositoryContributor.contribute(generationContext);
 		generationContext.writeGeneratedContent();
 
-		String expectedTypeName = "example.UserRepositoryImpl__Aot";
+		String expectedTypeName = "example.UserRepositoryImpl__AotRepository";
 
 		TestCompiler.forSystem().with(generationContext).compile(compiled -> {
 			String content = compiled.getResourceFile().getContent();
@@ -154,7 +154,9 @@ class RepositoryContributorUnitTests {
 		when(repositoryInformation.isQueryMethod(argThat(it -> it.getName().equals("findByFirstname")))).thenReturn(true);
 
 		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
-		contributor.contribute(new TestGenerationContext(UserRepository.class));
+		TestGenerationContext generationContext = new TestGenerationContext(UserRepository.class);
+		contributor.contribute(generationContext);
+		generationContext.writeGeneratedContent();
 
 		contributor.verifyContributionFor("findByFirstname");
 	}
@@ -174,8 +176,11 @@ class RepositoryContributorUnitTests {
 				.thenReturn(true);
 		when(repositoryInformation.isQueryMethod(argThat(it -> !it.getName().equals("findByFirstname")))).thenReturn(true);
 
+		TestGenerationContext testGenerationContext = new TestGenerationContext(UserRepository.class);
 		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
-		contributor.contribute(new TestGenerationContext(UserRepository.class));
+		contributor.contribute(testGenerationContext);
+		testGenerationContext.writeGeneratedContent();
+
 
 		contributor.verifyContributedMethods().isNotEmpty().doesNotContainKey("findByFirstname");
 	}
@@ -200,7 +205,9 @@ class RepositoryContributorUnitTests {
 		when(repositoryInformation.isQueryMethod(argThat(it -> it.getName().equals("findByFirstname")))).thenReturn(true);
 
 		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
-		contributor.contribute(new TestGenerationContext(UserRepository.class));
+		TestGenerationContext generationContext = new TestGenerationContext(UserRepository.class);
+		contributor.contribute(generationContext);
+		generationContext.writeGeneratedContent();
 
 		contributor.verifyContributedMethods().isNotEmpty().doesNotContainKey("findUserByExtensionMethod");
 	}
@@ -221,7 +228,9 @@ class RepositoryContributorUnitTests {
 		when(repositoryInformation.isQueryMethod(any())).thenReturn(true);
 
 		MethodCapturingRepositoryContributor contributor = new MethodCapturingRepositoryContributor(repositoryContext);
-		contributor.contribute(new TestGenerationContext(UserRepository.class));
+		TestGenerationContext generationContext = new TestGenerationContext(UserRepository.class);
+		contributor.contribute(generationContext);
+		generationContext.writeGeneratedContent();
 
 		contributor.verifyContributedMethods().containsKey("findByFirstname").hasSizeGreaterThan(1);
 	}


### PR DESCRIPTION
This PR makes sure register AOT repository code with a generated typename. This is necessary to allow recreation for repository code with different configuration/context settings during tests.

Closes: #3339 