### PR TITLE
Refine AOT Repositories infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-GH-3267-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/aot/AotTypeConfiguration.java
+++ b/src/main/java/org/springframework/data/aot/AotTypeConfiguration.java
@@ -22,19 +22,15 @@ import java.util.stream.Stream;
 
 import org.springframework.aop.SpringProxy;
 import org.springframework.aop.framework.Advised;
-import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.core.DecoratingProxy;
-import org.springframework.core.env.Environment;
 import org.springframework.data.projection.TargetAware;
 
 /**
  * Configuration object that captures various AOT configuration aspects of types within the data context by offering
  * predefined methods to register native configuration necessary for data binding, projection proxy definitions, AOT
  * cglib bytecode generation and other common tasks.
- * <p>
- * On {@link #contribute(Environment, GenerationContext)} the configuration is added to the {@link GenerationContext}.
  *
  * @author Christoph Strobl
  * @since 4.0
@@ -134,11 +130,4 @@ public interface AotTypeConfiguration {
 	 */
 	AotTypeConfiguration forQuerydsl();
 
-	/**
-	 * Write the configuration to the given {@link GenerationContext}.
-	 *
-	 * @param environment must not be {@literal null}.
-	 * @param generationContext must not be {@literal null}.
-	 */
-	void contribute(Environment environment, GenerationContext generationContext);
 }

--- a/src/main/java/org/springframework/data/aot/DefaultAotContext.java
+++ b/src/main/java/org/springframework/data/aot/DefaultAotContext.java
@@ -17,7 +17,6 @@ package org.springframework.data.aot;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
+
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.TypeReference;
@@ -55,13 +55,13 @@ import org.springframework.util.StringUtils;
  * @author Christoph Strobl
  * @since 3.0
  */
