### PR TITLE
Example code in the scrolling document might not consume every element in the database.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/scrolling.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/scrolling.adoc
@@ -11,16 +11,16 @@ Similar to consuming a Java `Iterator<List<…>>` by obtaining the next batch of
 
 [source,java]
 ----
-Window<User> users = repository.findFirst10ByLastnameOrderByFirstname("Doe", ScrollPosition.offset());
-do {
-
+ScrollPosition position = ScrollPosition.offset();
+while (true) {
+  users = repository.findFirst10ByLastnameOrderByFirstname("Doe", position);
+  if (users.isEmpty()) break;
   for (User u : users) {
     // consume the user
   }
-
-  // obtain the next Scroll
-  users = repository.findFirst10ByLastnameOrderByFirstname("Doe", users.positionAt(users.size() - 1));
-} while (!users.isEmpty() && users.hasNext());
+  if (!users.hasNext()) break;
+  position = users.positionAt(users.size() - 1);
+}
 ----
 
 [NOTE]


### PR DESCRIPTION
The example code in the document: 

```java
Window<User> users = repository.findFirst10ByLastnameOrderByFirstname("Doe", ScrollPosition.offset());
do {

  for (User u : users) {
    // consume the user
  }

  // obtain the next Scroll
  users = repository.findFirst10ByLastnameOrderByFirstname("Doe", users.positionAt(users.size() - 1));
} while (!users.isEmpty() && users.hasNext());
```

The execution result is as follows (there are slight differences from the code in the documentation, but it illustrates the point):

<img width="1810" height="904" alt="screenshot-20250821-170027" src="https://github.com/user-attachments/assets/cd76b28a-3a5a-46b1-9a4a-087d316b77e7" />

It can be observed that the elements with indices 10 through 14 have not been consumed.

Modified code:

```java
ScrollPosition position = ScrollPosition.offset();
while (true) {
    users = repository.findFirst10ByLastnameOrderByFirstname("Doe", position);
    if (users.isEmpty()) break;
    for (User u : users) {
        // consume the user
    }
    if (!users.hasNext()) break;
    position = users.positionAt(users.size() - 1);
}
```

This code accounts for more cases, such as when the count of data is 0 or an exact multiple of 10.


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
