### PR TITLE
Leniently resolve entities during property path traversal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-3515-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/mapping/context/MappingContext.java
+++ b/src/main/java/org/springframework/data/mapping/context/MappingContext.java
@@ -134,14 +134,13 @@ public interface MappingContext<E extends PersistentEntity<?, P>, P extends Pers
 	E getPersistentEntity(P persistentProperty);
 
 	/**
-	 * Returns the {@link PersistentEntity} mapped by the given {@link PersistentProperty}.
+	 * Returns the {@link PersistentEntity} mapped by the given {@link PersistentProperty}. Will throw
+	 * {@link MappingException} for types that are considered simple ones.
 	 *
 	 * @param persistentProperty must not be {@literal null}.
-	 * @return the {@link PersistentEntity} mapped by the given {@link PersistentProperty} or {@literal null} if no
-	 *         {@link PersistentEntity} exists for it or the {@link PersistentProperty} does not refer to an entity (the
-	 *         type of the property is considered simple see
-	 *         {@link org.springframework.data.mapping.model.SimpleTypeHolder#isSimpleType(Class)}).
+	 * @return the {@link PersistentEntity} mapped by the given {@link PersistentProperty}.
 	 * @throws MappingException when no {@link PersistentEntity} can be found for given {@link PersistentProperty}.
+	 * @see #getPersistentEntity(PersistentProperty)
 	 */
 	default E getRequiredPersistentEntity(P persistentProperty) throws MappingException {
 

--- a/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
+++ b/src/main/java/org/springframework/data/mapping/context/PersistentPropertyPathFactory.java
@@ -15,8 +15,16 @@
  */
 package org.springframework.data.mapping.context;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -48,8 +56,6 @@ import org.springframework.util.StringUtils;
  * @soundtrack Cypress Hill - Boom Biddy Bye Bye (Fugees Remix, Unreleased & Revamped)
  */
 class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends PersistentProperty<P>> {
-
-	private static final Predicate<PersistentProperty<? extends PersistentProperty<?>>> IS_ENTITY = PersistentProperty::isEntity;
 
 	private final ConcurrentLruCache<TypeAndPath, PathResolution> propertyPaths = new ConcurrentLruCache<>(512, it -> createPersistentPropertyPath(it.path(), it.type()));
 	private final MappingContext<E, P> context;
@@ -228,7 +234,18 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 			return Collections.emptyList();
 		}
 
-		return from(context.getRequiredPersistentEntity(actualType), filter, traversalGuard, basePath);
+		E entity;
+		if (type.isCollectionLike() || type.isMap()) {
+			entity = context.getPersistentEntity(actualType);
+		} else {
+			entity = context.getRequiredPersistentEntity(actualType);
+		}
+
+		if (entity == null) {
+			return Collections.emptyList();
+		}
+
+		return from(entity, filter, traversalGuard, basePath);
 	}
 
 	private Collection<PersistentPropertyPath<P>> from(E entity, Predicate<? super P> filter, Predicate<P> traversalGuard,
@@ -251,9 +268,11 @@ class PersistentPropertyPathFactory<E extends PersistentEntity<?, P>, P extends 
 				properties.add(currentPath);
 			}
 
-			if (traversalGuard.and(IS_ENTITY).test(persistentProperty)) {
-				var persistentEntity = context.getRequiredPersistentEntity(persistentProperty);
-				properties.addAll(from(persistentEntity, filter, traversalGuard, currentPath));
+			if (traversalGuard.test(persistentProperty)) {
+				E persistentEntity = context.getPersistentEntity(persistentProperty);
+				if (persistentEntity != null) {
+					properties.addAll(from(persistentEntity, filter, traversalGuard, currentPath));
+				}
 			}
 		};
 

--- a/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/auditing/MappingAuditableBeanWrapperFactoryUnitTests.java
@@ -84,6 +84,18 @@ class MappingAuditableBeanWrapperFactoryUnitTests {
 		assertThat(metadataCache).hasSize(4);
 	}
 
+	@Test // GH-3515
+	void initializesFactoryForEntityWithNestedMapProperty() {
+
+		var context = new SampleMappingContext();
+		context.getPersistentEntity(WithNestedMap.class);
+		context.findPersistentPropertyPaths(WithNestedMap.class, it -> true);
+
+		var factory = new MappingAuditableBeanWrapperFactory(PersistentEntities.of(context));
+
+		assertThat(factory.getBeanWrapperFor(new WithNestedMap())).isNotNull();
+	}
+
 	@Test // DATACMNS-365
 	void discoversAuditingPropertyOnField() {
 
@@ -405,5 +417,13 @@ class MappingAuditableBeanWrapperFactoryUnitTests {
 		Embedded embedded;
 		Collection<Embedded> embeddeds;
 		Map<String, Embedded> embeddedMap;
+	}
+
+	static class Cell {
+		Object value;
+	}
+
+	static class WithNestedMap {
+		Map<String, Map<String, Cell>> values;
 	}
 }

--- a/src/test/java/org/springframework/data/mapping/context/PersistentPropertyPathFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/mapping/context/PersistentPropertyPathFactoryUnitTests.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @soundtrack Cypress Hill - Illusions (Q-Tip Remix, Unreleased & Revamped)
  */
 class PersistentPropertyPathFactoryUnitTests {
@@ -176,6 +177,22 @@ class PersistentPropertyPathFactoryUnitTests {
 				.hasValueSatisfying(it -> assertThat(it.toDotPath()).isEqualTo("third.lastname"));
 	}
 
+	@Test // GH-3515
+	void returnsPathsForMapWithEntityKeyAndSimpleValueType() {
+
+		var paths = factory.from(WithEntityKeyMap.class, it -> true);
+
+		assertThat(paths).extracting(PersistentPropertyPath::toDotPath).containsExactly("map");
+	}
+
+	@Test // GH-3515
+	void returnsPathsForRawTypeComplexBound() {
+
+		var paths = factory.from(BoundedGeneric.class, it -> true);
+
+		assertThat(paths).extracting(PersistentPropertyPath::toDotPath).containsExactly("map");
+	}
+
 	static class PersonSample {
 		List<Person> persons;
 	}
@@ -222,4 +239,13 @@ class PersistentPropertyPathFactoryUnitTests {
 	static class Third {
 		String lastname;
 	}
+
+	static class WithEntityKeyMap {
+		Map<Second, Double> map;
+	}
+
+	static class BoundedGeneric<T extends Second> {
+		Map<T, Double> map;
+	}
+
 }


### PR DESCRIPTION
We now rely on `MappingContext.getPersistentEntity(…)` for persistent entity resolution instead of validating PersistentProperty.isEntity(…) ourselves. isEntity considers key and value types when using Map types whereas getPersistentEntity(…) only considers the value type for property path traversal. This difference in behavior caused MappingException during property path traversal amplified by eager auditing metadata resolution.

Additionally, we leniently resolve a backing persistent entity when obtaining property paths from a collection or map type as MappingContext contains registrations for Map-based entity types that resolve to a raw Map type erasing type parameters.

Closes #3515