+@SuppressWarnings("removal")
 class DefaultAotContext implements AotContext {
 
 	private final AotMappingContext mappingContext;
 	private final ConfigurableListableBeanFactory factory;
 
-	// TODO: should we reuse the config or potentially have multiple ones with different settings for the same type
-	private final Map<Class<?>, AotTypeConfiguration> typeConfigurations = new HashMap<>();
+	private final Map<Class<?>, ContextualTypeConfiguration> typeConfigurations = new HashMap<>();
 	private final Environment environment;
 
 	public DefaultAotContext(BeanFactory beanFactory, Environment environment) {
@@ -101,10 +101,13 @@ class DefaultAotContext implements AotContext {
 	}
 
 	@Override
-	public Collection<AotTypeConfiguration> typeConfigurations() {
-		return typeConfigurations.values();
+	public void contributeTypeConfigurations(GenerationContext generationContext) {
+		typeConfigurations.forEach((type, configuration) -> {
+			configuration.contribute(this.environment, generationContext);
+		});
 	}
 
+	@SuppressWarnings("removal")
 	class DefaultTypeIntrospector implements TypeIntrospector {
 
 		private final String typeName;
@@ -144,6 +147,7 @@ class DefaultAotContext implements AotContext {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	class DefaultIntrospectedBeanDefinition implements IntrospectedBeanDefinition {
 
 		private final String beanName;
@@ -227,7 +231,6 @@ class DefaultAotContext implements AotContext {
 			return this;
 		}
 
-		@Override
 		public void contribute(Environment environment, GenerationContext generationContext) {
 
 			try {

--- a/src/main/java/org/springframework/data/aot/DefaultAotContext.java
+++ b/src/main/java/org/springframework/data/aot/DefaultAotContext.java
@@ -33,6 +33,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.hint.annotation.ReflectiveRuntimeHintsRegistrar;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.aot.AotProcessingException;
@@ -63,6 +64,7 @@ class DefaultAotContext implements AotContext {
 
 	private final Map<Class<?>, ContextualTypeConfiguration> typeConfigurations = new HashMap<>();
 	private final Environment environment;
+	private final ReflectiveRuntimeHintsRegistrar runtimeHintsRegistrar = new ReflectiveRuntimeHintsRegistrar();
 
 	public DefaultAotContext(BeanFactory beanFactory, Environment environment) {
 		this(beanFactory, environment, new AotMappingContext());
@@ -257,6 +259,7 @@ class DefaultAotContext implements AotContext {
 			}
 
 			if (forDataBinding) {
+				runtimeHintsRegistrar.registerRuntimeHints(generationContext.getRuntimeHints(), type);
 				TypeContributor.contribute(type, Set.of(TypeContributor.DATA_NAMESPACE), generationContext);
 			}
 

--- a/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
@@ -155,10 +155,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 		Set<String> annotationNamespaces = Collections.singleton(TypeContributor.DATA_NAMESPACE);
 
 		configureTypeContribution(type.toClass(), aotContext);
-
-		aotContext.typeConfiguration(type, config -> {
-			config.contribute(environment.get(), generationContext);
-		});
+		aotContext.contributeTypeConfigurations(generationContext);
 
 		TypeUtils.resolveUsedAnnotations(type.toClass()).forEach(
 				annotation -> TypeContributor.contribute(annotation.getType(), annotationNamespaces, generationContext));

--- a/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
@@ -155,7 +155,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 
 		Set<String> annotationNamespaces = Collections.singleton(TypeContributor.DATA_NAMESPACE);
 
-		configureTypeHints(type.toClass(), aotContext);
+		configureTypeContribution(type.toClass(), aotContext);
 
 		TypeUtils.resolveUsedAnnotations(type.toClass()).forEach(
 				annotation -> TypeContributor.contribute(annotation.getType(), annotationNamespaces, generationContext));
@@ -168,7 +168,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	 * @param aotContext AOT context for type configuration.
 	 * @since 4.0
 	 */
-	protected void configureTypeHints(Class<?> type, AotContext aotContext) {
+	protected void configureTypeContribution(Class<?> type, AotContext aotContext) {
 		aotContext.typeConfiguration(type, config -> config.forDataBinding().contributeAccessors().forQuerydsl());
 	}
 

--- a/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesBeanRegistrationAotProcessor.java
@@ -119,7 +119,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 
 	/**
 	 * Hook to provide a customized flavor of {@link BeanRegistrationAotContribution}. By overriding this method calls to
-	 * {@link #contributeType(ResolvableType, GenerationContext, AotContext)} might no longer be issued.
+	 * {@link #registerTypeHints(ResolvableType, AotContext, GenerationContext)} might no longer be issued.
 	 *
 	 * @param aotContext never {@literal null}.
 	 * @param managedTypes never {@literal null}.
@@ -128,7 +128,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	protected BeanRegistrationAotContribution contribute(AotContext aotContext, ManagedTypes managedTypes,
 			RegisteredBean registeredBean) {
 		return new ManagedTypesRegistrationAotContribution(aotContext, managedTypes, registeredBean,
-				typeCollectorCustomizer(), this::contributeType);
+				typeCollectorCustomizer(), this::registerTypeHints);
 	}
 
 	/**
@@ -140,13 +140,14 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	protected Consumer<TypeCollector> typeCollectorCustomizer() {
 		return typeCollector -> {};
 	}
+
 	/**
 	 * Hook to contribute configuration for a given {@literal type}.
 	 *
 	 * @param type never {@literal null}.
 	 * @param generationContext never {@literal null}.
 	 */
-	protected void contributeType(ResolvableType type, GenerationContext generationContext, AotContext aotContext) {
+	protected void registerTypeHints(ResolvableType type, AotContext aotContext, GenerationContext generationContext) {
 
 		if (logger.isDebugEnabled()) {
 			logger.debug(String.format("Contributing type information for [%s]", type.getType()));
@@ -154,8 +155,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 
 		Set<String> annotationNamespaces = Collections.singleton(TypeContributor.DATA_NAMESPACE);
 
-		configureTypeContribution(type.toClass(), aotContext);
-		aotContext.contributeTypeConfigurations(generationContext);
+		configureTypeHints(type.toClass(), aotContext);
 
 		TypeUtils.resolveUsedAnnotations(type.toClass()).forEach(
 				annotation -> TypeContributor.contribute(annotation.getType(), annotationNamespaces, generationContext));
@@ -168,7 +168,7 @@ public class ManagedTypesBeanRegistrationAotProcessor implements BeanRegistratio
 	 * @param aotContext AOT context for type configuration.
 	 * @since 4.0
 	 */
-	protected void configureTypeContribution(Class<?> type, AotContext aotContext) {
+	protected void configureTypeHints(Class<?> type, AotContext aotContext) {
 		aotContext.typeConfiguration(type, config -> config.forDataBinding().contributeAccessors().forQuerydsl());
 	}
 

--- a/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
+++ b/src/main/java/org/springframework/data/aot/ManagedTypesRegistrationAotContribution.java
@@ -98,8 +98,10 @@ class ManagedTypesRegistrationAotContribution implements RegisteredBeanAotContri
 
 		if (!types.isEmpty()) {
 			TypeCollector.inspect(typeCollectorCustomizer, types)
-					.forEach(type -> contributionAction.register(type, generationContext, aotContext));
+					.forEach(type -> contributionAction.register(type, aotContext, generationContext));
 		}
+
+		aotContext.contributeTypeConfigurations(generationContext);
 	}
 
 	@Override
@@ -117,7 +119,7 @@ class ManagedTypesRegistrationAotContribution implements RegisteredBeanAotContri
 	}
 
 	interface TypeRegistration {
-		void register(ResolvableType type, GenerationContext generationContext, AotContext aotContext);
+		void register(ResolvableType type, AotContext aotContext, GenerationContext generationContext);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/javapoet/LordOfTheStrings.java
+++ b/src/main/java/org/springframework/data/javapoet/LordOfTheStrings.java
@@ -858,10 +858,37 @@ public abstract class LordOfTheStrings {
 		 */
 		@Contract("_ -> this")
 		public TypedReturnBuilder number(String resultToReturn) {
+
 			return whenBoxedLong("$1L != null ? $1L.longValue() : null", resultToReturn)
 					.whenLong("$1L != null ? $1L.longValue() : 0L", resultToReturn)
 					.whenBoxedInteger("$1L != null ? $1L.intValue() : null", resultToReturn)
-					.whenInt("$1L != null ? $1L.intValue() : 0", resultToReturn);
+					.whenInt("$1L != null ? $1L.intValue() : 0", resultToReturn)
+					.whenBoxed(Byte.class, "$1L != null ? $1L.byteValue() : null", resultToReturn)
+					.when(byte.class, "$1L != null ? $1L.byteValue() : 0", resultToReturn)
+					.whenBoxed(Short.class, "$1L != null ? $1L.shortValue() : null", resultToReturn)
+					.when(short.class, "$1L != null ? $1L.shortValue() : 0", resultToReturn)
+					.whenBoxed(Double.class, "$1L != null ? $1L.doubleValue() : null", resultToReturn)
+					.when(double.class, "$1L != null ? $1L.doubleValue() : 0", resultToReturn)
+					.whenBoxed(Float.class, "$1L != null ? $1L.floatValue() : null", resultToReturn)
+					.when(float.class, "$1L != null ? $1L.floatValue() : 0f", resultToReturn);
+		}
+
+		/**
+		 * Add return statements for numeric types if the given {@code resultToReturn} points to a non-nullable
+		 * {@link Number}. Considers all primitive numeric types assuming that {@code resultToReturn} is never
+		 * {@literal null}.
+		 *
+		 * @param resultToReturn the argument or variable name holding the result.
+		 * @return {@code this} builder.
+		 */
+		@Contract("_ -> this")
+		public TypedReturnBuilder nonNullableNumber(String resultToReturn) {
+			return whenPrimitiveOrBoxed(long.class, "$1L.longValue()", resultToReturn)
+					.whenPrimitiveOrBoxed(int.class, "$1L.intValue()", resultToReturn)
+					.whenPrimitiveOrBoxed(short.class, "$1L.shortValue()", resultToReturn)
+					.whenPrimitiveOrBoxed(byte.class, "$1L.byteValue()", resultToReturn)
+					.whenPrimitiveOrBoxed(float.class, "$1L.floatValue()", resultToReturn)
+					.whenPrimitiveOrBoxed(double.class, "$1L.doubleValue()", resultToReturn);
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryBeanDefinitionPropertiesDecorator.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryBeanDefinitionPropertiesDecorator.java
@@ -41,8 +41,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * Delegate to decorate AOT {@code BeanDefinition} properties during AOT processing. Adds a {@link CodeBlock} for the
- * fragment function that resolves {@link RepositoryContributor#requiredArgs()} from the {@link BeanFactory} and
- * provides them to the generated repository fragment.
+ * fragment function that resolves {@link RepositoryContributor#getAotFragmentMetadata()} from the {@link BeanFactory}
+ * and provides them to the generated repository fragment.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -128,7 +128,8 @@ public class AotRepositoryBeanDefinitionPropertiesDecorator {
 		CodeBlock.Builder callback = CodeBlock.builder();
 		List<Object> arguments = new ArrayList<>();
 
-		for (Entry<String, ConstructorArgument> entry : repositoryContributor.getConstructorArguments().entrySet()) {
+		for (Entry<String, ConstructorArgument> entry : repositoryContributor.getAotFragmentMetadata()
+				.getConstructorArguments().entrySet()) {
 
 			ConstructorArgument argument = entry.getValue();
 			AotRepositoryConstructorBuilder.ParameterOrigin parameterOrigin = argument.parameterOrigin();

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryCreator.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryCreator.java
@@ -19,9 +19,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.lang.model.element.Modifier;
@@ -30,9 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.core.ResolvableType;
 import org.springframework.data.projection.ProjectionFactory;
-import org.springframework.data.repository.aot.generate.AotRepositoryFragmentMetadata.ConstructorArgument;
 import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.support.RepositoryComposition;
 import org.springframework.data.repository.core.support.RepositoryFragment;
@@ -100,18 +96,8 @@ class AotRepositoryCreator {
 		return repositoryInformation.getRepositoryInterface().getPackageName();
 	}
 
-	Map<String, ResolvableType> getAutowireFields() {
-
-		Map<String, ResolvableType> autowireFields = new LinkedHashMap<>(
-				generationMetadata.getConstructorArguments().size());
-		for (Map.Entry<String, ConstructorArgument> entry : generationMetadata.getConstructorArguments().entrySet()) {
-			autowireFields.put(entry.getKey(), entry.getValue().parameterType());
-		}
-		return autowireFields;
-	}
-
-	Map<String, ConstructorArgument> getConstructorArguments() {
-		return generationMetadata.getConstructorArguments();
+	AotRepositoryFragmentMetadata getRepositoryMetadata() {
+		return generationMetadata;
 	}
 
 	RepositoryInformation getRepositoryInformation() {

--- a/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryFragmentMetadata.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/AotRepositoryFragmentMetadata.java
@@ -129,6 +129,15 @@ class AotRepositoryFragmentMetadata {
 		return constructorArguments;
 	}
 
+	Map<String, ResolvableType> getAutowireFields() {
+
+		Map<String, ResolvableType> autowireFields = new LinkedHashMap<>(getConstructorArguments().size());
+		for (Map.Entry<String, ConstructorArgument> entry : getConstructorArguments().entrySet()) {
+			autowireFields.put(entry.getKey(), entry.getValue().parameterType());
+		}
+		return autowireFields;
+	}
+
 	public Map<String, LocalMethod> getMethods() {
 		return methods;
 	}

--- a/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/RepositoryContributor.java
@@ -18,19 +18,18 @@ package org.springframework.data.repository.aot.generate;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
+
 import org.springframework.aot.generate.GeneratedClass;
 import org.springframework.aot.generate.GeneratedFiles.Kind;
 import org.springframework.aot.generate.GeneratedTypeReference;
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.TypeReference;
-import org.springframework.core.ResolvableType;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.aot.generate.AotRepositoryCreator.AotBundle;
@@ -66,7 +65,7 @@ public class RepositoryContributor {
 	public RepositoryContributor(AotRepositoryContext repositoryContext) {
 
 		this.repositoryContext = repositoryContext;
-		creator = AotRepositoryCreator.forRepository(repositoryContext.getRepositoryInformation(),
+		this.creator = AotRepositoryCreator.forRepository(repositoryContext.getRepositoryInformation(),
 				repositoryContext.getModuleName(), createProjectionFactory());
 	}
 
@@ -102,28 +101,10 @@ public class RepositoryContributor {
 	}
 
 	/**
-	 * Get the required constructor arguments for the to be generated repository implementation. Types will be obtained by
-	 * type from {@link org.springframework.beans.factory.BeanFactory} upon initialization of the generated fragment
-	 * during application startup.
-	 * <p>
-	 * Can be overridden if required. Needs to match arguments of generated repository implementation.
-	 *
-	 * @return key/value pairs of required argument required to instantiate the generated fragment.
+	 * @return the associated {@link AotRepositoryFragmentMetadata}.
 	 */
-	// TODO: should we switch from ResolvableType to some custom value object to cover qualifiers?
-	java.util.Map<String, ResolvableType> requiredArgs() {
-		return Collections.unmodifiableMap(creator.getAutowireFields());
-	}
-
-	/**
-	 * Get the required constructor arguments for the to be generated repository implementation.
-	 * <p>
-	 * Can be overridden if required. Needs to match arguments of generated repository implementation.
-	 *
-	 * @return key/value pairs of required argument required to instantiate the generated fragment.
-	 */
-	java.util.Map<String, AotRepositoryFragmentMetadata.ConstructorArgument> getConstructorArguments() {
-		return Collections.unmodifiableMap(creator.getConstructorArguments());
+	AotRepositoryFragmentMetadata getAotFragmentMetadata() {
+		return creator.getRepositoryMetadata();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryContext.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryContext.java
@@ -36,8 +36,12 @@ public interface AotRepositoryContext extends AotContext {
 
 	/**
 	 * @return the {@link String bean name} of the repository / factory bean.
+	 * @deprecated since 4.0, this doesn't really belong in here.
 	 */
-	String getBeanName();
+	@Deprecated(since = "4.0", forRemoval = true)
+	default String getBeanName() {
+		throw new UnsupportedOperationException(); // prepare for removal
+	}
 
 	/**
 	 * @return the Spring Data module name, see {@link RepositoryConfigurationExtension#getModuleName()}.
@@ -52,7 +56,10 @@ public interface AotRepositoryContext extends AotContext {
 
 	/**
 	 * @return a {@link Set} of {@link String base packages} to search for repositories.
+	 * @deprecated since 4.0, use {@link #getConfigurationSource()} and call
+	 *             {@link RepositoryConfigurationSource#getBasePackages()}
 	 */
+	@Deprecated(since = "4.0", forRemoval = true)
 	default Set<String> getBasePackages() {
 		return getConfigurationSource().getBasePackages().toSet();
 	}
@@ -78,7 +85,5 @@ public interface AotRepositoryContext extends AotContext {
 	 * @return all {@link Class types} reachable from the repository.
 	 */
 	Set<Class<?>> getResolvedTypes();
-
-	Set<Class<?>> getUserDomainTypes();
 
 }

--- a/src/main/java/org/springframework/data/repository/config/AotRepositoryContextSupport.java
+++ b/src/main/java/org/springframework/data/repository/config/AotRepositoryContextSupport.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.repository.config;
+
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.Environment;
+import org.springframework.data.aot.AotContext;
+import org.springframework.data.aot.AotTypeConfiguration;
+import org.springframework.data.util.TypeScanner;
+
+/**
+ * Support class for {@link AotRepositoryContext} implementations delegating to an underlying {@link AotContext}.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+public abstract class AotRepositoryContextSupport implements AotRepositoryContext {
+
+	private final AotContext aotContext;
+
+	/**
+	 * Create a new {@code AotRepositoryContextSupport} given the {@link AotContext}.
+	 *
+	 * @param aotContext
+	 */
+	public AotRepositoryContextSupport(AotContext aotContext) {
+		this.aotContext = aotContext;
+	}
+
+	@Override
+	public boolean isGeneratedRepositoriesEnabled(@Nullable String moduleName) {
+		return aotContext.isGeneratedRepositoriesEnabled(moduleName);
+	}
+
+	@Override
+	public boolean isGeneratedRepositoriesMetadataEnabled() {
+		return aotContext.isGeneratedRepositoriesMetadataEnabled();
+	}
+
+	@Override
+	public ConfigurableListableBeanFactory getBeanFactory() {
+		return aotContext.getBeanFactory();
+	}
+
+	@Override
+	public Environment getEnvironment() {
+		return aotContext.getEnvironment();
+	}
+
+	@Override
+	public @Nullable ClassLoader getClassLoader() {
+		return aotContext.getClassLoader();
+	}
+
+	@Override
+	public ClassLoader getRequiredClassLoader() {
+		return aotContext.getRequiredClassLoader();
+	}
+
+	@Override
+	public TypeScanner getTypeScanner() {
+		return aotContext.getTypeScanner();
+	}
+
+	@Override
+	public void typeConfiguration(ResolvableType resolvableType, Consumer<AotTypeConfiguration> configurationConsumer) {
+		aotContext.typeConfiguration(resolvableType, configurationConsumer);
+	}
+
+	@Override
+	public void typeConfiguration(Class<?> type, Consumer<AotTypeConfiguration> configurationConsumer) {
+		aotContext.typeConfiguration(type, configurationConsumer);
+	}
+
+	@Override
+	public void contributeTypeConfigurations(GenerationContext generationContext) {
+		aotContext.contributeTypeConfigurations(generationContext);
+	}
+
+}

--- a/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
@@ -26,12 +26,9 @@ import java.util.stream.Stream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
-
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.MemberCategory;
-import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
-import org.springframework.aot.hint.annotation.ReflectiveRuntimeHintsRegistrar;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -216,7 +213,8 @@ public class RepositoryRegistrationAotProcessor
 	 * @param generationContext the generation context.
 	 * @since 4.0
 	 */
-	private void configureTypeContributions(AotRepositoryContext repositoryContext, GenerationContext generationContext) {
+	protected void configureTypeContributions(AotRepositoryContext repositoryContext,
+			GenerationContext generationContext) {
 
 		RepositoryInformation information = repositoryContext.getRepositoryInformation();
 
@@ -246,22 +244,17 @@ public class RepositoryRegistrationAotProcessor
 	 * @param generationContext the generation context.
 	 * @since 4.0
 	 */
-	protected void configureDomainTypeContributions(AotRepositoryContext repositoryContext,
+	private void configureDomainTypeContributions(AotRepositoryContext repositoryContext,
 			GenerationContext generationContext) {
 
 		RepositoryInformation information = repositoryContext.getRepositoryInformation();
-		RuntimeHints hints = generationContext.getRuntimeHints();
 
-		// Domain types, related types, projections
-		ReflectiveRuntimeHintsRegistrar registrar = new ReflectiveRuntimeHintsRegistrar();
 		Stream.concat(Stream.of(information.getDomainType()), information.getAlternativeDomainTypes().stream())
 				.forEach(it -> {
-
-					registrar.registerRuntimeHints(hints, it);
 					configureTypeContribution(it, repositoryContext);
 				});
 
-		// TODO: Looks like a duplicate
+		// Domain types my be part of this, but it also contains reachable ones.
 		repositoryContext.getResolvedTypes().stream()
 				.filter(it -> TypeContributor.isPartOf(it, Set.of(information.getDomainType().getPackageName())))
 				.forEach(it -> configureTypeContribution(it, repositoryContext));

--- a/src/test/java/org/springframework/data/aot/AotContextUnitTests.java
+++ b/src/test/java/org/springframework/data/aot/AotContextUnitTests.java
@@ -17,8 +17,6 @@ package org.springframework.data.aot;
 
 import static org.mockito.Mockito.*;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.function.Consumer;
 
 import org.assertj.core.api.Assertions;
@@ -28,6 +26,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoSettings;
+
+import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -102,7 +102,7 @@ class AotContextUnitTests {
 			context.typeConfiguration(aClass, AotTypeConfiguration::contributeAccessors);
 		}
 
-		context.typeConfigurations().forEach(it -> it.contribute(mockEnvironment, new TestGenerationContext()));
+		context.contributeTypeConfigurations(new TestGenerationContext());
 	}
 
 	@ParameterizedTest // GH-3322
@@ -163,8 +163,8 @@ class AotContextUnitTests {
 		}
 
 		@Override
-		public Collection<AotTypeConfiguration> typeConfigurations() {
-			return List.of();
+		public void contributeTypeConfigurations(GenerationContext generationContext) {
+
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/javapoet/JavaPoetUnitTests.java
+++ b/src/test/java/org/springframework/data/javapoet/JavaPoetUnitTests.java
@@ -188,6 +188,50 @@ class JavaPoetUnitTests {
 
 		block = LordOfTheStrings.returning(Integer.class).number("someNumericVariable").otherwise(":-[").build();
 		assertThat(block).hasToString("return someNumericVariable != null ? someNumericVariable.intValue() : null");
+
+		block = LordOfTheStrings.returning(Short.class).number("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable != null ? someNumericVariable.shortValue() : null");
+
+		block = LordOfTheStrings.returning(short.class).number("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable != null ? someNumericVariable.shortValue() : 0");
+
+		block = LordOfTheStrings.returning(Byte.class).number("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable != null ? someNumericVariable.byteValue() : null");
+
+		block = LordOfTheStrings.returning(Float.class).number("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable != null ? someNumericVariable.floatValue() : null");
+
+		block = LordOfTheStrings.returning(float.class).number("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable != null ? someNumericVariable.floatValue() : 0f");
+	}
+
+	@Test // GH-3357
+	void shouldRenderConditionalSafeNumericReturn() {
+
+		CodeBlock block = LordOfTheStrings.returning(boolean.class).nonNullableNumber("someNumericVariable")
+				.otherwise(":-[").build();
+		assertThat(block).hasToString("return :-[");
+
+		block = LordOfTheStrings.returning(long.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.longValue()");
+
+		block = LordOfTheStrings.returning(Long.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.longValue()");
+
+		block = LordOfTheStrings.returning(Integer.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.intValue()");
+
+		block = LordOfTheStrings.returning(short.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.shortValue()");
+
+		block = LordOfTheStrings.returning(byte.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.byteValue()");
+
+		block = LordOfTheStrings.returning(Double.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.doubleValue()");
+
+		block = LordOfTheStrings.returning(Float.class).nonNullableNumber("someNumericVariable").otherwise(":-[").build();
+		assertThat(block).hasToString("return someNumericVariable.floatValue()");
 	}
 
 	@Test // GH-3357

--- a/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryBeanDefinitionPropertiesDecoratorUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryBeanDefinitionPropertiesDecoratorUnitTests.java
@@ -56,10 +56,9 @@ class AotRepositoryBeanDefinitionPropertiesDecoratorUnitTests {
 	void beforeEach() {
 
 		when(contributor.getContributedTypeName()).thenReturn(GeneratedTypeReference.of(ClassName.bestGuess(TYPE_NAME)));
+		when(contributor.getAotFragmentMetadata()).thenReturn(metadata);
 		inheritedSource = CodeBlock.builder();
 		decorator = new AotRepositoryBeanDefinitionPropertiesDecorator(() -> inheritedSource.build(), contributor);
-
-		when(contributor.getConstructorArguments()).thenReturn(metadata.getConstructorArguments());
 	}
 
 	@Test // GH-3344

--- a/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/AotRepositoryConfigurationUnitTests.java
@@ -69,7 +69,8 @@ class AotRepositoryConfigurationUnitTests {
 		assertThat(contributedTypeName).isNotNull();
 
 		// required constructor arguments need to be present at this point
-		Map<String, ResolvableType> requiredArgs = new LinkedHashMap<>(contributor.requiredArgs());
+		Map<String, ResolvableType> requiredArgs = new LinkedHashMap<>(
+				contributor.getAotFragmentMetadata().getAutowireFields());
 		assertThat(requiredArgs).hasSize(1);
 
 		// decorator kicks in and enhanced the BeanDefinition. No files written so far.
@@ -86,7 +87,7 @@ class AotRepositoryConfigurationUnitTests {
 
 		// make sure write operation for generated content did not change constructor nor type name
 		assertThat(contributor.getContributedTypeName()).isEqualTo(contributedTypeName);
-		assertThat(contributor.requiredArgs()).containsExactlyEntriesOf(requiredArgs);
+		assertThat(contributor.getAotFragmentMetadata().getAutowireFields()).containsExactlyEntriesOf(requiredArgs);
 
 		// file is actually present now
 		assertThat(generationContext.getGeneratedFiles().getGeneratedFiles(Kind.SOURCE))


### PR DESCRIPTION
Decouple `RepositoryRegistrationAotContribution` and `RepositoryRegistrationAotProcessor`, introduce support class for `AotRepositoryContext` implementations to better protect `AotRepositoryContext` implementations from changes to `AotContext`.

Remove contribute method from `AotTypeConfiguration` and move contribution code to `AotContext`.

Deprecate introspection methods for removal with only a single use in Commons and no usage in other modules.

Add more fine-grained customization hooks to `RepositoryRegistrationAotProcessor` and remove superfluous context objects that aren't necessary in their context.

Closes #3267