### PR TITLE
Properly handle mixed property paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-3533-SNAPSHOT</version>
 
 	<name>Spring Data Core</name>
 	<description>Core Spring concepts underpinning every Spring Data module.</description>

--- a/src/main/java/org/springframework/data/core/SimplePropertyPath.java
+++ b/src/main/java/org/springframework/data/core/SimplePropertyPath.java
@@ -144,6 +144,21 @@ class SimplePropertyPath implements PropertyPath {
 		return next != null;
 	}
 
+	/**
+	 * Reimplementation of {@link #getLeafProperty()} in order to
+	 * retain the concrete type {@link SimplePropertyPath}.
+	 */
+	public SimplePropertyPath getLeafProperty() {
+
+		SimplePropertyPath result = this;
+
+		while (result.next != null) {
+			result = result.next;
+		}
+
+		return result;
+	}
+
 	@Override
 	public boolean isCollection() {
 		return isCollection;
@@ -269,6 +284,10 @@ class SimplePropertyPath implements PropertyPath {
 
 	/**
 	 * Creates a new {@link SimplePropertyPath} as subordinary of the given {@link SimplePropertyPath}.
+	 * <p>
+	 * {@code base} holds one entry per part of the path, namely the part's first property. A part spelled in camel case
+	 * stands for a chain of properties rather than a single one, so what the next part continues from is that entry's
+	 * {@link #getLeafProperty()}  leaf}, not the entry itself.
 	 *
 	 * @param source
 	 * @param base
@@ -276,11 +295,9 @@ class SimplePropertyPath implements PropertyPath {
 	 */
 	private static SimplePropertyPath create(String source, Stack<SimplePropertyPath> base) {
 
-		SimplePropertyPath previous = base.peek();
+		SimplePropertyPath previous = base.peek().getLeafProperty();
 
-		SimplePropertyPath propertyPath = create(source, previous.typeInformation.getRequiredActualType(), base);
-		previous.next = propertyPath;
-		return propertyPath;
+		return create(source, previous.typeInformation.getRequiredActualType(), base);
 	}
 
 	/**
@@ -322,7 +339,7 @@ class SimplePropertyPath implements PropertyPath {
 			current = new SimplePropertyPath(source, type, base);
 
 			if (!base.isEmpty()) {
-				base.get(base.size() - 1).next = current;
+				base.get(base.size() - 1).getLeafProperty().next = current;
 			}
 
 			List<SimplePropertyPath> newBase = new ArrayList<>(base);

--- a/src/test/java/org/springframework/data/core/PropertyPathUnitTests.java
+++ b/src/test/java/org/springframework/data/core/PropertyPathUnitTests.java
@@ -177,6 +177,54 @@ class PropertyPathUnitTests {
 		assertThat(propertyPath.getLeafProperty()).isEqualTo(PropertyPath.from("name", FooBar.class));
 	}
 
+	@Test // GH-3533
+	void continuesAfterCamelCaseSegmentAtItsLeaf() {
+
+		var propertyPath = PropertyPath.from("barUser.name", Sample.class);
+
+		assertThat(propertyPath.toDotPath()).isEqualTo("bar.user.name");
+		assertThat(propertyPath.getLeafProperty()).isEqualTo(PropertyPath.from("name", FooBar.class));
+	}
+
+	@Test // GH-3533
+	void continuesAfterCamelCaseSegmentAtItsLeafWithUnderscore() {
+
+		var propertyPath = PropertyPath.from("barUser_name", Sample.class);
+
+		assertThat(propertyPath.toDotPath()).isEqualTo("bar.user.name");
+		assertThat(propertyPath.getLeafProperty()).isEqualTo(PropertyPath.from("name", FooBar.class));
+	}
+
+	@Test // GH-3533
+	void continuesAfterCollectionCamelCaseSegmentAtItsLeaf() {
+		assertThat(PropertyPath.from("barUsers.name", Sample.class).toDotPath()).isEqualTo("bar.users.name");
+	}
+
+	@Test // GH-3533
+	void continuesAfterMapCamelCaseSegmentAtItsLeaf() {
+		assertThat(PropertyPath.from("barUserMap.name", Sample.class).toDotPath()).isEqualTo("bar.userMap.name");
+	}
+
+	@Test // GH-3533
+	void rejectsPropertyMissingOnLeafOfPrecedingCamelCaseSegment() {
+
+		// FooBar, the leaf of barUser, has no property 'user'; Bar, its owner, has one
+		assertThatExceptionOfType(PropertyReferenceException.class) //
+				.isThrownBy(() -> PropertyPath.from("barUser.user", Sample.class)) //
+				.withMessageContaining("No property 'user' found for type 'FooBar'");
+	}
+
+	@Test // GH-3533
+	void keepsCamelCaseSegmentIntactWhenFollowedByDotNotation() {
+
+		var propertyPath = PropertyPath.from("barUser.name", Sample.class);
+
+		List<String> segments = new ArrayList<>();
+		propertyPath.forEach(it -> segments.add(it.getSegment()));
+
+		assertThat(segments).containsExactly("bar", "user", "name");
+	}
+
 	@Test
 	void returnsCorrectIteratorForSingleElement() {
 


### PR DESCRIPTION
Property paths mixed between camelcase and dot or underscore paths now get properly resolved.

Closes https://github.com/spring-projects/spring-data-commons/issues/3533