### PR TITLE
Avoid redundant type inspection and contribution during repository AOT processing

### DIFF
--- a/src/main/java/org/springframework/data/repository/config/DefaultAotRepositoryContext.java
+++ b/src/main/java/org/springframework/data/repository/config/DefaultAotRepositoryContext.java
@@ -19,7 +19,9 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.support.RegisteredBean;
@@ -36,6 +38,7 @@ import org.springframework.data.util.TypeUtils;
  * @author Christoph Strobl
  * @author John Blum
  * @author Mark Paluch
+ * @author Blaz Snuderl
  * @see AotRepositoryContext
  * @since 3.0
  */
@@ -50,6 +53,7 @@ class DefaultAotRepositoryContext extends AotRepositoryContextSupport {
 
 	private Collection<Class<? extends Annotation>> identifyingAnnotations = Collections.emptySet();
 	private String beanName;
+	private Map<IdentifyingTypesKey, Set<Class<?>>> identifyingTypesCache = new ConcurrentHashMap<>();
 
 	public DefaultAotRepositoryContext(RegisteredBean bean, RepositoryInformation repositoryInformation,
 			String moduleName, AotContext aotContext, RepositoryConfigurationSource configurationSource) {
@@ -89,6 +93,15 @@ class DefaultAotRepositoryContext extends AotRepositoryContextSupport {
 
 	public void setIdentifyingAnnotations(Collection<Class<? extends Annotation>> identifyingAnnotations) {
 		this.identifyingAnnotations = identifyingAnnotations;
+	}
+
+	/**
+	 * Set the cache to reuse types discovered through scanning base packages for
+	 * {@link #getIdentifyingAnnotations() identifying annotations}. Repository contexts sharing a cache scan and inspect a
+	 * set of base packages once instead of once per repository.
+	 */
+	public void setIdentifyingTypesCache(Map<IdentifyingTypesKey, Set<Class<?>>> identifyingTypesCache) {
+		this.identifyingTypesCache = identifyingTypesCache;
 	}
 
 	@Override
@@ -132,13 +145,27 @@ class DefaultAotRepositoryContext extends AotRepositoryContextSupport {
 
 		if (!getIdentifyingAnnotations().isEmpty()) {
 
-			Set<Class<?>> classes = aotContext.getTypeScanner()
-					.scanPackages(getConfigurationSource().getBasePackages().toSet())
-					.forTypesAnnotatedWith(getIdentifyingAnnotations()).collectAsSet();
-			types.addAll(TypeCollector.inspect(classes).list());
+			Set<String> basePackages = getConfigurationSource().getBasePackages().toSet();
+			IdentifyingTypesKey cacheKey = new IdentifyingTypesKey(basePackages, Set.copyOf(getIdentifyingAnnotations()));
+
+			types.addAll(identifyingTypesCache.computeIfAbsent(cacheKey, this::discoverIdentifyingTypes));
 		}
 
 		return types;
+	}
+
+	private Set<Class<?>> discoverIdentifyingTypes(IdentifyingTypesKey key) {
+
+		Set<Class<?>> classes = aotContext.getTypeScanner().scanPackages(key.basePackages())
+				.forTypesAnnotatedWith(key.identifyingAnnotations()).collectAsSet();
+
+		return new LinkedHashSet<>(TypeCollector.inspect(classes).list());
+	}
+
+	/**
+	 * Key to cache types discovered by scanning base packages for identifying annotations.
+	 */
+	record IdentifyingTypesKey(Set<String> basePackages, Set<Class<? extends Annotation>> identifyingAnnotations) {
 	}
 
 }

--- a/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
+++ b/src/main/java/org/springframework/data/repository/config/RepositoryRegistrationAotProcessor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -78,6 +79,7 @@ import org.springframework.util.ClassUtils;
  * @author Christoph Strobl
  * @author John Blum
  * @author Mark Paluch
+ * @author Blaz Snuderl
  * @since 3.0
  */
 public class RepositoryRegistrationAotProcessor
@@ -102,6 +104,8 @@ public class RepositoryRegistrationAotProcessor
 	private Environment environment = new StandardEnvironment();
 
 	private Map<String, RepositoryConfiguration<?>> configMap = Collections.emptyMap();
+
+	private final Map<DefaultAotRepositoryContext.IdentifyingTypesKey, Set<Class<?>>> identifyingTypesCache = new ConcurrentHashMap<>();
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
@@ -261,8 +265,9 @@ public class RepositoryRegistrationAotProcessor
 				.filter(it -> TypeContributor.isPartOf(it, Set.of(information.getDomainType().getPackageName())))
 				.forEach(it -> configureTypeContribution(it, repositoryContext));
 
-		repositoryContext.getResolvedTypes().stream().filter(it -> !isJavaOrPrimitiveType(it))
-				.forEach(it -> contributeType(it, generationContext));
+		TypeContributor.contribute(
+				repositoryContext.getResolvedTypes().stream().filter(it -> !isJavaOrPrimitiveType(it)).toList(), it -> true,
+				generationContext);
 	}
 
 	/**
@@ -365,6 +370,7 @@ public class RepositoryRegistrationAotProcessor
 				extension.getModuleName(), aotContext, configuration.getConfigurationSource());
 
 		repositoryContext.setIdentifyingAnnotations(extension.getIdentifyingAnnotations());
+		repositoryContext.setIdentifyingTypesCache(identifyingTypesCache);
 
 		return repositoryContext;
 	}

--- a/src/main/java/org/springframework/data/util/TypeCollector.java
+++ b/src/main/java/org/springframework/data/util/TypeCollector.java
@@ -60,6 +60,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Sebastien Deleuze
  * @author John Blum
  * @author Mark Paluch
+ * @author Blaz Snuderl
  * @since 3.0
  */
 public class TypeCollector {
@@ -197,8 +198,8 @@ public class TypeCollector {
 		return this.typeFilter;
 	}
 
-	private void process(Class<?> root, Consumer<ResolvableType> consumer) {
-		processType(ResolvableType.forType(root), new InspectionCache(), consumer);
+	private void process(Class<?> root, InspectionCache cache, Consumer<ResolvableType> consumer) {
+		processType(ResolvableType.forType(root), cache, consumer);
 	}
 
 	private void processType(ResolvableType type, InspectionCache cache, Consumer<ResolvableType> callback) {
@@ -318,7 +319,10 @@ public class TypeCollector {
 		 * @param action The action to be performed for each element
 		 */
 		public void forEach(Consumer<ResolvableType> action) {
-			roots.forEach(it -> typeCollector.process(it, action));
+
+			InspectionCache cache = new InspectionCache();
+
+			roots.forEach(it -> typeCollector.process(it, cache, action));
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/util/TypeContributor.java
+++ b/src/main/java/org/springframework/data/util/TypeContributor.java
@@ -16,17 +16,26 @@
 package org.springframework.data.util;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
+import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.annotation.ReflectiveRuntimeHintsRegistrar;
 import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
 /**
  * @author Christoph Strobl
+ * @author Blaz Snuderl
  * @since 3.0
  */
 public class TypeContributor {
@@ -34,6 +43,14 @@ public class TypeContributor {
 	public static final String DATA_NAMESPACE = "org.springframework.data";
 	public static final BindingReflectionHintsRegistrar DATA_BINDING_REGISTRAR = new BindingReflectionHintsRegistrar();
 	public static final ReflectiveRuntimeHintsRegistrar REFLECTIVE_REGISTRAR = new ReflectiveRuntimeHintsRegistrar();
+
+	/**
+	 * Types already contributed to a {@link RuntimeHints} instance. Contributing a (non-annotation) type twice registers
+	 * the very same hints again while re-walking its entire type graph, which is why contributions are tracked per
+	 * {@link RuntimeHints}. Keys are held weakly to not retain hints beyond AOT processing.
+	 */
+	private static final Map<RuntimeHints, Set<Class<?>>> contributedTypes = new ConcurrentReferenceHashMap<>(8,
+			ConcurrentReferenceHashMap.ReferenceType.WEAK);
 
 	/**
 	 * Contribute the type with default reflection configuration, skip annotations.
@@ -68,8 +85,69 @@ public class TypeContributor {
 			return;
 		}
 
+		if (!isNewContribution(type, contribution)) {
+			return;
+		}
+
 		DATA_BINDING_REGISTRAR.registerReflectionHints(contribution.getRuntimeHints().reflection(), type);
 		REFLECTIVE_REGISTRAR.registerRuntimeHints(contribution.getRuntimeHints(), type);
+	}
+
+	/**
+	 * Contribute the given types with default reflection configuration and only include matching annotations.
+	 * <p>
+	 * Data binding hints are registered for all given types in a single pass so that types reachable from more than one of
+	 * the given types are visited once instead of once per given type.
+	 *
+	 * @param types the types to contribute.
+	 * @param filter filter to include annotation types.
+	 * @param contribution the generation context to contribute to.
+	 * @since 4.2
+	 */
+	@SuppressWarnings("unchecked")
+	public static void contribute(Collection<Class<?>> types, Predicate<Class<? extends Annotation>> filter,
+			GenerationContext contribution) {
+
+		List<Class<?>> dataBindingTypes = new ArrayList<>(types.size());
+
+		for (Class<?> type : types) {
+
+			if (type.isPrimitive()) {
+				continue;
+			}
+
+			if (type.isAnnotation() && filter.test((Class<? extends Annotation>) type)) {
+
+				contribution.getRuntimeHints().reflection().registerType(type, hint -> {});
+				continue;
+			}
+
+			if (!isNewContribution(type, contribution)) {
+				continue;
+			}
+
+			dataBindingTypes.add(type);
+		}
+
+		if (dataBindingTypes.isEmpty()) {
+			return;
+		}
+
+		DATA_BINDING_REGISTRAR.registerReflectionHints(contribution.getRuntimeHints().reflection(),
+				dataBindingTypes.toArray(Type[]::new));
+
+		for (Class<?> type : dataBindingTypes) {
+			REFLECTIVE_REGISTRAR.registerRuntimeHints(contribution.getRuntimeHints(), type);
+		}
+	}
+
+	/**
+	 * Register the type as contributed to the given {@link GenerationContext} returning whether the type was contributed
+	 * for the first time.
+	 */
+	private static boolean isNewContribution(Class<?> type, GenerationContext contribution) {
+		return contributedTypes.computeIfAbsent(contribution.getRuntimeHints(), it -> ConcurrentHashMap.newKeySet())
+				.add(type);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/aot/TypeCollectorUnitTests.java
+++ b/src/test/java/org/springframework/data/aot/TypeCollectorUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.util.TypeCollector;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Blaz Snuderl
  */
 public class TypeCollectorUnitTests {
 
@@ -65,6 +66,13 @@ public class TypeCollectorUnitTests {
 	void includesDeclaredClassesInInspection() {
 		assertThat(TypeCollector.inspect(WithDeclaredClass.class).list()).containsExactlyInAnyOrder(WithDeclaredClass.class,
 				WithDeclaredClass.SomeEnum.class);
+	}
+
+	@Test
+	void inspectsTypesReachableFromMultipleRootsOnce() {
+
+		assertThat(TypeCollector.inspect(CyclicPropertiesA.class, CyclicPropertiesB.class).list())
+				.containsExactlyInAnyOrder(CyclicPropertiesA.class, CyclicPropertiesB.class);
 	}
 
 	@Test // GH-2744

--- a/src/test/java/org/springframework/data/util/TypeContributorUnitTests.java
+++ b/src/test/java/org/springframework/data/util/TypeContributorUnitTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.data.aot.types.CyclicPropertiesA;
+import org.springframework.data.aot.types.CyclicPropertiesB;
+
+/**
+ * Unit tests for {@link TypeContributor}.
+ *
+ * @author Blaz Snuderl
+ */
+class TypeContributorUnitTests {
+
+	@Test
+	void contributesTypesOnlyOncePerGenerationContext() {
+
+		GenerationContext generationContext = new TestGenerationContext();
+
+		TypeContributor.contribute(CyclicPropertiesA.class, it -> true, generationContext);
+
+		List<TypeReference> afterFirstContribution = registeredTypes(generationContext);
+
+		TypeContributor.contribute(CyclicPropertiesA.class, it -> true, generationContext);
+
+		assertThat(registeredTypes(generationContext)).containsExactlyElementsOf(afterFirstContribution);
+	}
+
+	@Test
+	void contributingCollectionRegistersSameHintsAsIndividualContributions() {
+
+		GenerationContext individually = new TestGenerationContext();
+
+		TypeContributor.contribute(CyclicPropertiesA.class, it -> true, individually);
+		TypeContributor.contribute(CyclicPropertiesB.class, it -> true, individually);
+
+		GenerationContext batched = new TestGenerationContext();
+
+		TypeContributor.contribute(List.of(CyclicPropertiesA.class, CyclicPropertiesB.class), it -> true, batched);
+
+		assertThat(registeredTypes(batched)).containsExactlyInAnyOrderElementsOf(registeredTypes(individually));
+	}
+
+	private static List<TypeReference> registeredTypes(GenerationContext generationContext) {
+		return generationContext.getRuntimeHints().reflection().typeHints().map(it -> it.getType()).sorted().toList();
+	}
+}


### PR DESCRIPTION
Closes #3518.

Repository AOT processing walks the same domain type graph repeatedly, which makes `SpringApplicationAotProcessor` scale poorly with the number of repositories and the size of the domain model:

- `DefaultAotRepositoryContext.discoverTypes()` scans the configured base packages for types carrying the store's identifying annotations and inspects all of them — for every repository.
- `TypeContributor.contribute(…)` hands each resolved type to `BindingReflectionHintsRegistrar` individually. The registrar starts with a fresh `seen` set per call, so shared types are re-traversed once per resolved type.
- `TypeCollector.ReachableTypes` uses a per-root inspection cache, re-inspecting types reachable from more than one root.

This PR addresses all three:

- Base package scan results are cached across the repository contexts created by a `RepositoryRegistrationAotProcessor`.
- Reachable type inspection shares one inspection cache across all roots of a `ReachableTypes` instance.
- Resolved types are contributed in a single `BindingReflectionHintsRegistrar` pass, skipping types already contributed to the same `RuntimeHints`.

The generated `reachability-metadata.json` is unchanged. For a real application with 17 Mongo repositories over a Jackson-annotated protobuf domain model, `SpringApplicationAotProcessor` drops from 60s to 12s; for a synthetic application with 32 repositories, from 33.6s to 4.5s.

A standalone reproducer with scaling measurements is available at https://github.com/snuderl/spring-data-aot-repro.

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
