### PR TITLE
Stop supporting params not annotated with `@ProjectedPayload`

### DIFF
--- a/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
@@ -115,7 +115,7 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 		// Parameter annotated with @ModelAttribute
 		if (parameter.hasParameterAnnotation(ModelAttribute.class)) {
 			this.deprecationLogger.logDeprecationForParameter(parameter);
-			return true;
+			return false;
 		}
 
 		// Exclude any other parameters annotated with Spring annotation
@@ -131,7 +131,7 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 		String packageName = ClassUtils.getPackageName(type);
 		if (IGNORED_PACKAGES.stream().noneMatch(packageName::startsWith)) {
 			this.deprecationLogger.logDeprecationForParameter(parameter);
-			return true;
+			return false;
 		}
 
 		return false;
@@ -157,7 +157,7 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 	 */
 	static class ProjectedPayloadDeprecationLogger {
 
-		private static final String MESSAGE = "Parameter %sat index %s in [%s] is not annotated with @ProjectedPayload. Support for parameters not annotated with @ProjectedPayload (at the parameter or type level) will be dropped in a future version.";
+		private static final String MESSAGE = "Parameter %sat index %s in [%s] is not annotated with @ProjectedPayload. Make sure to annotate it with @ProjectedPayload (at the parameter or type level) to use it for projections.";
 
 		private final Set<MethodParameter> loggedParameters = Collections.synchronizedSet(new HashSet<>());
 

--- a/src/test/java/example/ProjectedPayloadMarkedSampleInterface.java
+++ b/src/test/java/example/ProjectedPayloadMarkedSampleInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author Chris Bono
+ * @see org.springframework.data.web.ProxyingHandlerMethodArgumentResolverUnitTests
+ */
+package example;
+
+import org.springframework.data.web.ProjectedPayload;
+
+@ProjectedPayload
+public interface ProjectedPayloadMarkedSampleInterface {}


### PR DESCRIPTION
This commit drops support for projections if a parameter (or the parameter type) is not explicitly annotated with `@ ProjectedPayload`. A warning is still logged in these cases to help user understand why the parameter is not being projected.

Closes #3301 