### PR TITLE
Add `String` to `LocalTime` converter

### DIFF
--- a/src/main/java/org/springframework/data/convert/Jsr310Converters.java
+++ b/src/main/java/org/springframework/data/convert/Jsr310Converters.java
@@ -45,6 +45,7 @@ import org.springframework.core.convert.converter.Converter;
  * @author Christoph Strobl
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Jan Durovec
  */
 public abstract class Jsr310Converters {
 
@@ -75,6 +76,7 @@ public abstract class Jsr310Converters {
 		converters.add(StringToDurationConverter.INSTANCE);
 		converters.add(PeriodToStringConverter.INSTANCE);
 		converters.add(StringToPeriodConverter.INSTANCE);
+		converters.add(StringToLocalTimeConverter.INSTANCE);
 		converters.add(StringToLocalDateConverter.INSTANCE);
 		converters.add(StringToLocalDateTimeConverter.INSTANCE);
 		converters.add(StringToInstantConverter.INSTANCE);
@@ -283,6 +285,18 @@ public abstract class Jsr310Converters {
 		@Override
 		public Period convert(String s) {
 			return Period.parse(s);
+		}
+	}
+
+	@ReadingConverter
+	public enum StringToLocalTimeConverter implements Converter<String, LocalTime> {
+
+		INSTANCE;
+
+		@NonNull
+		@Override
+		public LocalTime convert(String source) {
+			return LocalTime.parse(source);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/convert/Jsr310ConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/convert/Jsr310ConvertersUnitTests.java
@@ -47,6 +47,7 @@ import org.springframework.core.convert.support.GenericConversionService;
  * @author Barak Schoster
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Jan Durovec
  */
 class Jsr310ConvertersUnitTests {
 
@@ -149,6 +150,14 @@ class Jsr310ConvertersUnitTests {
 		var convertedDateTime = CONVERSION_SERVICE.convert(dateTime, LocalDateTime.class);
 
 		assertThat(convertedDateTime).isEqualTo(dateTime);
+	}
+
+	@Test
+	void convertsIsoFormattedStringToLocalTime() {
+
+		var time = LocalTime.now();
+
+		assertThat(CONVERSION_SERVICE.convert(time.toString(), LocalTime.class)).isEqualTo(time);
 	}
 
 	@Test


### PR DESCRIPTION
The current set of JSR310 converters is missing the support for deserialization of `LocalTime` from `String`.

See #3522
