### PR TITLE
Refine public API Javadoc descriptions

### DIFF
--- a/src/main/java/org/springframework/data/domain/Range.java
+++ b/src/main/java/org/springframework/data/domain/Range.java
@@ -29,6 +29,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author wonderfulrosemari
  * @since 1.10
  */
 public final class Range<T> {
@@ -172,7 +173,7 @@ public final class Range<T> {
 	/**
 	 * Creates a new Range with the given value as sole member.
 	 *
-	 * @param <T> the type of the range.>
+	 * @param <T> the type of the range.
 	 * @param value must not be {@literal null}.
 	 * @return a range containing the given value.
 	 * @see Range#closed(Object, Object)

--- a/src/main/java/org/springframework/data/repository/CrudRepository.java
+++ b/src/main/java/org/springframework/data/repository/CrudRepository.java
@@ -28,6 +28,7 @@ import org.springframework.dao.OptimisticLockingFailureException;
  * @author Oliver Gierke
  * @author Eberhard Wolff
  * @author Jens Schauder
+ * @author wonderfulrosemari
  */
 @NoRepositoryBean
 public interface CrudRepository<T, ID> extends Repository<T, ID> {
@@ -36,7 +37,7 @@ public interface CrudRepository<T, ID> extends Repository<T, ID> {
 	 * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
 	 * entity instance completely.
 	 *
-	 * @param entity must not be {@literal null}.
+	 * @param entity the entity to save; must not be {@literal null}.
 	 * @return the saved entity; will never be {@literal null}.
 	 * @throws IllegalArgumentException in case the given {@literal entity} is {@literal null}.
 	 * @throws OptimisticLockingFailureException when the entity uses optimistic locking and has a version attribute with

--- a/src/main/java/org/springframework/data/repository/RepositoryDefinition.java
+++ b/src/main/java/org/springframework/data/repository/RepositoryDefinition.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Indexed;
  *
  * @see Repository
  * @author Oliver Gierke
+ * @author wonderfulrosemari
  */
 @Indexed
 @Documented
@@ -42,7 +43,7 @@ public @interface RepositoryDefinition {
 	 * The domain class the repository manages. Equivalent to the T type parameter in {@link Repository}.
 	 *
 	 * @see Repository
-	 * @return
+	 * @return the domain class managed by the repository.
 	 */
 	Class<?> domainClass();
 
@@ -50,7 +51,7 @@ public @interface RepositoryDefinition {
 	 * The id class of the entity the repository manages. Equivalent to the ID type parameter in {@link Repository}.
 	 *
 	 * @see Repository
-	 * @return
+	 * @return the id class of the entity managed by the repository.
 	 */
 	Class<?> idClass();
 }


### PR DESCRIPTION
Closes #2602

Refine public API Javadoc in a few public types by:
- completing missing `@return` descriptions in `RepositoryDefinition`
- clarifying the `entity` parameter description in `CrudRepository#save`
- fixing a typo in `Range#just` generic type Javadoc (`@param <T>`)
