### PR TITLE
Do not render meta-annotations for AOT repository method parameters

### DIFF
--- a/src/main/java/org/springframework/data/repository/aot/generate/MethodMetadata.java
+++ b/src/main/java/org/springframework/data/repository/aot/generate/MethodMetadata.java
@@ -108,7 +108,9 @@ class MethodMetadata {
 		MergedAnnotations annotations = MergedAnnotations.from(methodParameter.getParameterAnnotations());
 
 		for (MergedAnnotation<Annotation> annotation : annotations) {
-			builder.addAnnotation(AnnotationSpec.get(annotation.synthesize()));
+			if (annotation.isDirectlyPresent()) {
+				builder.addAnnotation(AnnotationSpec.get(annotation.synthesize()));
+			}
 		}
 
 		return builder.build();

--- a/src/test/java/org/springframework/data/repository/aot/generate/MethodMetadataUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/aot/generate/MethodMetadataUnitTests.java
@@ -18,6 +18,10 @@ package org.springframework.data.repository.aot.generate;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
@@ -61,6 +65,16 @@ class MethodMetadataUnitTests {
 				.containsExactly(SortDefault.class.getTypeName(), Param.class.getTypeName());
 	}
 
+	@Test // GH-3499
+	void doesNotRenderMetaAnnotations() throws NoSuchMethodException {
+
+		MethodMetadata metadata = methodMetadataFor("metaAnnotatedArgMethod");
+
+		ParameterSpec arg0 = metadata.getMethodArguments().get("arg0");
+		assertThat(arg0.annotations()).extracting(annotationSpec -> annotationSpec.type().toString())
+				.containsExactly(MetaAnnotated.class.getCanonicalName());
+	}
+
 	@Test // GH-3270
 	void getParameterNameByNonExistingIndex() throws NoSuchMethodException {
 
@@ -100,5 +114,16 @@ class MethodMetadataUnitTests {
 		String noArgsMethod();
 
 		String threeArgsMethod(Object arg0, @SortDefault Pageable arg1, @SortDefault @Param("foo") Object arg2);
+
+		String metaAnnotatedArgMethod(@MetaAnnotated Object arg0);
 	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.ANNOTATION_TYPE)
+	private @interface Meta {}
+
+	@Meta
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.PARAMETER)
+	private @interface MetaAnnotated {}
 }


### PR DESCRIPTION
Fixes #3499

### Root cause
`MethodMetadata.buildParameter(…)` (added in 852d789 to render query-method parameter annotations for AOT repositories) iterates `MergedAnnotations.from(methodParameter.getParameterAnnotations())`. `MergedAnnotations` also exposes *meta*-annotations, so for a parameter annotated with e.g. `jakarta.validation.constraints.@NotNull`, its meta-annotation `@jakarta.validation.Constraint` was rendered standalone into the generated repository source. Because `@Constraint` has a mandatory `validatedBy` element, `process-aot` / native builds fail to compile the generated code:

```
annotation @jakarta.validation.Constraint is missing a default value for the element 'validatedBy'
```

This is a regression: repositories with `jakarta.validation.constraints.*` parameters that built with 4.0.3 broke on 4.0.6.

### Change
Only render **directly-present** annotations (`MergedAnnotation#isDirectlyPresent()`). Meta-annotations remain discoverable through the concrete annotation itself, so the introspection intent of #3458 is preserved while the invalid standalone meta-annotation is no longer emitted.

### Tests
Added `MethodMetadataUnitTests#doesNotRenderMetaAnnotations`, which declares a parameter annotated with a meta-annotated annotation (mirroring how `@NotNull` is meta-annotated with `@Constraint`) and asserts only the directly-present annotation is rendered. The test fails before the change and passes after.

### Verification done
- Reproduced the meta-annotation expansion in `buildParameter` on current `main`.
- New regression test fails on unpatched `main`, passes with the fix.
- Re-ran `MethodMetadataUnitTests`, `AotRepositoryMethodBuilderUnitTests`, `MethodContributorUnitTests`, `RepositoryContributorUnitTests` — all green.