### PR TITLE
Remove duplicate documentation heading identifiers

### DIFF
--- a/src/main/antora/modules/ROOT/pages/dependencies.adoc
+++ b/src/main/antora/modules/ROOT/pages/dependencies.adoc
@@ -19,7 +19,6 @@ Due to the different inception dates of individual Spring Data modules, most of 
 </dependencyManagement>
 ----
 
-[[dependencies.train-names]]
 [[dependencies.train-version]]
 The current release train version is `{releasetrainVersion}`. The train version uses https://calver.org/[calver] with the pattern `YYYY.MINOR.MICRO`.
 The version name follows `+${calver}+` for GA releases and service releases and the following pattern for all other versions: `+${calver}-${modifier}+`, where `modifier` can be one of the following:

--- a/src/main/antora/modules/ROOT/pages/repositories/create-instances.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/create-instances.adoc
@@ -61,7 +61,7 @@ class ApplicationConfiguration {
 ======
 
 ifeval::[{include-xml-namespaces} != false]
-[[repositories.create-instances.spring]]
+
 [[repositories.create-instances.xml]]
 == XML Configuration
 

--- a/src/main/antora/modules/ROOT/pages/upgrade.adoc
+++ b/src/main/antora/modules/ROOT/pages/upgrade.adoc
@@ -1,4 +1,3 @@
-[[new-features]]
 [[upgrading]]
 = Upgrading Spring Data
 :page-section-summary-toc: 1


### PR DESCRIPTION
```asciidoc
[[id1]]
[[id2]]
== Title
```

`id1` will not work with the title, and only `id2` will link correctly.

Example:
`#repositories.create-instances.spring` doesn't work
https://docs.spring.io/spring-data/rest/reference/data-commons/4.0-SNAPSHOT/repositories/create-instances.html#repositories.create-instances.spring

`#repositories.create-instances.xml` works
https://docs.spring.io/spring-data/rest/reference/data-commons/4.0-SNAPSHOT/repositories/create-instances.html#repositories.create-instances.xml