### PR TITLE
Ensure findByIdOrNull respects AOP on overridden repository methods.

### DIFF
--- a/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/repository/CrudRepositoryExtensions.kt
@@ -22,6 +22,7 @@ package org.springframework.data.repository
  * @return the entity with the given id or `null` if none found.
  * @author Sebastien Deleuze
  * @author Oscar Hernandez
+ * @author Subin Kim
  * @since 2.1.4
  */
-fun <T: Any, ID: Any> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)
+inline fun <T: Any, ID: Any> CrudRepository<T, ID>.findByIdOrNull(id: ID): T? = findById(id).orElse(null)


### PR DESCRIPTION
This PR ensures that the `findByIdOrNull` Kotlin extension correctly respects AOP annotations on user-overridden repository methods.

## Problem

The `findByIdOrNull` Kotlin extension was not declared as an `inline` function. This caused the call to bind to the generic `CrudRepository.findById(Object)` method at compile time, which bypasses any AOP proxies on user-overridden repository methods with specific types (e.g., `findById(String)`). As a result, annotations like `@Cacheable` or `@EntityGraph` were silently ignored.

## Solution

By declaring the extension function as `inline`, the function body is inlined at the call site. This change ensures that the Kotlin compiler resolves the call to the most specific, user-defined `findById` method. Consequently, the call correctly goes through the AOP proxy, allowing features like caching or entity graphs to be applied as expected.

An accompanying unit test has been added to `CrudRepositoryExtensionsTests` to verify this fix, using `ProxyFactory` to simulate the AOP behavior.

Resolved: #3326 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

