### PR TITLE
Convert elements of collection- and array-valued query method parameters

### DIFF
--- a/src/main/java/org/springframework/data/repository/support/ReflectionRepositoryInvoker.java
+++ b/src/main/java/org/springframework/data/repository/support/ReflectionRepositoryInvoker.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Alessandro Nistico
  * @author Johannes Englmeier
+ * @author Seonwoo Jung
  * @since 1.10
  */
 class ReflectionRepositoryInvoker implements RepositoryInvoker {
@@ -188,7 +189,13 @@ class ReflectionRepositoryInvoker implements RepositoryInvoker {
 
 				Object value = unwrapSingleElement(rawParameters.get(parameterName));
 
-				result[i] = targetType.isInstance(value) ? value : convert(value, param);
+				// Collection- and array-valued parameters must be converted even if the value already is an instance of
+				// the target type (e.g. a List), as the raw elements (typically String) still need to be converted to the
+				// declared element type (see GH-3502).
+				boolean elementConversionRequired = value != null
+						&& (targetType.isArray() || Iterable.class.isAssignableFrom(targetType));
+
+				result[i] = (targetType.isInstance(value) && !elementConversionRequired) ? value : convert(value, param);
 			}
 		}
 

--- a/src/test/java/org/springframework/data/repository/support/ReflectionRepositoryInvokerUnitTests.java
+++ b/src/test/java/org/springframework/data/repository/support/ReflectionRepositoryInvokerUnitTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.AdditionalAnswers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.ConversionService;
@@ -52,6 +53,7 @@ import org.springframework.util.MultiValueMap;
  * Integration tests for {@link ReflectionRepositoryInvoker}.
  *
  * @author Oliver Gierke
+ * @author Seonwoo Jung
  */
 @ExtendWith(MockitoExtension.class)
 class ReflectionRepositoryInvokerUnitTests {
@@ -221,6 +223,24 @@ class ReflectionRepositoryInvokerUnitTests {
 		}
 	}
 
+	@Test // GH-3502
+	void convertsElementsOfCollectionValuedQueryParameter() throws Exception {
+
+		MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+		parameters.put("colors", Arrays.asList("RED", "GREEN"));
+
+		var method = ColorRepository.class.getMethod("findByColorIn", Collection.class);
+		var repository = mock(ColorRepository.class);
+
+		getInvokerFor(repository, expectInvocationOf(method)).invokeQueryMethod(method, parameters, Pageable.unpaged(),
+				Sort.unsorted());
+
+		var captor = ArgumentCaptor.forClass(Collection.class);
+		verify(repository).findByColorIn(captor.capture());
+
+		assertThat(captor.getValue()).containsExactly(Color.RED, Color.GREEN);
+	}
+
 	@Test // DATACMNS-700
 	void failedParameterConversionCapturesContext() throws Exception {
 
@@ -371,4 +391,13 @@ class ReflectionRepositoryInvokerUnitTests {
 	}
 
 	interface DeleteByIdOverrideSubRepository extends DeleteByIdOverrideRepository<Domain, Long> {}
+
+	// GH-3502
+	enum Color {
+		RED, GREEN;
+	}
+
+	interface ColorRepository extends Repository<Domain, Long> {
+		List<Domain> findByColorIn(@Param("colors") Collection<Color> colors);
+	}
 }


### PR DESCRIPTION
Fixes #3502

**Root cause**
`ReflectionRepositoryInvoker#prepareParameters` skipped conversion whenever the resolved value already was an instance of the declared parameter type. For a collection- or array-valued parameter this is wrong: a repeated query parameter (e.g. `?colors=RED&colors=GREEN`) resolves to a `List<String>`, which *is* an instance of the target `List`/`Collection`, so `convert(...)` was never called and the raw `String` elements were never converted to the declared element type (e.g. an enum). The unconverted `List<String>` then reached the `in`-style query and the persistence provider failed. (As diagnosed by @antonioT90 in the issue, with a reproducer.)

**Change**
For array- and `Iterable`-typed parameters, conversion is now performed even when the value already matches the target type, so the elements are converted to the declared element type. Scalar parameters keep the previous fast-path (no redundant conversion).

**Tests**
Added `ReflectionRepositoryInvokerUnitTests#convertsElementsOfCollectionValuedQueryParameter`, which binds a `List<String>` to a `Collection<Color>` query parameter and asserts the repository receives converted enum values. It fails before the change (repository receives the raw `String`s) and passes after.

Verification done: (1) no in-flight PR — searched open PRs for `3502` and `ReflectionRepositoryInvoker` (only unrelated #3439); (2) no self-claim comments; assignee `odrotbohm` is routine triage tracking (89 open issues assigned); (3) code-focused, touches only `.java`; (4) confirmed the pattern still present on current `main`; (6) issue is past triage (`type: bug`), so no triage gate. Ran `./mvnw -o test -Dtest=ReflectionRepositoryInvokerUnitTests` — 20/20 pass with the fix; the new test fails without it.


---
_Recreated from #3506, which was inadvertently closed by a force-push on my fork branch. Same change; commit is now signed off (DCO)._
