### PR TITLE
Provide a SlicedModel DTO to render stable JSON representations of Slice

### DIFF
--- a/src/main/antora/modules/ROOT/pages/aot.adoc
+++ b/src/main/antora/modules/ROOT/pages/aot.adoc
@@ -157,5 +157,5 @@ These are in particular hints for:
 ** Repository fragments
 ** Querydsl `Q` classes
 ** Kotlin Coroutine support
-* Web support (Jackson Hints for `PagedModel`)
+* Web support (Jackson Hints for `PagedModel` and `SlicedModel`)
 

--- a/src/main/antora/modules/ROOT/pages/repositories/core-extensions-web.adoc
+++ b/src/main/antora/modules/ROOT/pages/repositories/core-extensions-web.adoc
@@ -195,10 +195,54 @@ This will result in a JSON structure looking like this:
 
 Note how the document contains a `page` field exposing the essential pagination metadata.
 
-[[core.web.page.config]]
-=== Globally enabling simplified `Page` rendering
+[[core.web.page.sliced-model]]
+=== Using Spring Data's `SlicedModel`
 
-If you don't want to change all your existing controllers to add the mapping step to return `PagedModel` instead of `Page` you can enable the automatic translation of `PageImpl` instances into `PagedModel` by tweaking `@EnableSpringDataWebSupport` as follows:
+Similarly to `PagedModel`, Spring Data provides `SlicedModel` to wrap `Slice` instances:
+
+[source,java]
+----
+import org.springframework.data.web.SlicedModel;
+
+@Controller
+class MyController {
+
+  private final MyRepository repository;
+
+  // Constructor omitted
+
+  @GetMapping("/slice")
+  SlicedModel<?> slice(Pageable pageable) {
+    return new SlicedModel<>(repository.findAll(pageable)); // <1>
+  }
+}
+----
+
+<1> Wraps the `Slice` instance into a `SlicedModel`.
+
+This will result in a JSON structure looking like this:
+
+[source,javascript]
+----
+{
+  "content" : [
+     … // Slice content rendered here
+  ],
+  "page" : {
+    "size" : 20,
+    "number" : 0,
+    "numberOfElements" : 20,
+    "hasNext" : true
+  }
+}
+----
+
+Note how the document contains a `page` field exposing the slice metadata (size, number, number of elements, and whether a next slice is available) while deliberately omitting `totalElements` and `totalPages` as that information is not available on a `Slice`.
+
+[[core.web.page.config]]
+=== Globally enabling simplified `Page` and `Slice` rendering
+
+If you don't want to change all your existing controllers to add the mapping step to return `PagedModel` or `SlicedModel` instead of `Page` or `Slice` you can enable the automatic translation of `PageImpl` instances into `PagedModel` and `SliceImpl` instances into `SlicedModel` by tweaking `@EnableSpringDataWebSupport` as follows:
 
 [source,java]
 ----
@@ -206,7 +250,7 @@ If you don't want to change all your existing controllers to add the mapping ste
 class MyConfiguration { }
 ----
 
-This will allow your controller to still return `Page` instances and they will automatically be rendered into the simplified representation:
+This will allow your controller to still return `Page` and `Slice` instances and they will automatically be rendered into the simplified representation:
 
 [source,java]
 ----
@@ -219,6 +263,11 @@ class MyController {
 
   @GetMapping("/page")
   Page<?> page(Pageable pageable) {
+    return repository.findAll(pageable);
+  }
+
+  @GetMapping("/slice")
+  Slice<?> slice(Pageable pageable) {
     return repository.findAll(pageable);
   }
 }

