### PR TITLE
Cache Kotlin parameter optionality in KotlinInstantiationDelegate

### DIFF
--- a/src/main/java/org/springframework/data/mapping/model/KotlinInstantiationDelegate.java
+++ b/src/main/java/org/springframework/data/mapping/model/KotlinInstantiationDelegate.java
@@ -44,6 +44,7 @@ import org.springframework.data.util.ReflectionUtils;
  *
  * @author Mark Paluch
  * @author Yohan Lee
+ * @author Blaz Snuderl
  * @since 3.1
  */
 class KotlinInstantiationDelegate {
@@ -54,6 +55,10 @@ class KotlinInstantiationDelegate {
 	private final Map<KParameter, Integer> indexByKParameter;
 	private final List<Function<@Nullable Object, @Nullable Object>> wrappers;
 	private final boolean hasDefaultConstructorMarker;
+	private final int[] optionalParameterIndices;
+	private final int[] optionalParameterBitPositions;
+	private final int defaultMaskSlotCount;
+	private final boolean hasOptionalParameters;
 
 	private KotlinInstantiationDelegate(PreferredConstructor<?, ?> constructor, KFunction<?> constructorFunction) {
 
@@ -64,9 +69,26 @@ class KotlinInstantiationDelegate {
 		this.kParameters = constructorFunction.getParameters();
 		this.indexByKParameter = new IdentityHashMap<>(kParameters.size());
 
+		List<Integer> optIndices = new ArrayList<>();
+		List<Integer> optBitPositions = new ArrayList<>();
+		int valueIndex = 0;
+
 		for (int i = 0; i < kParameters.size(); i++) {
 			indexByKParameter.put(kParameters.get(i), i);
+			KParameter kp = kParameters.get(i);
+			if (kp.getKind() == KParameter.Kind.VALUE) {
+				if (kp.isOptional()) {
+					optIndices.add(i);
+					optBitPositions.add(valueIndex);
+				}
+				valueIndex++;
+			}
 		}
+
+		this.optionalParameterIndices = optIndices.stream().mapToInt(Integer::intValue).toArray();
+		this.optionalParameterBitPositions = optBitPositions.stream().mapToInt(Integer::intValue).toArray();
+		this.hasOptionalParameters = optionalParameterIndices.length > 0;
+		this.defaultMaskSlotCount = hasOptionalParameters ? KotlinDefaultMask.getMaskCount(valueIndex) : 0;
 
 		this.wrappers = new ArrayList<>(kParameters.size());
 
@@ -133,29 +155,30 @@ class KotlinInstantiationDelegate {
 
 		if (hasDefaultConstructorMarker) {
 
-			KotlinDefaultMask defaultMask = KotlinDefaultMask.forConstructor(constructorFunction, it -> {
+			int[] masks = new int[defaultMaskSlotCount];
 
-				int index = indexByKParameter.get(it);
+			if (hasOptionalParameters) {
+				for (int j = 0; j < optionalParameterIndices.length; j++) {
+					int paramIndex = optionalParameterIndices[j];
+					int bitPosition = optionalParameterBitPositions[j];
 
-				Parameter<Object, P> parameter = parameters.get(index);
-				Class<Object> type = parameter.getType().getType();
+					if (params[paramIndex] == null) {
+						Parameter<Object, P> parameter = parameters.get(paramIndex);
+						Class<Object> type = parameter.getType().getType();
 
-				if (it.isOptional() && (params[index] == null)) {
-					if (type.isPrimitive()) {
+						if (type.isPrimitive()) {
 
-						// apply primitive defaulting to prevent NPE on primitive downcast
-						params[index] = ReflectionUtils.getPrimitiveDefault(type);
+							// apply primitive defaulting to prevent NPE on primitive downcast
+							params[paramIndex] = ReflectionUtils.getPrimitiveDefault(type);
+						}
+						masks[bitPosition / Integer.SIZE] |= (1 << (bitPosition % Integer.SIZE));
 					}
-					return false;
 				}
+			}
 
-				return true;
-			});
-
-			int[] defaulting = defaultMask.getDefaulting();
 			// append nullability masks to creation arguments
-			for (int i = 0; i < defaulting.length; i++) {
-				params[userParameterCount + i] = defaulting[i];
+			for (int i = 0; i < masks.length; i++) {
+				params[userParameterCount + i] = masks[i];
 			}
 		}
 	}


### PR DESCRIPTION
Closes #3479.

## Summary

`KotlinInstantiationDelegate.extractInvocationArguments()` calls `KotlinDefaultMask.forConstructor()` on every entity instantiation. That call exercises `KFunction.getParameters()` and `KParameter.isOptional()` via Kotlin reflection for every constructor parameter, even though parameter optionality is fixed per entity type.

This PR lifts that work into the `KotlinInstantiationDelegate` constructor so it runs once per entity type. `extractInvocationArguments()` then builds the default mask directly from cached `int[]` arrays with no Kotlin reflection.

Four new fields back the cache:

- `int[] optionalParameterIndices` — `params[]` positions of optional VALUE-kind parameters
- `int[] optionalParameterBitPositions` — the corresponding bit positions within the Kotlin default mask
- `int defaultMaskSlotCount` — number of `int` slots in the mask
- `boolean hasOptionalParameters` — fast-path flag

## Behavior equivalence

The refactor mirrors the existing `KotlinDefaultMask.from()` contract: a bit is set only when a parameter is VALUE-kind, optional, and currently `null`; primitive defaulting is applied in the same case; non-optional parameters are never touched. Non-optional VALUE parameters with `null` values continue to bypass bit setting exactly as before.

No guards were removed — just relocated from per-call to per-delegate.

## Motivation

Observed on a production Spring Data MongoDB service handling ~10k requests/sec: flame graphs show `KotlinDefaultMask.from` + `KotlinInstantiationDelegate.extractInvocationArguments` together consuming ~0.9% of service CPU, entirely inside `KParameter.isOptional()` / `KFunction.getParameters()`. Entities have 8–35 constructor parameters with Kotlin defaults.

## Benchmark

Timing-loop smoke microbenchmark (500K iterations, warmup 50K), comparing before/after on current `main`:

| Scenario | Before (ns/op) | After (ns/op) | Speedup |
|---|---|---|---|
| 8 params, 8 optional, all defaulted | 923 | 34 | **27x** |
| 8 params, 8 optional, all provided | 645 | 36 | **18x** |
| 35 params, 32 optional, mixed (crosses 32-bit mask boundary) | 3,266 | 148 | **22x** |
| 2 params, 0 optional (baseline) | 235 | 21 | **11x** |

Source: https://gist.github.com/snuderl/122c8fa3cb0ea304aff122fc63a48442

This is a timing-loop smoke test, not a JMH benchmark — happy to rewrite in `src/jmh/java` using your Microbenchmark Runner convention if you'd prefer that before merge.

## Testing

Existing coverage is exercised by:

- `KotlinClassGeneratingEntityInstantiatorUnitTests` (15 tests) — covers the hot path end-to-end, including value classes, nullable defaults, and primitive defaulting
- `ParameterizedKotlinInstantiatorUnitTests` (260 tests) — parameterised sweep over a large matrix of Kotlin data class shapes
- Broader `org.springframework.data.mapping.model.*` + neighbouring suites (438 tests total)

All pass locally on this branch:

```
$ ./mvnw test -Dtest='*Mapping*,*Kotlin*,*Instantiat*' -Dsurefire.failIfNoSpecifiedTests=false
Tests run: 438, Failures: 0, Errors: 0, Skipped: 4
BUILD SUCCESS
```

I deliberately did not add new unit tests: the existing `ParameterizedKotlinInstantiatorUnitTests` already exercises the edge cases I care about (optional + null, optional + non-null, non-optional, primitive optional, value-class optional, >32 parameters crossing the mask-slot boundary). Let me know if you'd like a targeted regression test anyway.

## Versions affected

4.0.x `main` and all previous releases that ship `KotlinClassGeneratingEntityInstantiator` (since 3.1).
