### PR TITLE
Fix null check in withStringMatcher

### DIFF
--- a/src/main/java/org/springframework/data/domain/TypedExampleMatcher.java
+++ b/src/main/java/org/springframework/data/domain/TypedExampleMatcher.java
@@ -30,6 +30,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Dongho Kim
  * @since 2.0
  */
 class TypedExampleMatcher implements ExampleMatcher {
@@ -73,7 +74,7 @@ class TypedExampleMatcher implements ExampleMatcher {
 	@Override
 	public ExampleMatcher withStringMatcher(StringMatcher defaultStringMatcher) {
 
-		Assert.notNull(ignoredPaths, "DefaultStringMatcher must not be empty");
+		Assert.notNull(defaultStringMatcher, "DefaultStringMatcher must not be empty");
 
 		return new TypedExampleMatcher(nullHandler, defaultStringMatcher, propertySpecifiers, ignoredPaths,
 				defaultIgnoreCase, mode);

--- a/src/test/java/org/springframework/data/domain/ExampleMatcherUnitTests.java
+++ b/src/test/java/org/springframework/data/domain/ExampleMatcherUnitTests.java
@@ -42,6 +42,11 @@ class ExampleMatcherUnitTests {
 		assertThat(matcher.getDefaultStringMatcher()).isEqualTo(StringMatcher.DEFAULT);
 	}
 
+	@Test // GH-3539
+	void withStringMatcherShouldThrowExceptionWhenStringMatcherIsNull() {
+		assertThatIllegalArgumentException().isThrownBy(() -> matcher.withStringMatcher(null));
+	}
+
 	@Test // DATACMNS-810
 	void ignoreCaseShouldReturnFalseByDefault() {
 		assertThat(matcher.isIgnoreCaseEnabled()).isFalse();


### PR DESCRIPTION
`TypedExampleMatcher.withStringMatcher(StringMatcher)` asserted the `ignoredPaths` field instead of its `defaultStringMatcher` parameter:

```java
public ExampleMatcher withStringMatcher(StringMatcher defaultStringMatcher) {
    Assert.notNull(ignoredPaths, "DefaultStringMatcher must not be empty");
    ...
}
```

`ignoredPaths` is always set, so the assertion always passed and a `null` `defaultStringMatcher` was accepted and stored, only to fail later. This asserts the parameter instead, matching the message and the sibling `withIgnorePaths(String...)` method, and adds a test covering the null argument.

Closes #3539
