### PR TITLE
Bind multipart files in ProxyingHandlerMethodArgumentResolver.

### DIFF
--- a/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolver.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.annotation.ModelAttributeMethodProcessor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.multipart.MultipartRequest;
 import org.springframework.web.multipart.support.MultipartResolutionDelegate;
 
 /**
@@ -46,6 +47,7 @@ import org.springframework.web.multipart.support.MultipartResolutionDelegate;
  * @author Chris Bono
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Seonggon Cho
  * @since 1.10
  */
 public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodProcessor
@@ -122,9 +124,31 @@ public class ProxyingHandlerMethodArgumentResolver extends ModelAttributeMethodP
 
 		MapDataBinder binder = new MapDataBinder(parameter.getParameterType(), conversionService.getObject(),
 				collectionSizeLimit);
-		binder.bind(new MutablePropertyValues(request.getParameterMap()));
+		binder.bind(getPropertyValues(request));
 
 		return proxyFactory.createProjection(parameter.getParameterType(), binder.getTarget());
+	}
+
+	/**
+	 * Returns the request parameters and, in case of a multipart request, the uploaded files of the given
+	 * {@link NativeWebRequest} as {@link MutablePropertyValues}. Files are bound the same way
+	 * {@link org.springframework.web.bind.WebDataBinder} binds them: a single file as is, multiple files for the same
+	 * name as {@link java.util.List}.
+	 *
+	 * @param request must not be {@literal null}.
+	 * @return will never be {@literal null}.
+	 */
+	private static MutablePropertyValues getPropertyValues(NativeWebRequest request) {
+
+		MutablePropertyValues values = new MutablePropertyValues(request.getParameterMap());
+		MultipartRequest multipartRequest = request.getNativeRequest(MultipartRequest.class);
+
+		if (multipartRequest != null) {
+			multipartRequest.getMultiFileMap()
+					.forEach((name, files) -> values.add(name, files.size() == 1 ? files.get(0) : files));
+		}
+
+		return values;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/web/ProxyingHandlerMethodArgumentResolverUnitTests.java
@@ -28,7 +28,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.support.DefaultDataBinderFactory;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -37,6 +42,7 @@ import org.springframework.web.multipart.MultipartFile;
  * @author Oliver Gierke
  * @author Chris Bono
  * @author Mark Paluch
+ * @author Seonggon Cho
  * @soundtrack Karlijn Langendijk & Sönke Meinen - Englishman In New York (Sting,
  *             https://www.youtube.com/watch?v=O7LZsqrnaaA)
  */
@@ -125,6 +131,39 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		assertThat(resolver.supportsParameter(parameter)).isFalse();
 	}
 
+	@Test // GH-1136
+	void bindsMultipartFileIntoProjectedPayload() throws Exception {
+
+		var request = new MockMultipartHttpServletRequest();
+		request.addParameter("name", "Dave");
+		request.addFile(new MockMultipartFile("file", "hello.txt", "text/plain", "Hello".getBytes()));
+
+		var result = resolver.resolveArgument(getParameter("withMultipartForm"), new ModelAndViewContainer(),
+				new ServletWebRequest(request), new DefaultDataBinderFactory(null));
+
+		assertThat(result).isInstanceOfSatisfying(MultipartForm.class, form -> {
+			assertThat(form.getName()).isEqualTo("Dave");
+			assertThat(form.getFile()).isNotNull();
+			assertThat(form.getFile().getOriginalFilename()).isEqualTo("hello.txt");
+		});
+	}
+
+	@Test // GH-1136
+	void bindsMultipleMultipartFilesIntoProjectedPayload() throws Exception {
+
+		var request = new MockMultipartHttpServletRequest();
+		request.addFile(new MockMultipartFile("files", "first.txt", "text/plain", "First".getBytes()));
+		request.addFile(new MockMultipartFile("files", "second.txt", "text/plain", "Second".getBytes()));
+
+		var result = resolver.resolveArgument(getParameter("withMultipartForm"), new ModelAndViewContainer(),
+				new ServletWebRequest(request), new DefaultDataBinderFactory(null));
+
+		assertThat(result).isInstanceOfSatisfying(MultipartForm.class, form -> {
+			assertThat(form.getFiles()).extracting(MultipartFile::getOriginalFilename).containsExactly("first.txt",
+					"second.txt");
+		});
+	}
+
 	private static MethodParameter getParameter(String methodName) {
 
 		for (Method method : Controller.class.getMethods()) {
@@ -141,6 +180,16 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 	interface AnnotatedInterface {}
 
 	interface UnannotatedInterface {}
+
+	@ProjectedPayload
+	interface MultipartForm {
+
+		String getName();
+
+		MultipartFile getFile();
+
+		List<MultipartFile> getFiles();
+	}
 
 	interface Controller {
 
@@ -163,6 +212,8 @@ class ProxyingHandlerMethodArgumentResolverUnitTests {
 		void withProjectedPayload(@ProjectedPayload SampleInterface param);
 
 		void withProjectedPayloadMultipart(@ProjectedPayload MultipartFile file);
+
+		void withMultipartForm(MultipartForm form);
 	}
 
 }


### PR DESCRIPTION
Interface-based form-backing objects created by `ProxyingHandlerMethodArgumentResolver` return `null` for `MultipartFile` properties, see #1136.

**Cause.** `createAttribute` binds `request.getParameterMap()` only. The files of a multipart request live in `MultipartRequest#getMultiFileMap()`, so they never reach the `Map` backing the projection proxy, and `bindRequestParameters` is a no-op, so there is no second binding pass either. In a `@NullMarked` context the proxy's nullness validation turns the `null` into a `NullPointerException` ("Return value is null but must not be null").

**Change.** `createAttribute` now also adds the files of a `MultipartRequest` to the property values, following `WebDataBinder#bindMultipart`: a single file is bound as is, multiple files for the same name as a `List<MultipartFile>`. Requests without a `MultipartRequest` are unaffected.

**Tests.** Two unit tests in `ProxyingHandlerMethodArgumentResolverUnitTests` (`bindsMultipartFileIntoProjectedPayload`, `bindsMultipleMultipartFilesIntoProjectedPayload`) resolve a `@ProjectedPayload` interface from a `MockMultipartHttpServletRequest`. Both fail without the change and pass with it; `EnableSpringDataWebSupportIntegrationTests` still passes.

**Open question.** I kept the change local to the resolver. Alternatively `MapDataBinder` could extend `WebRequestDataBinder` and use `bind(WebRequest)`, which would additionally bind Servlet `Part`s when no `MultipartResolver` is configured. Happy to switch if you prefer that route.

Closes #1136

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).