### PR TITLE
Retain subclass fields over masked superclass fields in `TypeDiscoverer`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-3500-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/core/TypeDiscoverer.java
+++ b/src/main/java/org/springframework/data/core/TypeDiscoverer.java
@@ -407,8 +407,11 @@ class TypeDiscoverer<S> implements TypeInformation<S> {
 
 		Map<String, TypeInformation<?>> result = new HashMap<>();
 		Class<?> type = getType();
-		FieldCallback callback = field -> result.put(field.getName(),
-				TypeInformation.of(ResolvableType.forField(field, resolvableType)));
+		FieldCallback callback = field -> {
+			if (!result.containsKey(field.getName())) {
+				result.put(field.getName(), TypeInformation.of(ResolvableType.forField(field, resolvableType)));
+			}
+		};
 
 		// Inspect fields first
 		ReflectionUtils.doWithFields(type, callback);

--- a/src/test/java/org/springframework/data/core/TypeDiscovererUnitTests.java
+++ b/src/test/java/org/springframework/data/core/TypeDiscovererUnitTests.java
@@ -379,6 +379,14 @@ public class TypeDiscovererUnitTests {
 		assertThat(domainType.isAssignableFrom(actualType)).isTrue();
 	}
 
+	@Test // GH-3500
+	void superclassFieldsDoNotHideSubclassFields() {
+
+		TypeDiscoverer<?> discoverer = TypeDiscoverer.ofCached(ResolvableType.forClass(TheOne.class));
+
+		assertThat(discoverer.getProperty("theOne").getType()).isEqualTo(String.class);
+	}
+
 	class Person {
 
 		Addresses addresses;
@@ -486,6 +494,16 @@ public class TypeDiscovererUnitTests {
 	static abstract class SomeType<Self extends SomeType<Self>> {
 
 	}
+
+	static class SuperclassWithProperties {
+		private CharSequence theOne;
+		private String theOther;
+	}
+
+	class TheOne extends SuperclassWithProperties {
+		private String theOne;
+	}
+
 
 	@SuppressWarnings("rawtypes")
 	interface RepoWithRawGenerics extends Repository<SomeType, SomeType> {


### PR DESCRIPTION
When a class hides a superclass field by declaring a field of the same name, property discovery overwrote the property type from the superclass field instead of retaining the declaring subclass field.
This happened because `ReflectionUtils.doWithFields` traverses fields from the leaf type up through its superclasses, and the field callback unconditionally put each field into the result map.
As a result, the superclass field, visited last, overwrote the entry contributed by the subclass, exposing the wrong (and potentially incompatible) property type.

We now keep the first field encountered for a given name, which is the one declared closest to the inspected type, so a hidden superclass field no longer overrides the subclass declaration.

Closes #3500