### PR TITLE
Add test cases for Kotlin private constructor instantiation edge cases

### DIFF
--- a/src/test/kotlin/org/springframework/data/mapping/model/InlineClasses.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/InlineClasses.kt
@@ -20,6 +20,7 @@ import java.time.LocalDate
 
 /**
  * @author Mark Paluch
+ * @author Edward Poot
  */
 @JvmInline
 value class MyValueClass(val id: String)
@@ -45,6 +46,10 @@ data class WithMyValueClass(val id: MyValueClass) {
 	// public static WithMyValueClass copy-R7yrDNU$default(WithMyValueClass var0, String var1, int var2, Object var3) {
 	// ---------
 }
+
+data class WithMyValueClassPrivateConstructor private constructor(val id: MyValueClass)
+
+data class WithMyValueClassPrivateConstructorAndDefaultValue private constructor(val id: MyValueClass = MyValueClass("id"))
 
 @JvmInline
 value class MyNullableValueClass(val id: String? = "id")

--- a/src/test/kotlin/org/springframework/data/mapping/model/KotlinClassGeneratingEntityInstantiatorUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/model/KotlinClassGeneratingEntityInstantiatorUnitTests.kt
@@ -30,6 +30,7 @@ import kotlin.reflect.KClass
  *
  * @author Mark Paluch
  * @author Sebastien Deleuze
+ * @author Edward Poot
  */
 @Suppress("UNCHECKED_CAST")
 class KotlinClassGeneratingEntityInstantiatorUnitTests {
@@ -185,6 +186,24 @@ class KotlinClassGeneratingEntityInstantiatorUnitTests {
 
 		every { provider.getParameterValue<String>(any()) } returns "hello"
 		val instance = construct(WithMyValueClass::class)
+
+		assertThat(instance.id.id).isEqualTo("hello")
+	}
+
+	@Test // GH-3389
+	fun `should use private default constructor for types using value class`() {
+
+		every { provider.getParameterValue<String>(any()) } returns "hello"
+		val instance = construct(WithMyValueClassPrivateConstructor::class)
+
+		assertThat(instance.id.id).isEqualTo("hello")
+	}
+
+	@Test // GH-3389
+	fun `should use private default constructor for types using value class with default value`() {
+
+		every { provider.getParameterValue<String>(any()) } returns "hello"
+		val instance = construct(WithMyValueClassPrivateConstructorAndDefaultValue::class)
 
 		assertThat(instance.id.id).isEqualTo("hello")
 	}


### PR DESCRIPTION
This commit adds two test cases to demonstrate a bug in Kotlin constructor resolution when dealing with private constructors. The first test case shows the failure scenario where a private constructor without default parameter values causes a runtime exception. The second test case demonstrates that adding default parameter values to the private constructor doesn't display the same issue.

The bug seems to occur because the code incorrectly assumes that private constructors always generate synthetic parameters for both the default mask and the DefaultConstructorMarker. However, when a private primary constructor has no default parameter values, the Kotlin compiler only generates the DefaultConstructorMarker variant, not the mask parameter.

References #3389