### PR TITLE
fix 'exits' to 'exists' in default methods section

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
@@ -124,7 +124,7 @@ Therefore, it is not a derived query using of `id` as the property name would su
 <5> Targets the `id` property by using the descriptive token between `find` and `by` to avoid collisions with _reserved methods_.
 ====
 
-This special behaviour not only targets lookup methods but also applies to the `exits` and `delete` ones.
+This special behaviour not only targets lookup methods but also applies to the `exists` and `delete` ones.
 Please refer to the "`xref:repositories/query-keywords-reference.adoc#appendix.query.method.reserved[Repository query keywords]`" for the list of methods.
 
 [[repositories.query-methods.query-property-expressions]]


### PR DESCRIPTION
In the default methods section, fix a reference to the `exits` [sic] default methods, to say `exists`.