--- a/src/main/java/org/springframework/data/web/SlicedModel.java
+++ b/src/main/java/org/springframework/data/web/SlicedModel.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO to build stable JSON representations of a Spring Data {@link Slice}. It can either be selectively used in
+ * controller methods by calling {@code new SlicedModel<>(slice)} or generally activated as representation model for
+ * {@link org.springframework.data.domain.SliceImpl} instances by setting
+ * {@link org.springframework.data.web.config.EnableSpringDataWebSupport}'s {@code pageSerializationMode} to
+ * {@link org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode#VIA_DTO}.
+ *
+ * @author Arnab Nandy
+ * @since 4.2
+ */
+public class SlicedModel<T> {
+
+	private final Slice<T> slice;
+
+	/**
+	 * Creates a new {@link SlicedModel} for the given {@link Slice}.
+	 *
+	 * @param slice must not be {@literal null}.
+	 */
+	public SlicedModel(Slice<T> slice) {
+
+		Assert.notNull(slice, "Slice must not be null");
+
+		this.slice = slice;
+	}
+
+	@JsonProperty
+	public List<T> getContent() {
+		return slice.getContent();
+	}
+
+	@JsonProperty("page")
+	public SliceMetadata getMetadata() {
+		return new SliceMetadata(slice.getSize(), slice.getNumber(), slice.getNumberOfElements(), slice.hasNext());
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof SlicedModel<?> that)) {
+			return false;
+		}
+
+		return Objects.equals(this.slice, that.slice);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(slice);
+	}
+
+	public record SliceMetadata(long size, long number, long numberOfElements, boolean hasNext) {
+
+		public SliceMetadata {
+			Assert.isTrue(size > -1, "Size must not be negative!");
+			Assert.isTrue(number > -1, "Number must not be negative!");
+			Assert.isTrue(numberOfElements > -1, "Number of elements must not be negative!");
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/web/aot/WebRuntimeHints.java
+++ b/src/main/java/org/springframework/data/web/aot/WebRuntimeHints.java
@@ -32,6 +32,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Arnab Nandy
  * @since 3.2.3
  */
 class WebRuntimeHints implements RuntimeHintsRegistrar {
@@ -50,12 +51,18 @@ class WebRuntimeHints implements RuntimeHintsRegistrar {
 
 		if (JACKSON2_PRESENT || JACKSON3_PRESENT) {
 
-			// Page Model for Jackson Rendering
+			// Page and Slice Models for Jackson Rendering
 			hints.reflection().registerType(org.springframework.data.web.PagedModel.class,
 					MemberCategory.INVOKE_PUBLIC_METHODS);
 
 			hints.reflection().registerType(PagedModel.PageMetadata.class, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
 					MemberCategory.INVOKE_PUBLIC_METHODS);
+
+			hints.reflection().registerType(org.springframework.data.web.SlicedModel.class,
+					MemberCategory.INVOKE_PUBLIC_METHODS);
+
+			hints.reflection().registerType(org.springframework.data.web.SlicedModel.SliceMetadata.class,
+					MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
 
 			hints.reflection().registerType(TypeReference.of("org.springframework.data.domain.Unpaged"));
 
@@ -80,6 +87,13 @@ class WebRuntimeHints implements RuntimeHintsRegistrar {
 					hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
 					hint.onReachableType(PageModule.class);
 				});
+		hints.reflection().registerType(
+				TypeReference
+						.of("org.springframework.data.web.config.SpringDataJacksonConfiguration$PageModule$SliceModelConverter"),
+				hint -> {
+					hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
+					hint.onReachableType(PageModule.class);
+				});
 		hints.reflection().registerType(TypeReference.of(
 				"org.springframework.data.web.config.SpringDataJacksonConfiguration$PageModule$PlainPageSerializationWarning"),
 				hint -> {
@@ -94,6 +108,13 @@ class WebRuntimeHints implements RuntimeHintsRegistrar {
 		hints.reflection().registerType(
 				TypeReference
 						.of("org.springframework.data.web.config.SpringDataJackson3Configuration$PageModule$PageModelConverter"),
+				hint -> {
+					hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
+					hint.onReachableType(SpringDataJackson3Configuration.PageModule.class);
+				});
+		hints.reflection().registerType(
+				TypeReference
+						.of("org.springframework.data.web.config.SpringDataJackson3Configuration$PageModule$SliceModelConverter"),
 				hint -> {
 					hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
 					hint.onReachableType(SpringDataJackson3Configuration.PageModule.class);

--- a/src/main/java/org/springframework/data/web/config/EnableSpringDataWebSupport.java
+++ b/src/main/java/org/springframework/data/web/config/EnableSpringDataWebSupport.java
@@ -70,6 +70,7 @@ import org.springframework.util.ClassUtils;
  * @see HateoasAwareSpringDataWebConfiguration
  * @author Oliver Gierke
  * @author Yanming Zhou
+ * @author Arnab Nandy
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
@@ -82,11 +83,14 @@ import org.springframework.util.ClassUtils;
 public @interface EnableSpringDataWebSupport {
 
 	/**
-	 * Configures how to render {@link org.springframework.data.domain.PageImpl} instances. Defaults to
+	 * Configures how to render {@link org.springframework.data.domain.PageImpl} and
+	 * {@link org.springframework.data.domain.SliceImpl} instances. Defaults to
 	 * {@link PageSerializationMode#DIRECT} for backward compatibility reasons. Prefer explicitly setting this to
 	 * {@link PageSerializationMode#VIA_DTO}, or manually convert {@link org.springframework.data.domain.PageImpl}
-	 * instances before handing them out of a controller method, either by manually calling {@code new PagedModel<>(page)}
-	 * or using Spring HATEOAS {@link org.springframework.hateoas.PagedModel} abstraction.
+	 * and {@link org.springframework.data.domain.SliceImpl} instances before handing them out of a controller method,
+	 * either by manually calling {@code new PagedModel<>(page)} / {@code new SlicedModel<>(slice)}
+	 * or using Spring HATEOAS {@link org.springframework.hateoas.PagedModel} /
+	 * {@link org.springframework.hateoas.SlicedModel} abstraction.
 	 *
 	 * @return will never be {@literal null}.
 	 * @since 3.3
@@ -96,16 +100,17 @@ public @interface EnableSpringDataWebSupport {
 	enum PageSerializationMode {
 
 		/**
-		 * {@link org.springframework.data.domain.PageImpl} instances will be rendered as is (discouraged, as there's no
-		 * guarantee on the stability of the serialization result as we might need to change the type's API for unrelated
-		 * reasons).
+		 * {@link org.springframework.data.domain.PageImpl} and {@link org.springframework.data.domain.SliceImpl}
+		 * instances will be rendered as is (discouraged, as there's no guarantee on the stability of the serialization
+		 * result as we might need to change the type's API for unrelated reasons).
 		 */
 		DIRECT,
 
 		/**
-		 * Causes {@link org.springframework.data.domain.PageImpl} instances to be wrapped into
-		 * {@link org.springframework.data.web.PagedModel} instances before rendering them as JSON to make sure the
-		 * representation stays stable even if {@link org.springframework.data.domain.PageImpl} is changed.
+		 * Causes {@link org.springframework.data.domain.PageImpl} and {@link org.springframework.data.domain.SliceImpl}
+		 * instances to be wrapped into {@link org.springframework.data.web.PagedModel} and
+		 * {@link org.springframework.data.web.SlicedModel} instances before rendering them as JSON to make sure the
+		 * representation stays stable even if domain types are changed.
 		 */
 		VIA_DTO;
 	}

--- a/src/main/java/org/springframework/data/web/config/SpringDataJackson3Configuration.java
+++ b/src/main/java/org/springframework/data/web/config/SpringDataJackson3Configuration.java
@@ -33,8 +33,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.geo.GeoJacksonModule;
 import org.springframework.data.web.PagedModel;
+import org.springframework.data.web.SlicedModel;
 import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 import org.springframework.util.ClassUtils;
 
@@ -43,6 +46,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Arnab Nandy
  * @since 4.0
  */
 public class SpringDataJackson3Configuration implements SpringDataJackson3Modules {
@@ -95,6 +99,7 @@ public class SpringDataJackson3Configuration implements SpringDataJackson3Module
 
 			} else {
 				setMixInAnnotation(PageImpl.class, WrappingMixing.class);
+				setMixInAnnotation(SliceImpl.class, SliceWrappingMixing.class);
 			}
 		}
 
@@ -127,8 +132,20 @@ public class SpringDataJackson3Configuration implements SpringDataJackson3Module
 			}
 		}
 
+		@JsonSerialize(converter = SliceModelConverter.class)
+		abstract static class SliceWrappingMixing {}
+
+		static class SliceModelConverter extends StdConverter<Slice<?>, SlicedModel<?>> {
+
+			@Override
+			public @Nullable SlicedModel<?> convert(@Nullable Slice<?> value) {
+				return value == null ? null : new SlicedModel<>(value);
+			}
+		}
+
 		/**
-		 * A {@link ValueSerializerModifier} that logs a warning message if an instance of {@link Page} will be rendered.
+		 * A {@link ValueSerializerModifier} that logs a warning message if an instance of {@link Page} or {@link Slice} will
+		 * be rendered.
 		 *
 		 * @author Oliver Drotbohm
 		 */
@@ -140,19 +157,34 @@ public class SpringDataJackson3Configuration implements SpringDataJackson3Module
 						For a stable JSON structure, please use Spring Data's PagedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO))
 						or Spring HATEOAS and Spring Data's PagedResourcesAssembler as documented in https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables.
 					""";
+			private static final String SLICE_MESSAGE = """
+					Serializing SliceImpl instances as-is is not supported, meaning that there is no guarantee about the stability of the resulting JSON structure!
+						For a stable JSON structure, please use Spring Data's SlicedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO))
+						or Spring HATEOAS and Spring Data's SlicedResourcesAssembler as documented in https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables.
+					""";
 
 			private static final @Serial long serialVersionUID = 954857444010009875L;
 
-			private boolean warningRendered = false;
+			private boolean pageWarningRendered = false;
+			private boolean sliceWarningRendered = false;
 
 			@Override
 			public List<BeanPropertyWriter> changeProperties(tools.jackson.databind.SerializationConfig config,
 					tools.jackson.databind.BeanDescription.Supplier beanDesc, List<BeanPropertyWriter> beanProperties) {
 
-				if (Page.class.isAssignableFrom(beanDesc.getBeanClass()) && !warningRendered) {
+				if (Page.class.isAssignableFrom(beanDesc.getBeanClass())) {
 
-					this.warningRendered = true;
-					LOGGER.warn(MESSAGE);
+					if (!pageWarningRendered) {
+						this.pageWarningRendered = true;
+						LOGGER.warn(MESSAGE);
+					}
+
+				} else if (Slice.class.isAssignableFrom(beanDesc.getBeanClass())) {
+
+					if (!sliceWarningRendered) {
+						this.sliceWarningRendered = true;
+						LOGGER.warn(SLICE_MESSAGE);
+					}
 				}
 
 				return super.changeProperties(config, beanDesc, beanProperties);

--- a/src/main/java/org/springframework/data/web/config/SpringDataJacksonConfiguration.java
+++ b/src/main/java/org/springframework/data/web/config/SpringDataJacksonConfiguration.java
@@ -27,8 +27,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.geo.GeoModule;
 import org.springframework.data.web.PagedModel;
+import org.springframework.data.web.SlicedModel;
 import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 import org.springframework.util.ClassUtils;
 
@@ -46,6 +49,7 @@ import com.fasterxml.jackson.databind.util.StdConverter;
  *
  * @author Oliver Gierke
  * @author Mark Paluch
+ * @author Arnab Nandy
  * @deprecated since 4.0, in favor of {@link SpringDataJackson3Configuration} which uses Jackson 3.
  */
 @SuppressWarnings("removal")
@@ -99,6 +103,7 @@ public class SpringDataJacksonConfiguration implements SpringDataJacksonModules 
 
 			} else {
 				setMixInAnnotation(PageImpl.class, WrappingMixing.class);
+				setMixInAnnotation(SliceImpl.class, SliceWrappingMixing.class);
 			}
 		}
 
@@ -133,8 +138,20 @@ public class SpringDataJacksonConfiguration implements SpringDataJacksonModules 
 			}
 		}
 
+		@JsonSerialize(converter = SliceModelConverter.class)
+		abstract static class SliceWrappingMixing {}
+
+		static class SliceModelConverter extends StdConverter<Slice<?>, SlicedModel<?>> {
+
+			@Override
+			public @Nullable SlicedModel<?> convert(@Nullable Slice<?> value) {
+				return value == null ? null : new SlicedModel<>(value);
+			}
+		}
+
 		/**
-		 * A {@link BeanSerializerModifier} that logs a warning message if an instance of {@link Page} will be rendered.
+		 * A {@link BeanSerializerModifier} that logs a warning message if an instance of {@link Page} or {@link Slice} will be
+		 * rendered.
 		 *
 		 * @author Oliver Drotbohm
 		 */
@@ -146,19 +163,34 @@ public class SpringDataJacksonConfiguration implements SpringDataJacksonModules 
 						For a stable JSON structure, please use Spring Data's PagedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO))
 						or Spring HATEOAS and Spring Data's PagedResourcesAssembler as documented in https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables.
 					""";
+			private static final String SLICE_MESSAGE = """
+					Serializing SliceImpl instances as-is is not supported, meaning that there is no guarantee about the stability of the resulting JSON structure!
+						For a stable JSON structure, please use Spring Data's SlicedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO))
+						or Spring HATEOAS and Spring Data's SlicedResourcesAssembler as documented in https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables.
+					""";
 
 			private static final @Serial long serialVersionUID = 954857444010009875L;
 
-			private boolean warningRendered = false;
+			private boolean pageWarningRendered = false;
+			private boolean sliceWarningRendered = false;
 
 			@Override
 			public List<BeanPropertyWriter> changeProperties(SerializationConfig config, BeanDescription beanDesc,
 					List<BeanPropertyWriter> beanProperties) {
 
-				if (Page.class.isAssignableFrom(beanDesc.getBeanClass()) && !warningRendered) {
+				if (Page.class.isAssignableFrom(beanDesc.getBeanClass())) {
 
-					this.warningRendered = true;
-					LOGGER.warn(MESSAGE);
+					if (!pageWarningRendered) {
+						this.pageWarningRendered = true;
+						LOGGER.warn(MESSAGE);
+					}
+
+				} else if (Slice.class.isAssignableFrom(beanDesc.getBeanClass())) {
+
+					if (!sliceWarningRendered) {
+						this.sliceWarningRendered = true;
+						LOGGER.warn(SLICE_MESSAGE);
+					}
 				}
 
 				return super.changeProperties(config, beanDesc, beanProperties);

--- a/src/test/java/org/springframework/data/web/PageImplJsonJackson2SerializationUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PageImplJsonJackson2SerializationUnitTests.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 import org.springframework.data.web.config.SpringDataJacksonConfiguration;
 import org.springframework.data.web.config.SpringDataWebSettings;
@@ -30,10 +32,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 
 /**
- * Unit tests for PageImpl serialization.
+ * Unit tests for PageImpl and SliceImpl serialization.
  *
  * @author Oliver Drotbohm
  * @author Mark Paluch
+ * @author Arnab Nandy
  */
 class PageImplJsonJackson2SerializationUnitTests {
 
@@ -52,11 +55,29 @@ class PageImplJsonJackson2SerializationUnitTests {
 		assertJsonRendering(PageSerializationMode.DIRECT, new Extension<>("header"), "$.pageable", "$.last", "$.first");
 	}
 
+	@Test // GH-3516
+	void serializesSliceImplAsJson() {
+		assertJsonRendering(PageSerializationMode.DIRECT, new SliceImpl<>(Collections.emptyList()), "$.pageable",
+				"$.hasNext", "$.first");
+	}
+
+	@Test // GH-3516
+	void serializesSliceImplAsSlicedModel() {
+		assertJsonRendering(PageSerializationMode.VIA_DTO, new SliceImpl<>(Collections.emptyList()), "$.content",
+				"$.page.size", "$.page.number", "$.page.numberOfElements", "$.page.hasNext");
+	}
+
+	@Test // GH-3516
+	void serializesCustomSliceAsSliceImpl() {
+		assertJsonRendering(PageSerializationMode.DIRECT, new SliceExtension<>("header"), "$.pageable", "$.hasNext",
+				"$.first");
+	}
+
 	private static void assertJsonRendering(PageSerializationMode mode, String... jsonPaths) {
 		assertJsonRendering(mode, new PageImpl<>(Collections.emptyList()), jsonPaths);
 	}
 
-	private static void assertJsonRendering(PageSerializationMode mode, PageImpl<?> page, String... jsonPaths) {
+	private static void assertJsonRendering(PageSerializationMode mode, Object payload, String... jsonPaths) {
 
 		SpringDataWebSettings settings = new SpringDataWebSettings(mode);
 
@@ -65,7 +86,7 @@ class PageImplJsonJackson2SerializationUnitTests {
 
 		assertThatNoException().isThrownBy(() -> {
 
-			String result = mapper.writeValueAsString(page);
+			String result = mapper.writeValueAsString(payload);
 
 			for (String jsonPath : jsonPaths) {
 				assertThat(JsonPath.<Object> read(result, jsonPath)).isNotNull();
@@ -78,6 +99,19 @@ class PageImplJsonJackson2SerializationUnitTests {
 		private Object header;
 
 		public Extension(Object header) {
+			super(Collections.emptyList());
+		}
+
+		public Object getHeader() {
+			return header;
+		}
+	}
+
+	static class SliceExtension<T> extends SliceImpl<T> {
+
+		private Object header;
+
+		public SliceExtension(Object header) {
 			super(Collections.emptyList());
 		}
 

--- a/src/test/java/org/springframework/data/web/PageImplJsonSerializationUnitTests.java
+++ b/src/test/java/org/springframework/data/web/PageImplJsonSerializationUnitTests.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 import org.springframework.data.web.config.SpringDataJackson3Configuration;
 import org.springframework.data.web.config.SpringDataWebSettings;
@@ -32,10 +34,11 @@ import org.springframework.data.web.config.SpringDataWebSettings;
 import com.jayway.jsonpath.JsonPath;
 
 /**
- * Unit tests for PageImpl serialization.
+ * Unit tests for PageImpl and SliceImpl serialization.
  *
  * @author Oliver Drotbohm
  * @author Mark Paluch
+ * @author Arnab Nandy
  */
 class PageImplJsonSerializationUnitTests {
 
@@ -54,11 +57,29 @@ class PageImplJsonSerializationUnitTests {
 		assertJsonRendering(PageSerializationMode.DIRECT, new Extension<>("header"), "$.pageable", "$.last", "$.first");
 	}
 
+	@Test // GH-3516
+	void serializesSliceImplAsJson() {
+		assertJsonRendering(PageSerializationMode.DIRECT, new SliceImpl<>(Collections.emptyList()), "$.pageable",
+				"$.hasNext", "$.first");
+	}
+
+	@Test // GH-3516
+	void serializesSliceImplAsSlicedModel() {
+		assertJsonRendering(PageSerializationMode.VIA_DTO, new SliceImpl<>(Collections.emptyList()), "$.content",
+				"$.page.size", "$.page.number", "$.page.numberOfElements", "$.page.hasNext");
+	}
+
+	@Test // GH-3516
+	void serializesCustomSliceAsSliceImpl() {
+		assertJsonRendering(PageSerializationMode.DIRECT, new SliceExtension<>("header"), "$.pageable", "$.hasNext",
+				"$.first");
+	}
+
 	private static void assertJsonRendering(PageSerializationMode mode, String... jsonPaths) {
 		assertJsonRendering(mode, new PageImpl<>(Collections.emptyList()), jsonPaths);
 	}
 
-	private static void assertJsonRendering(PageSerializationMode mode, PageImpl<?> page, String... jsonPaths) {
+	private static void assertJsonRendering(PageSerializationMode mode, Object payload, String... jsonPaths) {
 
 		SpringDataWebSettings settings = new SpringDataWebSettings(mode);
 
@@ -67,7 +88,7 @@ class PageImplJsonSerializationUnitTests {
 
 		assertThatNoException().isThrownBy(() -> {
 
-			String result = mapper.writeValueAsString(page);
+			String result = mapper.writeValueAsString(payload);
 
 			for (String jsonPath : jsonPaths) {
 				assertThat(JsonPath.<Object> read(result, jsonPath)).isNotNull();
@@ -80,6 +101,19 @@ class PageImplJsonSerializationUnitTests {
 		private Object header;
 
 		public Extension(Object header) {
+			super(Collections.emptyList());
+		}
+
+		public Object getHeader() {
+			return header;
+		}
+	}
+
+	static class SliceExtension<T> extends SliceImpl<T> {
+
+		private Object header;
+
+		public SliceExtension(Object header) {
 			super(Collections.emptyList());
 		}
 

--- a/src/test/java/org/springframework/data/web/SlicedModelUnitTests.java
+++ b/src/test/java/org/springframework/data/web/SlicedModelUnitTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.web;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.web.SlicedModel.SliceMetadata;
+
+/**
+ * Unit tests for {@link SlicedModel}.
+ *
+ * @author Arnab Nandy
+ */
+class SlicedModelUnitTests {
+
+	@Test // GH-3516
+	void rejectsNullSlice() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new SlicedModel<>(null));
+	}
+
+	@Test // GH-3516
+	void exposesContentAndMetadata() {
+
+		Slice<String> slice = new SliceImpl<>(List.of("first", "second"), PageRequest.of(1, 10), true);
+		SlicedModel<String> model = new SlicedModel<>(slice);
+
+		assertThat(model.getContent()).containsExactly("first", "second");
+
+		SliceMetadata metadata = model.getMetadata();
+		assertThat(metadata.size()).isEqualTo(10);
+		assertThat(metadata.number()).isEqualTo(1);
+		assertThat(metadata.numberOfElements()).isEqualTo(2);
+		assertThat(metadata.hasNext()).isTrue();
+	}
+
+	@Test // GH-3516
+	void equalsAndHashCode() {
+
+		Slice<String> slice1 = new SliceImpl<>(List.of("foo"), PageRequest.of(0, 5), false);
+		Slice<String> slice2 = new SliceImpl<>(List.of("foo"), PageRequest.of(0, 5), false);
+		Slice<String> slice3 = new SliceImpl<>(List.of("bar"), PageRequest.of(0, 5), false);
+
+		SlicedModel<String> model1 = new SlicedModel<>(slice1);
+		SlicedModel<String> model2 = new SlicedModel<>(slice2);
+		SlicedModel<String> model3 = new SlicedModel<>(slice3);
+
+		assertThat(model1).isEqualTo(model1);
+		assertThat(model1).isEqualTo(model2);
+		assertThat(model1).hasSameHashCodeAs(model2);
+		assertThat(model1).isNotEqualTo(model3);
+		assertThat(model1).isNotEqualTo(null);
+		assertThat(model1).isNotEqualTo("foo");
+	}
+
+	@Test // GH-3516
+	void validatesMetadata() {
+
+		assertThatIllegalArgumentException().isThrownBy(() -> new SliceMetadata(-1, 0, 0, false));
+		assertThatIllegalArgumentException().isThrownBy(() -> new SliceMetadata(0, -1, 0, false));
+		assertThatIllegalArgumentException().isThrownBy(() -> new SliceMetadata(0, 0, -1, false));
+
+		assertThatNoException().isThrownBy(() -> new SliceMetadata(0, 0, 0, false));
+	}
+}

--- a/src/test/java/org/springframework/data/web/aot/WebRuntimeHintsUnitTests.java
+++ b/src/test/java/org/springframework/data/web/aot/WebRuntimeHintsUnitTests.java
@@ -44,6 +44,8 @@ class WebRuntimeHintsUnitTests {
 
 		assertThat(runtimeHints).matches(
 				RuntimeHintsPredicates.reflection().onType(TypeReference.of("org.springframework.data.domain.Unpaged")));
+		assertThat(runtimeHints).matches(
+				RuntimeHintsPredicates.reflection().onType(org.springframework.data.web.SlicedModel.class));
 	}
 
 	@Test // GH-3033, GH-3171

--- a/src/test/java/org/springframework/data/web/config/EnableSpringDataWebSupportIntegrationTests.java
+++ b/src/test/java/org/springframework/data/web/config/EnableSpringDataWebSupportIntegrationTests.java
@@ -64,6 +64,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Vedran Pavic
  * @author Yanming Zhou
  * @author Christoph Strobl
+ * @author Arnab Nandy
  */
 class EnableSpringDataWebSupportIntegrationTests {
 
@@ -331,6 +332,32 @@ class EnableSpringDataWebSupportIntegrationTests {
 		mvc.perform(post("/page")) //
 				.andExpect(status().isOk()) //
 				.andExpect(jsonPath("$.page").exists());
+	}
+
+	@Test // GH-3516
+	void usesDirectSliceSerializationMode() throws Exception {
+
+		var context = WebTestUtils.createApplicationContext(PageSampleConfigWithDirect.class);
+
+		var mvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+		mvc.perform(post("/slice")) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.pageable").exists()) //
+				.andExpect(jsonPath("$.hasNext").value(true));
+	}
+
+	@Test // GH-3516
+	void usesViaDtoSliceSerializationMode() throws Exception {
+
+		var context = WebTestUtils.createApplicationContext(PageSampleConfigWithViaDto.class);
+
+		var mvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+		mvc.perform(post("/slice")) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.page").exists()) //
+				.andExpect(jsonPath("$.page.hasNext").value(true));
 	}
 
 	private static void assertResolversRegistered(ApplicationContext context, Class<?>... resolverTypes) {

--- a/src/test/java/org/springframework/data/web/config/PageSampleController.java
+++ b/src/test/java/org/springframework/data/web/config/PageSampleController.java
@@ -18,6 +18,8 @@ package org.springframework.data.web.config;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +27,7 @@ import java.util.List;
 
 /**
  * @author Yanming Zhou
+ * @author Arnab Nandy
  */
 @RestController
 class PageSampleController {
@@ -32,5 +35,10 @@ class PageSampleController {
 	@RequestMapping("/page")
 	Page<String> page() {
 		return new PageImpl<>(List.of("a", "b", "c"), Pageable.ofSize(10).withPage(0), 3);
+	}
+
+	@RequestMapping("/slice")
+	Slice<String> slice() {
+		return new SliceImpl<>(List.of("a", "b", "c"), Pageable.ofSize(10).withPage(0), true);
 	}
 }


### PR DESCRIPTION
Provide a SlicedModel DTO to render stable JSON representations of Slice.

`org.springframework.data.web.PagedModel` was introduced in 3.3 via #3024 as a middle ground between serializing `PageImpl` directly and adopting Spring HATEOAS. There was previously no equivalent for `Slice`.

### Problem

Returning a `Slice` from a Spring MVC controller carried stability risks:
1. `SliceImpl` is a domain type and serializing it directly exposes internal structure that can change across releases.
2. In `DIRECT` mode, no warning was emitted for `SliceImpl` instances.
3. Applications not using Spring HATEOAS (`SlicedResourcesAssembler`) had to define custom DTOs per project to wrap `Slice`.

### Solution

This PR introduces `SlicedModel<T>` in `org.springframework.data.web`, mirroring `PagedModel` in shape and usage:

- **`SlicedModel<T>` and `SliceMetadata`**:
  - Exposes `content` and `page` metadata (`size`, `number`, `numberOfElements`, `hasNext`).
  - Deliberately omits `totalElements` and `totalPages` as that information is unavailable on a `Slice`.
  - Implements `equals(Object)` and `hashCode()`.
- **Jackson Integration (Jackson 2 & 3)**:
  - In `PageSerializationMode.VIA_DTO`, registers a mix-in on `SliceImpl.class` with `SliceModelConverter` to wrap `SliceImpl` instances into `SlicedModel`.
  - In `PageSerializationMode.DIRECT`, emits a one-time warning log highlighting stability risks and suggesting `SlicedModel` or `SlicedResourcesAssembler`.
- **Web Support & Javadoc**:
  - Updated `@EnableSpringDataWebSupport` and `PageSerializationMode` Javadocs to document `SliceImpl` and `SlicedModel`.
- **AOT / Native Hints**:
  - Registered reflection hints in `WebRuntimeHints` for `SlicedModel`, `SliceMetadata`, and `SliceModelConverter`.
- **Documentation & Tests**:
  - Added Antora reference documentation for `SlicedModel` in `core-extensions-web.adoc` and `aot.adoc`.
  - Added unit and integration tests across `SlicedModelUnitTests`, `PageImplJsonSerializationUnitTests`, `PageImplJsonJackson2SerializationUnitTests`, `EnableSpringDataWebSupportIntegrationTests`, and `WebRuntimeHintsUnitTests`.

Closes #3516 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).