### PR TITLE
Document Vavr collection types as query method parameters

### DIFF
--- a/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
@@ -280,9 +280,9 @@ You can use the types in the first column (or subtypes thereof) as query method 
 Alternatively, you can declare `Traversable` (the Vavr `Iterable` equivalent), and we then derive the implementation class from the actual return value.
 That is, a `java.util.List` is turned into a Vavr `List` or `Seq`, a `java.util.Set` becomes a Vavr `LinkedHashSet` `Set`, and so on.
 
-The same types are also accepted as query method *parameters*.
-Spring Data unwraps a Vavr `Seq`, `Set`, or `Map` argument to a Java collection before the store sees it, so a derived query such as `findByStatusIn(io.vavr.collection.List<Status> statuses)` binds as a regular `IN` clause.
-A Vavr `Option` argument is unwrapped to its value (or `null`), not to `java.util.Optional`.
+These Vavr types are also accepted as query method *parameters* (as of 2.0). If a repository method parameter uses one of the types above (or `Traversable`), Spring Data automatically unwraps it into its Java-native equivalent before executing the query.
+
+For example, a derived query method declared as `findAllByIdIn(io.vavr.collection.List<Long> ids)` accepts a Vavr `List` and unwraps it to a `java.util.List` so it binds correctly as an `IN`-clause. A Vavr `Option` parameter is similarly unwrapped to its inner value (or `null`).
 
 
 [[repositories.query-streaming]]

--- a/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-methods-details.adoc
@@ -280,6 +280,10 @@ You can use the types in the first column (or subtypes thereof) as query method 
 Alternatively, you can declare `Traversable` (the Vavr `Iterable` equivalent), and we then derive the implementation class from the actual return value.
 That is, a `java.util.List` is turned into a Vavr `List` or `Seq`, a `java.util.Set` becomes a Vavr `LinkedHashSet` `Set`, and so on.
 
+The same types are also accepted as query method *parameters*.
+Spring Data unwraps a Vavr `Seq`, `Set`, or `Map` argument to a Java collection before the store sees it, so a derived query such as `findByStatusIn(io.vavr.collection.List<Status> statuses)` binds as a regular `IN` clause.
+A Vavr `Option` argument is unwrapped to its value (or `null`), not to `java.util.Optional`.
+
 
 [[repositories.query-streaming]]
 == Streaming Query Results

--- a/src/main/antora/modules/ROOT/pages/repositories/query-return-types-reference.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/query-return-types-reference.adoc
@@ -27,7 +27,7 @@ Some store modules may define their own result wrapper types.
 |`Stream<T>`|A Java `Stream`.
 |`Streamable<T>`|A convenience extension of `Iterable` that directly exposes methods to stream, map and filter results, concatenate them etc.
 |Types that implement `Streamable` and take a `Streamable` constructor or factory method argument|Types that expose a constructor or `….of(…)`/`….valueOf(…)` factory method taking a `Streamable` as argument. See xref:repositories/query-methods-details.adoc#repositories.collections-and-iterables.streamable-wrapper[Returning Custom Streamable Wrapper Types] for details.
-|Vavr `Seq`, `List`, `Map`, `Set`|Vavr collection types. See xref:repositories/query-methods-details.adoc#repositories.collections-and-iterables.vavr[Support for Vavr Collections] for details.
+|Vavr `Seq`, `List`, `Map`, `Set`|Vavr collection types, also accepted as query method parameters. See xref:repositories/query-methods-details.adoc#repositories.collections-and-iterables.vavr[Support for Vavr Collections] for details.
 |`Future<T>`|A `Future`. Expects a method to be annotated with `@Async` and requires Spring's asynchronous method execution capability to be enabled.
 |`CompletableFuture<T>`|A `CompletableFuture`. Expects a method to be annotated with `@Async` and requires Spring's asynchronous method execution capability to be enabled.
 |`Slice<T>`|A sized chunk of data with an indication of whether there is more data available. Requires a `Pageable` method parameter.


### PR DESCRIPTION
The Vavr section only talked about return types. Those wrappers are also unwrapped on the way in (ParametersParameterAccessor / QueryExecutionConverters), so findByStatusIn(io.vavr.collection.List) is a regular IN clause.

Fixes #3525