### PR TITLE
Support legacy Kotlin property path rendering.

### DIFF
--- a/src/main/kotlin/org/springframework/data/core/KPropertyPath.kt
+++ b/src/main/kotlin/org/springframework/data/core/KPropertyPath.kt
@@ -17,6 +17,8 @@
 
 package org.springframework.data.core
 
+import org.springframework.data.mapping.KIterablePropertyPath as MappingKIterablePropertyPath
+import org.springframework.data.mapping.KPropertyPath as MappingKPropertyPath
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 
@@ -101,6 +103,7 @@ internal class KIterablePropertyReference<T, M, out P>(
  *
  * @author Tjeu Kayim
  * @author Mikhail Polivakha
+ * @author hutiefang
  * @since 4.1
  */
 internal fun asString(property: KProperty<*>): String {
@@ -109,8 +112,13 @@ internal fun asString(property: KProperty<*>): String {
 		is KPropertyPath<*, *> ->
 			"${asString(property.property)}.${property.leaf.name}"
 
+		is MappingKPropertyPath<*, *> ->
+			"${asString(property.parent)}.${property.child.name}"
+
+		is MappingKIterablePropertyPath<*, *> ->
+			"${asString(property.parent)}.${property.child.name}"
+
 		else -> property.name
 	}
 
 }
-

--- a/src/main/kotlin/org/springframework/data/mapping/KPropertyPath.kt
+++ b/src/main/kotlin/org/springframework/data/mapping/KPropertyPath.kt
@@ -24,9 +24,10 @@ import kotlin.reflect.KProperty1
  * @author Tjeu Kayim
  * @author Mark Paluch
  * @author Yoann de Martino
+ * @author hutiefang
  * @since 2.5
  */
-private class KPropertyPath<T, U>(
+internal class KPropertyPath<T, U>(
 	val parent: KProperty<U?>,
 	val child: KProperty1<U, T>
 ) : KProperty<T> by child

--- a/src/test/kotlin/org/springframework/data/mapping/KPropertyPathTests.kt
+++ b/src/test/kotlin/org/springframework/data/mapping/KPropertyPathTests.kt
@@ -17,6 +17,7 @@ package org.springframework.data.mapping
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.springframework.data.core.toDotPath as coreToDotPath
 
 /**
  * Unit tests for [KPropertyPath] and its extensions.
@@ -25,6 +26,7 @@ import org.junit.Test
  * @author Yoann de Martino
  * @author Mark Paluch
  * @author Mikhail Polivakha
+ * @author hutiefang
  */
 class KPropertyPathTests {
 
@@ -44,12 +46,36 @@ class KPropertyPathTests {
 		assertThat(property).isEqualTo("author.name")
 	}
 
+	@Test // GH-3503
+	fun `Core toDotPath renders nested mapping KProperty`() {
+
+		val property = (Book::author / Author::name).coreToDotPath()
+
+		assertThat(property).isEqualTo("author.name")
+	}
+
 	@Test // GH-3010
 	fun `Convert from Iterable nested KProperty to field name`() {
 
 		val property = (Author::books / Book::title).toDotPath()
 
 		assertThat(property).isEqualTo("books.title")
+	}
+
+	@Test // GH-3503
+	fun `Core toDotPath renders iterable mapping KProperty`() {
+
+		val property = (Author::books / Book::title).coreToDotPath()
+
+		assertThat(property).isEqualTo("books.title")
+	}
+
+	@Test // GH-3503
+	fun `Core toDotPath renders recursively nested mapping KProperty`() {
+
+		val property = (Author::books / Book::author / Author::name).coreToDotPath()
+
+		assertThat(property).isEqualTo("books.author.name")
 	}
 
 	@Test // GH-3010


### PR DESCRIPTION
The Kotlin property-path DSL moved from `org.springframework.data.mapping` to `org.springframework.data.core`, but a path built with the deprecated mapping `div` extensions was not recognized by the new core `toDotPath`. As a result, paths such as `author.name` and `books.author.name` were reduced to their final segment.

This change lets the core renderer recognize both legacy mapping path wrappers. It only expands the legacy non-iterable wrapper from `private` to `internal`; public extension signatures remain unchanged.

Tests:
- `./mvnw -Dtest=KPropertyPathTests test` (13 tests)
- Core and mapping property-path suites together (25 tests)
- `./mvnw -DskipTests package`
- `git diff --check`

- [x] I have read the Spring Data contribution guidelines.
- [x] I followed the existing Kotlin import and formatting style.
- [x] I added regression coverage for normal, iterable, and recursively nested legacy paths.
- [x] I added myself as an author to the Kotlin types and test class I touched.

Closes #3503
