### PR TITLE
Avoid attempts to override AOT generated query method metadata. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.x-GH-3354-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/aot/AotContext.java
+++ b/src/main/java/org/springframework/data/aot/AotContext.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
 public interface AotContext extends EnvironmentCapable {
 
 	String GENERATED_REPOSITORIES_ENABLED = "spring.aot.repositories.enabled";
+	String GENERATED_REPOSITORIES_JSON_ENABLED = "spring.aot.repositories.metadata.enabled";
 
 	/**
 	 * Create an {@link AotContext} backed by the given {@link BeanFactory}.
@@ -114,6 +115,19 @@ public interface AotContext extends EnvironmentCapable {
 		String modulePropertyName = GENERATED_REPOSITORIES_ENABLED.replace("repositories",
 				"%s.repositories".formatted(moduleName.toLowerCase(Locale.ROOT)));
 		return environment.getProperty(modulePropertyName, Boolean.class, true);
+	}
+
+	/**
+	 * Checks if repository metadata file writing is enabled by checking environment variables for general
+	 * enablement ({@link #GENERATED_REPOSITORIES_JSON_ENABLED})
+	 * <p>
+	 * Unset properties are considered being {@literal true}.
+	 *
+	 * @return indicator if repository metadata should be written
+	 * @since 5.0
+	 */
+	default boolean isGeneratedRepositoriesMetadataEnabled() {
+		return getEnvironment().getProperty(GENERATED_REPOSITORIES_JSON_ENABLED, Boolean.class, true);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/repository/aot/generate/DummyModuleAotRepositoryContext.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/DummyModuleAotRepositoryContext.java
@@ -21,16 +21,15 @@ import java.util.List;
 import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
-
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.annotation.MergedAnnotation;
-import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.test.tools.ClassFile;
 import org.springframework.data.repository.config.AotRepositoryContext;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.RepositoryComposition;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Dummy {@link AotRepositoryContext} used to simulate module specific repository implementation.
@@ -40,6 +39,7 @@ import org.springframework.data.repository.core.support.RepositoryComposition;
 class DummyModuleAotRepositoryContext implements AotRepositoryContext {
 
 	private final StubRepositoryInformation repositoryInformation;
+	private final MockEnvironment environment = new MockEnvironment();
 
 	public DummyModuleAotRepositoryContext(Class<?> repositoryInterface, @Nullable RepositoryComposition composition) {
 		this.repositoryInformation = new StubRepositoryInformation(repositoryInterface, composition);
@@ -61,8 +61,8 @@ class DummyModuleAotRepositoryContext implements AotRepositoryContext {
 	}
 
 	@Override
-	public Environment getEnvironment() {
-		return null;
+	public MockEnvironment getEnvironment() {
+		return environment;
 	}
 
 	@Override


### PR DESCRIPTION
Prior to this change regenerating repository code for eg. test execution caused trouble when trying to override existing json metadata files. We now back off in case of existing files and added an explicit config flag for users to opt out of having the metadata file being present in the target resources.

Resolves: #3354 