### PR TITLE
Resolve repository method return types against the repository interface

### DIFF
--- a/src/main/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptor.java
+++ b/src/main/java/org/springframework/data/repository/core/support/QueryExecutorMethodInterceptor.java
@@ -51,6 +51,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * @author Christoph Strobl
  * @author John Blum
  * @author Johannes Englmeier
+ * @author Donghwan Kim
  */
 class QueryExecutorMethodInterceptor implements MethodInterceptor {
 
@@ -137,7 +138,7 @@ class QueryExecutorMethodInterceptor implements MethodInterceptor {
 	public @Nullable Object invoke(MethodInvocation invocation) throws Throwable {
 
 		Method method = invocation.getMethod();
-		MethodParameter returnType = returnTypeMap.computeIfAbsent(method, it -> new MethodParameter(it, -1));
+		MethodParameter returnType = returnTypeMap.computeIfAbsent(method, this::createReturnTypeParameter);
 
 		QueryExecutionConverters.ExecutionAdapter executionAdapter = QueryExecutionConverters //
 				.getExecutionAdapter(returnType.getParameterType());
@@ -148,6 +149,16 @@ class QueryExecutorMethodInterceptor implements MethodInterceptor {
 
 		return executionAdapter //
 				.apply(() -> resultHandler.postProcessInvocationResult(doInvoke(invocation), returnType));
+	}
+
+	/**
+	 * Creates the {@link MethodParameter} describing the return type of the given {@link Method}. The repository
+	 * interface is registered as containing class so that a return type declared as type variable on a base interface
+	 * (e.g. {@code T findById(ID id)}) resolves against the concrete repository interface instead of the type variable's
+	 * bound.
+	 */
+	private MethodParameter createReturnTypeParameter(Method method) {
+		return new MethodParameter(method, -1).withContainingClass(repositoryInformation.getRepositoryInterface());
 	}
 
 	@SuppressWarnings("NullAway")

--- a/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/core/support/RepositoryFactorySupportUnitTests.java
@@ -87,6 +87,7 @@ import org.springframework.util.ClassUtils;
  * @author Mark Paluch
  * @author Ariel Carrera
  * @author Johannes Englmeier
+ * @author Donghwan Kim
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -458,6 +459,17 @@ class RepositoryFactorySupportUnitTests {
 		verify(backingRepo).deleteAll();
 	}
 
+	@Test // GH-3507
+	void unwrapsOptionalForTypeVariableReturnTypeDeclaredOnBaseInterface() {
+
+		var user = new User();
+		when(backingRepo.findById(any())).thenReturn(Optional.of(user));
+
+		var repository = factory.getRepository(TypeVariableReturningRepository.class);
+
+		assertThat(repository.findById(1L)).isSameAs(user);
+	}
+
 	@Test // DATACMNS-1154
 	void considersRequiredKotlinParameter() {
 
@@ -632,6 +644,15 @@ class RepositoryFactorySupportUnitTests {
 	}
 
 	interface CustomRepository extends ReadOnlyRepository<Object, Long> {
+
+	}
+
+	interface TypeVariableReturningBaseRepository<T, ID> extends Repository<T, ID> {
+
+		T findById(ID id);
+	}
+
+	interface TypeVariableReturningRepository extends TypeVariableReturningBaseRepository<User, Long> {
 
 	}
 


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched.

A generic `@NoRepositoryBean` base declaring `T findById(ID id)` hands back an `Optional<T>` at runtime instead of `T`.

`QueryExecutorMethodInterceptor.invoke(…)` builds the return type as `new MethodParameter(method, -1)` with no containing class, so `T` resolves against `Repository<T, ID>` and ends up as `Object`. `QueryExecutionResultHandler.processingRequired(…)` then asks `!targetType.isInstance(source)`, which is `false` for a target type of `Object`, and the `Optional` goes back to the caller untouched.

This registers the repository interface as containing class of that `MethodParameter`, the same thing `MethodLookups` already does for parameter types.

The test added for #3125 didn't catch this because it calls `.withContainingClass(…)` on the `MethodParameter` itself, which the production call site never did, so it was green against a code path that doesn't exist. I put the new test on the proxy instead — it fails on current main with `ClassCastException: class java.util.Optional cannot be cast to class …sample.User` and passes with the change. Full suite green (3856 tests).

Written with AI assistance (Claude Code); the commit carries the co-author trailer.