### PR TITLE
Collect nested generic arguments when resolving type signatures

### DIFF
--- a/src/main/java/org/springframework/data/util/TypeUtils.java
+++ b/src/main/java/org/springframework/data/util/TypeUtils.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -37,6 +38,7 @@ import org.springframework.util.ObjectUtils;
 
 /**
  * @author Christoph Strobl
+ * @author arimu1
  */
 // TODO: Consider moving to the org.springframework.data.util package or make this package-private if not used somewhere
 // else.
@@ -159,21 +161,25 @@ public class TypeUtils {
 	}
 
 	private static void resolveTypesInSignature(ResolvableType current, Set<Class<?>> signatures) {
+		resolveTypesInSignature(current, signatures, new HashSet<>());
+	}
+
+	private static void resolveTypesInSignature(ResolvableType current, Set<Class<?>> signatures, Set<String> visited) {
 
 		if (ResolvableType.NONE.equals(current) || ObjectUtils.nullSafeEquals(Void.TYPE, current.getType())
 				|| ObjectUtils.nullSafeEquals(Object.class, current.getType())) {
 			return;
 		}
-		if (signatures.contains(current.toClass())) {
+		if (!visited.add(current.toString())) {
 			return;
 		}
 		signatures.add(current.toClass());
-		resolveTypesInSignature(current.getSuperType(), signatures);
+		resolveTypesInSignature(current.getSuperType(), signatures, visited);
 		for (ResolvableType type : current.getGenerics()) {
-			resolveTypesInSignature(type, signatures);
+			resolveTypesInSignature(type, signatures, visited);
 		}
 		for (ResolvableType type : current.getInterfaces()) {
-			resolveTypesInSignature(type, signatures);
+			resolveTypesInSignature(type, signatures, visited);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/aot/TypeCollectorUnitTests.java
+++ b/src/test/java/org/springframework/data/aot/TypeCollectorUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.util.TypeCollector;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author arimu1
  */
 public class TypeCollectorUnitTests {
 
@@ -97,6 +98,12 @@ public class TypeCollectorUnitTests {
 
 		assertThat(filter.test(FieldsAndMethods.class)).isFalse();
 		assertThat(TypeCollector.inspect(c -> c.filterTypes(cls -> false), FieldsAndMethods.class).list()).isEmpty();
+	}
+
+	@Test // GH-3530
+	void detectsTypesNestedMoreThanOneGenericLevel() {
+		assertThat(TypeCollector.inspect(NestedGenericMaps.class).list()).contains(NestedGenericMaps.class,
+				EmptyType1.class, EmptyType2.class);
 	}
 
 }

--- a/src/test/java/org/springframework/data/aot/types/NestedGenericMaps.java
+++ b/src/test/java/org/springframework/data/aot/types/NestedGenericMaps.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.aot.types;
+
+import java.util.Map;
+
+/**
+ * @author arimu1
+ */
+public class NestedGenericMaps {
+
+	Map<String, EmptyType1> one;
+	Map<String, Map<String, EmptyType2>> two;
+}


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

`DefaultAotRepositoryContext.discoverTypes()` collects reachable domain types via `TypeCollector.inspect(…)`, which delegates to `TypeUtils.resolveTypesInSignature`. Cycle detection used the raw `Class`, so a nested parameterization of a type already seen (for example `V` in `Map<K, Map<K, V>>`) was skipped. One-level `Map<K, V>` was collected as expected.

This change visits generic arguments using the `ResolvableType` signature instead of the raw class, so nested component types are included in the AOT type set used for accessor generation.

`TypeCollectorUnitTests.detectsTypesNestedMoreThanOneGenericLevel` fails on current `main` (`EmptyType2` missing) and passes with this change.

Closes #3530